### PR TITLE
fix: resolve page failing when any type other than string is used for a value

### DIFF
--- a/crates/frontend/src/components/default_config_form/default_config_form.rs
+++ b/crates/frontend/src/components/default_config_form/default_config_form.rs
@@ -290,7 +290,7 @@ where
                             <label class="label">
                                 <span class="label-text ">Value</span>
                             </label>
-                            <input
+                            <textarea
                                 type="text"
                                 placeholder="Value"
                                 class="input input-bordered w-full max-w-md"
@@ -299,7 +299,7 @@ where
                                     logging::log!("{:?}", event_target_value(& ev));
                                     set_config_value.set(event_target_value(&ev));
                                 }
-                            />
+                            ></textarea>
 
                         </div>
 

--- a/crates/frontend/src/components/dimension_form/dimension_form.rs
+++ b/crates/frontend/src/components/dimension_form/dimension_form.rs
@@ -253,10 +253,10 @@ where
                     </div>
 
                     <Show when=move || {
-                        (show_labels.get()
+                        show_labels.get()
                             && ((dimension_type.get() == "enum")
                                 || (dimension_type.get() == "pattern")
-                                || (dimension_type.get() == "other")))
+                                || (dimension_type.get() == "other"))
                     }>
                         <div class="form-control">
                             <label class="label font-mono">

--- a/crates/frontend/src/components/override_form/override_form.rs
+++ b/crates/frontend/src/components/override_form/override_form.rs
@@ -92,7 +92,7 @@ where
                                         </label>
                                     </div>
                                     <div class="form-control w-2/5">
-                                        <input
+                                        <textarea
                                             type="text"
                                             placeholder="Enter override here"
                                             name="override"
@@ -119,7 +119,7 @@ where
                                                             );
                                                     });
                                             }
-                                        />
+                                        ></textarea>
 
                                     </div>
                                     <div class="w-1/5">

--- a/crates/frontend/src/pages/Home/Home.rs
+++ b/crates/frontend/src/pages/Home/Home.rs
@@ -237,7 +237,7 @@ pub fn home() -> impl IntoView {
                     table_rows.push_str(
                     format!(
                         "<tr><td>{key}</td><td style='word-break: break-word;'>{}</td></tr>",
-                        check_url_and_return_val(value.as_str().unwrap().to_owned())
+                        check_url_and_return_val(serde_json::from_value(value.to_owned()).unwrap_or(format!("{}", value)))
                     )
                     .as_str(),
                 )
@@ -366,11 +366,12 @@ pub fn home() -> impl IntoView {
                                                                 view_vector
                                                                     .push(
                                                                         view! {
-                                                                            < tr > < td class = "min-w-48 font-mono" > < span name =
-                                                                            format!("{unique_name}-1") class = "config-name" class :
-                                                                            text - black = { ! striked } class : font - bold = { !
-                                                                            striked } class : text - gray - 300 = { striked } > { key }
-                                                                            </ span > </ td > < td class = "min-w-48 font-mono" style =
+                                                                            < tr > < td class = "min-w-48 max-w-72 font-mono" > < span
+                                                                            name = format!("{unique_name}-1") class = "config-name"
+                                                                            class : text - black = { ! striked } class : font - bold = {
+                                                                            ! striked } class : text - gray - 300 = { striked } > { key
+                                                                            } </ span > </ td > < td class =
+                                                                            "min-w-48 max-w-72 font-mono" style =
                                                                             "word-break: break-word;" > < span name =
                                                                             format!("{unique_name}-2") class = "config-value" class :
                                                                             text - black = { ! striked } class : font - bold = { !
@@ -497,7 +498,7 @@ pub fn home() -> impl IntoView {
                                                                                 key=|(key, value)| format!("{key}-{value}")
                                                                                 children=move |(config, value)| {
                                                                                     view! {
-                                                                                        <tr>
+                                                                                        <tr class="min-w-48 max-w-72">
                                                                                             <td>{config}</td>
                                                                                             <td style="word-break: break-word;">
                                                                                                 {match value {

--- a/crates/frontend/src/pages/default_config/default_config.rs
+++ b/crates/frontend/src/pages/default_config/default_config.rs
@@ -174,7 +174,6 @@ pub fn default_config() -> impl IntoView {
                             folder_click_handler(Some(key.clone()))
                         }
                     >
-
                         {label}
                     </span>
                 }
@@ -247,7 +246,6 @@ pub fn default_config() -> impl IntoView {
                                         close_drawer("default_config_drawer");
                                     }
                                 />
-
                             </Drawer>
                         }
                     }
@@ -296,7 +294,6 @@ pub fn default_config() -> impl IntoView {
                                                 folder_click_handler(None);
                                                 enable_grouping.set(!enable_grouping.get());
                                             }
-
                                             class="cursor-pointer label mr-10"
                                         >
                                             <span class="label-text mr-4">Enable Grouping</span>
@@ -362,7 +359,6 @@ where
                                     ""
                                 }
                             >
-
                                 {ele.key.clone()}
                             </h2>
                             <h2 class="pl-4 pr-4">{if index < last_index { ">" } else { "" }}</h2>

--- a/crates/frontend/src/pages/experiment_list/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list/experiment_list.rs
@@ -231,7 +231,6 @@ pub fn experiment_list() -> impl IntoView {
                                 close_drawer("create_exp_drawer");
                             }
                         >
-
                             <ExperimentForm
                                 name="".to_string()
                                 context=vec![]

--- a/crates/superposition/src/main.rs
+++ b/crates/superposition/src/main.rs
@@ -86,12 +86,6 @@ async fn main() -> Result<()> {
             .map(String::from)
             .collect::<HashSet<String>>();
 
-    let string_to_int = |s: &String| -> i32 {
-        s.chars()
-            .map(|i| (i as i32) & rand::random::<i32>())
-            .fold(0, i32::wrapping_add)
-    };
-
     let schema_manager: PgSchemaManager = init_pool_manager(
         tenants.clone(),
         enable_tenant_and_scope,


### PR DESCRIPTION
## Problem
Resolve page doesn't resolve when the type of a value is not a string because  the code was trying convert everything to string.

## Solution
Properly parse types and display them so that the resolve UI works correctly. Also replace `<input>` for values in some places with `textarea`