### PR TITLE
fix: reject experiment contexts with `variantIds`

### DIFF
--- a/crates/context_aware_config/src/api/context/helpers.rs
+++ b/crates/context_aware_config/src/api/context/helpers.rs
@@ -109,7 +109,7 @@ fn get_functions_map(
 }
 
 pub fn validate_value_with_function(
-    fun_name: &str,
+    _fun_name: &str,
     function: &str,
     key: &String,
     value: &Value,

--- a/crates/context_aware_config/src/validation_functions.rs
+++ b/crates/context_aware_config/src/validation_functions.rs
@@ -1,4 +1,4 @@
-use serde_json::{json, Value};
+use serde_json::Value;
 use service_utils::result as superposition;
 use service_utils::unexpected_error;
 use service_utils::validation_error;

--- a/crates/experimentation_platform/src/api/experiments/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiments/handlers.rs
@@ -35,6 +35,7 @@ use super::{
 };
 
 use crate::{
+    api::experiments::helpers::validate_context,
     db::models::{EventLog, Experiment, ExperimentStatusType},
     db::schema::{event_log::dsl as event_log, experiments::dsl as experiments},
 };
@@ -140,10 +141,8 @@ async fn create(
         );
     }
 
-    // Checking if context is a key-value pair map
-    if !req.context.is_object() {
-        return Err(bad_argument!("Context should be map of key value pairs."));
-    }
+    // validating context
+    validate_context(&req.context)?;
 
     // validating experiment against other active experiments based on permission flags
     let flags = &state.experimentation_flags;

--- a/crates/experimentation_platform/src/api/experiments/helpers.rs
+++ b/crates/experimentation_platform/src/api/experiments/helpers.rs
@@ -41,7 +41,7 @@ pub fn validate_context(context: &Value) -> superposition::Result<()> {
     let dimensions = extract_dimensions(context)?;
     if dimensions.contains_key("variantIds") {
         return Err(bad_argument!(
-            "variantIds dimension not allowed in experiment contexts"
+            "experiment's context should not contain variantIds dimension"
         ));
     }
     Ok(())

--- a/crates/experimentation_platform/src/api/experiments/helpers.rs
+++ b/crates/experimentation_platform/src/api/experiments/helpers.rs
@@ -37,6 +37,16 @@ pub fn check_variant_types(variants: &Vec<Variant>) -> superposition::Result<()>
     Ok(())
 }
 
+pub fn validate_context(context: &Value) -> superposition::Result<()> {
+    let dimensions = extract_dimensions(context)?;
+    if dimensions.contains_key("variantIds") {
+        return Err(bad_argument!(
+            "variantIds dimension not allowed in experiment contexts"
+        ));
+    }
+    Ok(())
+}
+
 pub fn validate_override_keys(override_keys: &Vec<String>) -> superposition::Result<()> {
     let mut key_set: HashSet<&str> = HashSet::new();
     for key in override_keys {

--- a/crates/experimentation_platform/tests/experimentation_tests.rs
+++ b/crates/experimentation_platform/tests/experimentation_tests.rs
@@ -28,8 +28,8 @@ fn single_dimension_ctx_gen(value: Dimensions) -> serde_json::Value {
         }),
         Dimensions::VARIANTIDS(id) => serde_json::json!({
             "in": [
-                {"var": "variantIds"},
                 id,
+                {"var": "variantIds"},
             ]
         }),
     }
@@ -596,8 +596,8 @@ fn test_fail_context_with_variantIds_dimensions() {
 
     let error_msg = result.unwrap_err();
     match error_msg {
-        AppError::BadArgument(msg) => assert_eq!(msg, "variantIds dimension not allowed in experiment contexts"),
-        _ => panic!("Not a AppError::BadArgument('variantIds dimension not allowed in experiment contexts')")
+        AppError::BadArgument(msg) => assert_eq!(msg, "experiment's context should not contain variantIds dimension"),
+        _ => panic!("Not a AppError::BadArgument('experiment's context should not contain variantIds dimension')")
     }
 }
 

--- a/crates/frontend/src/components/context_form/context_form.rs
+++ b/crates/frontend/src/components/context_form/context_form.rs
@@ -165,14 +165,11 @@ where
                                                         on:click=move |_| {
                                                             let mut current_context = context.get();
                                                             current_context.remove(idx);
-                                                            set_context.set(current_context.clone());
-                                                            logging::log!(
-                                                                "current context {:?}", current_context.clone()
-                                                            );
                                                             set_used_dimensions
                                                                 .update(|value| {
                                                                     value.remove(&dimension_name.get_value());
                                                                 });
+                                                            set_context.set(current_context);
                                                         }
                                                     >
 

--- a/crates/frontend/src/components/function_form/function_form.rs
+++ b/crates/frontend/src/components/function_form/function_form.rs
@@ -168,14 +168,7 @@ where
 }
 
 #[component]
-pub fn test_form<NF>(
-    function_name: String,
-    stage: String,
-    handle_submit: NF,
-) -> impl IntoView
-where
-    NF: Fn() + 'static + Clone,
-{
+pub fn test_form(function_name: String, stage: String) -> impl IntoView {
     let tenant_rs = use_context::<ReadSignal<String>>().unwrap();
     let (error_message, set_error_message) = create_signal("".to_string());
     let (output_message, set_output_message) =

--- a/crates/frontend/src/pages/ContextOverride/context_override.rs
+++ b/crates/frontend/src/pages/ContextOverride/context_override.rs
@@ -56,8 +56,12 @@ pub fn context_override() -> impl IntoView {
                 );
                 CombinedResourceOverride {
                     config: config_result.ok(),
-                    dimensions: dimensions_result.unwrap_or_else(|_| vec![]),
-                    default_config: default_config_result.unwrap_or_else(|_| vec![]),
+                    dimensions: dimensions_result
+                        .unwrap_or(vec![])
+                        .into_iter()
+                        .filter(|d| d.dimension != "variantIds")
+                        .collect::<Vec<Dimension>>(),
+                    default_config: default_config_result.unwrap_or(vec![]),
                 }
             },
         );

--- a/crates/frontend/src/pages/ContextOverride/context_override.rs
+++ b/crates/frontend/src/pages/ContextOverride/context_override.rs
@@ -60,7 +60,7 @@ pub fn context_override() -> impl IntoView {
                         .unwrap_or(vec![])
                         .into_iter()
                         .filter(|d| d.dimension != "variantIds")
-                        .collect::<Vec<Dimension>>(),
+                        .collect(),
                     default_config: default_config_result.unwrap_or(vec![]),
                 }
             },

--- a/crates/frontend/src/pages/Experiment/mod.rs
+++ b/crates/frontend/src/pages/Experiment/mod.rs
@@ -51,8 +51,12 @@ pub fn experiment_page() -> impl IntoView {
             // Construct the combined result, handling errors as needed
             CombinedResource {
                 experiment: experiments_result.ok(),
-                dimensions: dimensions_result.unwrap_or_else(|_| vec![]),
-                default_config: config_result.unwrap_or_else(|_| vec![]),
+                dimensions: dimensions_result
+                    .unwrap_or(vec![])
+                    .into_iter()
+                    .filter(|d| d.dimension != "variantIds")
+                    .collect(),
+                default_config: config_result.unwrap_or(vec![]),
             }
         });
 

--- a/crates/frontend/src/pages/experiment_list/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list/experiment_list.rs
@@ -58,15 +58,17 @@ pub fn experiment_list() -> impl IntoView {
 
                 // Construct the combined result, handling errors as needed
                 CombinedResource {
-                    experiments: experiments_result.unwrap_or_else(|_| {
-                        ExperimentsResponse {
-                            total_items: 0,
-                            total_pages: 0,
-                            data: vec![],
-                        }
+                    experiments: experiments_result.unwrap_or(ExperimentsResponse {
+                        total_items: 0,
+                        total_pages: 0,
+                        data: vec![],
                     }),
-                    dimensions: dimensions_result.unwrap_or_else(|_| vec![]),
-                    default_config: config_result.unwrap_or_else(|_| vec![]),
+                    dimensions: dimensions_result
+                        .unwrap_or(vec![])
+                        .into_iter()
+                        .filter(|d| d.dimension != "variantIds")
+                        .collect(),
+                    default_config: config_result.unwrap_or(vec![]),
                 }
             },
         );

--- a/crates/frontend/src/pages/function/function.rs
+++ b/crates/frontend/src/pages/function/function.rs
@@ -397,7 +397,6 @@ pub fn function_page() -> impl IntoView {
                                                                             <TestForm
                                                                                 function_name=fun_pub.function_name.clone()
                                                                                 stage="PUBLISHED".to_string()
-                                                                                handle_submit=move || {}
                                                                             />
 
                                                                         </div>
@@ -479,7 +478,6 @@ pub fn function_page() -> impl IntoView {
                                                                             <TestForm
                                                                                 function_name=function_test.function_name.clone()
                                                                                 stage="DRAFT".to_string()
-                                                                                handle_submit=move || {}
                                                                             />
 
                                                                         </div>

--- a/crates/frontend/src/utils.rs
+++ b/crates/frontend/src/utils.rs
@@ -105,6 +105,7 @@ pub fn get_tenants() -> Vec<String> {
         .unwrap_or(vec![])
 }
 
+#[allow(dead_code)]
 pub fn use_env() -> Envs {
     let context = use_context::<Envs>();
     context

--- a/crates/service_utils/src/helpers.rs
+++ b/crates/service_utils/src/helpers.rs
@@ -129,7 +129,7 @@ pub fn extract_dimensions(context_json: &Value) -> result::Result<Map<String, Va
     let context = context_json
         .as_object()
         .ok_or(
-            result::AppError::BadArgument("Error extracting dimensions, contect not a valid JSON object. Provide a valid JSON context".into())
+            result::AppError::BadArgument("Error extracting dimensions, context not a valid JSON object. Provide a valid JSON context".into())
             )?;
 
     let conditions = match context.get("and") {


### PR DESCRIPTION
## Problem
`variantIds` dimension, which is specific for experimentation-platform use, can be passed in the context when creating experiments.

## Solution
- validating experiment contexts to not have `variantIds` as dimensions
- excluded `variantIds` from the dropdown in create experiment and create context form