### PR TITLE
fix: creating experiments for default-config (no context)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3456,6 +3456,7 @@ dependencies = [
  "futures-util",
  "jsonschema",
  "log",
+ "once_cell",
  "reqwest",
  "rs-snowflake",
  "rusoto_core",

--- a/crates/experimentation_client/src/lib.rs
+++ b/crates/experimentation_client/src/lib.rs
@@ -101,7 +101,12 @@ impl Client {
         let filtered_running_experiments = running_experiments
             .iter()
             .filter(|(_, exp)| {
-                jsonlogic::apply(&exp.context, context) == Ok(Value::Bool(true))
+                let is_empty = exp
+                    .context
+                    .as_object()
+                    .map_or(false, |context| context.is_empty());
+                is_empty
+                    || jsonlogic::apply(&exp.context, context) == Ok(Value::Bool(true))
             })
             .map(|(_, exp)| exp.clone())
             .collect::<Experiments>();

--- a/crates/frontend/src/components/context_form/utils.rs
+++ b/crates/frontend/src/components/context_form/utils.rs
@@ -58,20 +58,25 @@ pub fn construct_context(
     conditions: Vec<(String, String, String)>,
     dimensions: Vec<Dimension>,
 ) -> Value {
-    let condition_schemas = conditions
-        .iter()
-        .map(|(variable, operator, value)| {
-            get_condition_schema(variable, operator, value, dimensions.clone()).unwrap()
-        })
-        .collect::<Vec<Value>>();
-
-    let context = if condition_schemas.len() == 1 {
-        condition_schemas[0].clone()
+    if conditions.is_empty() {
+        json!({})
     } else {
-        json!({ "and": condition_schemas })
-    };
+        let condition_schemas = conditions
+            .iter()
+            .map(|(variable, operator, value)| {
+                get_condition_schema(variable, operator, value, dimensions.clone())
+                    .unwrap()
+            })
+            .collect::<Vec<Value>>();
 
-    context
+        let context = if condition_schemas.len() == 1 {
+            condition_schemas[0].clone()
+        } else {
+            json!({ "and": condition_schemas })
+        };
+
+        context
+    }
 }
 
 pub fn construct_request_payload(

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -33,3 +33,4 @@ serde_json = { workspace = true }
 derive_more = { workspace = true }
 reqwest = { workspace = true }
 thiserror = { workspace = true }
+once_cell = { workspace = true }


### PR DESCRIPTION
## Problem
We were not able to create experiments and conclude them for default config, that is without giving any contexts

## Solution
Made contexts optional, if it's None then we accept it as default config

## Environment variable changes

What ENVs need to be added or changed

## Pre-deployment activity
DB schema has been changed for experiments table, made context as nullable before it was not null

## Post-deployment activity
Things needed to be done after deploying this change (if any)

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
Describe any possible issues that could occur because of this change