### PR TITLE
docs: update README/experimentation/cac docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ The Superposition platform comes with three components:
 4. [Client Context-Aware-Configuration](docs/client-context-aware-configuration.md)
 4. [Client Experimentation](docs/client-experimentation.md)
 5. [Local setup](docs/setup.md)
+6. [Context-Aware-Configuration API Ref - Postman Collection](postman/cac.postman_collection.json)
+7. [Experimentation API Ref - Postman Collection](postman/experimentation-platform.postman_collection.json)
 
 ## Key highlights
 * **Admin UI** - Out of the box administration (and tools) UI for configurations and experiments

--- a/docs/context-aware-config.md
+++ b/docs/context-aware-config.md
@@ -1,7 +1,7 @@
 # Context Aware Config
 ---
 
-Context Aware Config (abbreviated as CAC) is the foundational service of the Superposition Platform that is configuration management system that can override config values under certain domain contexts. CAC makes it easy to configure your applications and make sure that you can change these configurations without causing issues in your application
+Context Aware Config (abbreviated as CAC) is the foundational service of the Superposition Platform.  It is the configuration management system that can override configuration values under certain domain contexts.
 
 - [Context Aware Config](#context-aware-config)
   - [Concepts](#concepts)
@@ -13,92 +13,90 @@ Context Aware Config (abbreviated as CAC) is the foundational service of the Sup
 
 ## Concepts
 ---
+
+Context-Aware-Config is made of 4 key abstractions default-configs, dimensions, context and overrides.
+
+
 ### Default Configs
 
-Default Configs are a fundamental concept to CAC. Default Configs are key value pairs that help CAC model the entity/configuration it is trying to manage and serve. Think of default configs as the best assumption we can make about our configs.
+Default Configs is the set of all possible configuration keys of your application along with their default values.  One may think of default configs as the best assumption we can make about our configs.
 
-Example:
-Using our car classification example, we can establish defaults like:
-1. Number of doors - 4 (most cars do have 4 doors)
-2. Engine - Internal Combustion
-3. Chassis - Hatchback
-4. Color - Silver 
-5. interiors - leather
+Let us use a [simple cab ride-hailing application](https://github.com/knutties/superposition-demo-app/) that operates in different cities and capture some attributes that we might need configurable at a per city level.
 
-Again remember, these are our base assumptions that we provide to CAC about our configuration
+1.  `base_rate` - 100 INR
+2.  `per_distance_unit_rate` - 10 INR
 
 ### Dimensions
 
-Dimensions are typically attributes of your domain which can potentially govern values that a particular configuration takes.
+Dimensions are typically attributes of your domain which can potentially govern the values that a particular configuration can take.
 
-Example:
+In our example application, dimensions that could change the configuration values could be one or more of the following:
 
-Let us assume we are modelling a system for buying cars, the dimensions you might use are:
-   1. Engine horsepower
-   2. manufacturer
-   3. model
+1. `city` - city where the user is hailing the ride - e.g. Bangalore (India), Chennai (India), Seattle (USA)
+2. `hour_of_day` - a number ranging between 0 and 23 denoting the hour of the day the ride is taken
 
-Contexts build upon Dimensions
+The value of the default configuration could change based on which city the user is hailing the ride and the hour of the day.
 
 ### Context
 
-A Context is a logical expression built using dimensions as variables. It takes the form:
+A Context is a logical expression built using dimensions as variables. It can be defined using the following [EBNF notation](https://en.wikipedia.org/wiki/Extended_Backus%E2%80%93Naur_form)
 
-`Dimension operator value`
+```
+context = context <logical-operator> context
+context = dimension <relational-operator> value
+logical-operator = AND
+relational-operator - IS | HAS | BETWEEN
+```
 
-Operators are:
-- IS: an equality operator
-- HAS: similar to the IN operator
-- BETWEEN (inclusive): an operator that checks if a provided value is between `value`
+- `IS`: an equality operator
+- `HAS`: similar to the IN operator
+- `BETWEEN` (inclusive): a relational operator that checks if a provided value is between `value`
 
-When multiple Context are defined together, they are evaluated as AND - if a context is evaluated as false, then the entire rule will not apply.
+The `logical-operator` is typically AND to keep context evaluation and comprehension overhead simple.  While other `logical-operator` can be used in CAC - we strongly recommend against it to keep configuration override comprehension simple.
 
-Examples:
+Examples of contexts:
 
-- color IS "red"
-- manufacturer IS "hyundai"
-- chassis HAS "hatchback"
+- `[city IS "Bangalore"]`
+- `[hour_of_day IS 8]`
+- `[city IS "Bangalore" AND hour_of_day IS 8]`
 
 ### Overrides
 
-Overrides are a subset of the configuration from Default Config typically with different values. Overrides are always associated with Contexts and are applied when a Context is evaluated to `true`. 
+Overrides are a subset of the configurations from Default Config typically with different values.  Overrides are always associated with contexts and are applied when a context evaluates to `true`. 
 
 Example:
 
-lets take an example to configure Tesla cars
+Let us configure different overrides for configuration keys under different contexts in our example.
 
 ```
-[manufacturer IS "Tesla"]
-engine = "EV"
+[city IS "Bangalore"]
+base_rate = 25
+per_distance_unit_rate = 10
 
-[manufacturer IS "Tesla", model IS "cybertruck"]
-chassis = "truck"
+[city IS "Chennai"]
+base_rate = 30
+per_distance_unit_rate = 20
 
-[manufacturer IS "Tesla", model IS "roadster"]
-chassis = "sport"
+[city IS "Bangalore", hour_of_day IS "8"]
+base_rate = 50
+per_distance_unit_rate = 30
 
-[manufacturer IS "Tesla", model IS "Y"]
-chassis = "sedan"
 ```
 
 ## How CAC Works
 ---
 
-- Your application adds the CAC client as a library
-- At runtime, your application will provide a context to the client for evaluation. Using our car example from earlier, the context provided by your application would look like:
+This section shows a complete configuration and how 
 
+- Your application adds the CAC client as a library
+- At runtime, your application will provide a context to the client for evaluation. Using our ride hailing example from earlier, the context provided by your application would look like:
     ```
-    {
-        manufacturer: "Tesla",
-        "model": "Y"
-    }
+    [city IS "Bangalore", hour_of_day IS 8]
     ```
 - CAC will apply all contexts it has available, and return the final configuration for the application. If no rule applies for a configuration, it's default value will be returned. From our earlier examples (check Default Config and Overrides section) the configuration returned would be
-
     ```
-    engine = "EV"
-    chassis = "sedan"
-    number_of_doors = 4
-    color = "silver"
-    interiors = "leather"
+    {
+        "base_rate": 50,
+        "per_distance_unit_rate": 30
+    }
     ```

--- a/docs/experimentation.md
+++ b/docs/experimentation.md
@@ -1,27 +1,71 @@
 # Experimentation
 
 ## Introduction
-In a nutshell, **Experimentation** module enables to run A/B/../n testing for your configurations in equi-sized groups/cohorts, it works on top of **Context-Aware-Config** and can also work as a release system for your configuration.
+
+The **Experimentation** component enables one to run A/B/../Z testing for your
+configurations in equi-sized groups/cohorts. It works on top of
+**Context-Aware-Config**.  The Experimentation component can also be used as a
+release system for your configuration changes which becomes an A/B test with
+two variants - the current value and new value.
 
 ## Concepts
 
 ### Experiment
-An experiment as name suggest enables you to test and evaluate the behaviour of the system for different values of the same configuration. An experiment can have exactly one **CONTROL** variant and `n` **EXPERIMENTAL** variants, with each variant overriding/changing same set of keys in configuration. An experiment's scope can be controlled by declaring the context, which chalks out the sample set for the experiment from the population.
+An experiment, as the name suggests, enables you to test and evaluate the
+behaviour of the system for different values of the same configuration. An
+experiment can have exactly one **CONTROL** variant and `n` **EXPERIMENTAL**
+variants, with each variant overriding/changing same set of keys in
+configuration. An experiment's scope can be controlled by declaring the
+context, which chalks out the sample set for the experiment from the
+population.
 
-<br/>
-<br/>
-
-![context-example](experiment-context-example.png)
+For example in our ride-hailing example, we may want to run an experiment for
+the 8th hour of the day in the city of Bangalore.  We can do that by specifying
+a context for the experiment.
+```
+[city IS "Bangalore", hour_of_day IS "8"]
+```
 
 ### Variant
-A variant in an experiment, represent one of the `n` tests. In simple terms, its a collection of key-value pairs, where each key is your already defined **default-config** key, and the value can be any valid new/old configuration value for the key. There are two kinds of variants:
+A variant in an experiment, represent one of the `n` tests. In simple terms,
+its a collection of key-value pairs, where each key is one of your already
+defined **default-config** key, and the value can be any valid new/old
+configuration value for the key adhering to it type constraints. There are two kinds of variants:
+
 1. **CONTROL**: It conceptually represents the current state of the configuration. 
 2. **EXPERIMENTAL**: The experimental variant lets you define the newer value for the **default-config** keys.
 
-<br/>
-<br/>
+#### Control Variant
+```json
+    {
+        "base_rate": 50,
+        "per_distance_unit_rate": 30
+    }
+```
 
-![variant-example](experiment-variant-example.png)
+The context for the above configuration is setup using a special additional dimension called `variantIds`
+```
+[city IS "Bangalore", hour_of_day IS 8, variantId IS "control-variant-for-experiment-1"]
+```
+
+#### Experimental Variant
+```json
+    {
+        "base_rate": 45,
+        "per_distance_unit_rate": 30
+    }
+```
+The context for the above configuration is setup using a special additional dimension called `variantIds`
+```
+[city IS "Bangalore", hour_of_day IS 8, variantId IS "experimental-variant-for-experiment-1"]
+```
+
+> [!NOTE]
+> Note how the control and experimental configuration add additional conditions to the base context of the experiment.
+
 
 ### Experiment's Traffic Percentage
-This defines the traffic size for each variant of the experiment, for instance if traffic percentage is `13%` and there are `4` variants in the experiment, this makes each variant of the experiment receive `13%` of the entire traffic and in entirety `13 * 4 = 52%` of the total traffic. 
+This defines the traffic size for each variant of the experiment, for instance
+if traffic percentage is `13%` and there are `4` variants in the experiment,
+    this makes each variant of the experiment receive `13%` of the entire
+    traffic and in entirety `13 * 4 = 52%` of the total traffic. 


### PR DESCRIPTION
## Problem
This PR updates the docs to simplify some wording, use the same example as the proposed demo-app and makes both experimentation/cac docs refer to the same example.  It also links to the Postman collection as a substitute for API documentation

## Solution
Same as above

## Environment variable changes
NA

## Pre-deployment activity
NA

## Post-deployment activity
NA

## API changes
NA

## Possible Issues in the future
NA
