### PR TITLE
trigger semver workflow manually

### DIFF
--- a/.github/workflows/ci_merge_main.yaml
+++ b/.github/workflows/ci_merge_main.yaml
@@ -3,10 +3,7 @@ name: Create release tags
 permissions:
     contents: write
 
-on:
-    push:
-        branches:
-            - main
+on: workflow_dispatch
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Problem
The semver workflow automatically runs when changes are pushed to main. We don't want this right now

## Solution
Change event to listen on `workflow_dispatch` which lets the workflow be triggered manually from the actions tab