### PR TITLE
fix: sorted grouped config keys

### DIFF
--- a/crates/frontend/src/pages/default_config/default_config.rs
+++ b/crates/frontend/src/pages/default_config/default_config.rs
@@ -4,6 +4,7 @@ use crate::components::drawer::drawer::{close_drawer, open_drawer, Drawer, Drawe
 use crate::components::stat::stat::Stat;
 use crate::components::table::{table::Table, types::Column};
 use crate::types::BreadCrums;
+use crate::utils::unwrap_option_or_default_with_error;
 use leptos::*;
 use leptos_router::{use_navigate, use_query_map};
 use serde_json::{json, Map, Value};
@@ -412,7 +413,7 @@ pub fn modify_rows(
     cols: Vec<&str>,
 ) -> Vec<Map<String, Value>> {
     let mut groups: HashSet<String> = HashSet::new();
-    filtered_rows
+    let mut grouped_rows: Vec<Map<String, Value>> = filtered_rows
         .into_iter()
         .filter_map(|mut ele| {
             let key = ele.get("key").unwrap().to_owned();
@@ -459,5 +460,18 @@ pub fn modify_rows(
                 None
             }
         })
-        .collect()
+        .collect();
+    grouped_rows.sort_by(|a, b| {
+        let key_a =
+            unwrap_option_or_default_with_error(a.get("key").and_then(Value::as_str), "");
+        let key_b =
+            unwrap_option_or_default_with_error(b.get("key").and_then(Value::as_str), "");
+
+        match (key_a.contains('.'), key_b.contains('.')) {
+            (true, false) => std::cmp::Ordering::Less,
+            (false, true) => std::cmp::Ordering::Greater,
+            _ => std::cmp::Ordering::Equal,
+        }
+    });
+    grouped_rows
 }

--- a/crates/frontend/src/utils.rs
+++ b/crates/frontend/src/utils.rs
@@ -5,7 +5,6 @@ use crate::{
     providers::alert_provider::enqueue_alert,
     types::{DefaultConfig, Dimension, Envs, ErrorResponse},
 };
-use anyhow::anyhow;
 use leptos::*;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde_json::{Number, Value};
@@ -413,4 +412,13 @@ where
     })
 }
 
-/********* Reqyest Utils ends ****/
+pub fn unwrap_option_or_default_with_error<T>(option: Option<T>, default: T) -> T {
+    option.unwrap_or_else(|| {
+        enqueue_alert(
+            "Something went wrong. Please reload.".to_string(),
+            AlertType::Error,
+            5000,
+        );
+        default
+    })
+}


### PR DESCRIPTION
## Problem
Grouped config keys were not sorted as per folders and keys.

## Solution
Sorted it based on folder and keys

Before
<img width="1728" alt="Screenshot 2024-05-08 at 1 48 50 PM" src="https://github.com/juspay/superposition/assets/79959102/5214711f-dbb5-4d18-be8c-94c48c45c1bb">

After
<img width="1728" alt="Screenshot 2024-05-08 at 2 24 48 PM" src="https://github.com/juspay/superposition/assets/79959102/4a1ef422-0463-4495-97b0-b9b6b6f96d84">

