### PR TITLE
chore: clean-up sql files post tenant creation

### DIFF
--- a/makefile
+++ b/makefile
@@ -47,7 +47,7 @@ legacy_db_setup:
 	grep 'DATABASE_URL=' .env | sed -e 's/DATABASE_URL=//' | xargs ./scripts/legacy-db-setup.sh
 
 tenant:
-	grep 'DATABASE_URL=' .env | sed -e 's/DATABASE_URL=//' | xargs ./scripts/create-tenant.sh $(TENANT)
+	grep 'DATABASE_URL=' .env | sed -e 's/DATABASE_URL=//' | xargs ./scripts/create-tenant.sh -t $(TENANT) -d
 
 validate-aws-connection:
 	aws --endpoint-url=http://$(DOCKER_DNS):4566 --region=ap-south-1 sts get-caller-identity

--- a/makefile
+++ b/makefile
@@ -131,8 +131,6 @@ run: kill build
 ci-test: ci-setup
 	cargo test
 	npm run test
-	rm test_cac.sql
-	rm test_experimentation.sql
 
 tailwind:
 	cd crates/frontend && npx tailwindcss -i ./styles/tailwind.css -o ./pkg/style.css --watch

--- a/scripts/create-tenant.sh
+++ b/scripts/create-tenant.sh
@@ -1,8 +1,21 @@
 #!/usr/bin/env bash
 shopt -s extglob
 
-TENANT=$1
-DB_URL=$2
+KEEP_SCHEMA_SQL=0
+
+while getopts t:d:k flag
+do
+    case "${flag}" in
+        t) TENANT=${OPTARG};;
+        d) DB_URL=${OPTARG};;
+        k) KEEP_SCHEMA_SQL=1;;
+    esac
+done
+
+if [ -z ${TENANT} ] || [ -z ${DB_URL} ]; then
+    echo "tenant name (-t) and db_url (-d) parameters are mandatory parameters to create a tenant"
+    exit -
+fi
 
 echo "Tenant ID ==> $TENANT"
 echo "DB URL ==> $DB_URL"
@@ -11,11 +24,11 @@ echo "DB URL ==> $DB_URL"
 CAC_SCHEMA="${TENANT}_cac"
 EXP_SCHEMA="${TENANT}_experimentation"
 
-function generate_sql() {
+function create_schema() {
     service=$1
     schema=$2
 
-    rm ${schema}.sql
+    rm -f ${schema}.sql
 
     for f in $(find "crates/$service/migrations" -name "up.sql" | grep -v "diesel_initial_setup" | sort)
     do
@@ -30,10 +43,20 @@ function generate_sql() {
 
     echo "Running migrations for $schema"
     psql "$DB_URL" -f ${schema}.sql
+    if [ $? -ne 0 ]; then
+        echo "Could not execute ${schema}.sql in postgres, dumping it below"
+        echo "=======================================";
+        cat ${schema.sql}
+        echo "=======================================";
+    fi
+    if [ ${KEEP_SCHEMA_SQL} -ne 1 ]; then
+        # remove file to keep the repository clean if keep argument is not sent
+        rm -f ${schema}.sql
+    fi
 }
 
-generate_sql "context_aware_config" $CAC_SCHEMA
-generate_sql "experimentation_platform" $EXP_SCHEMA
-psql "$DB_URL" -c "INSERT INTO $CAC_SCHEMA.dimensions (dimension, priority, created_at, created_by, schema, function_name) VALUES ('variantIds', 1, CURRENT_TIMESTAMP, 'user@superposition.io', '{\"type\": \"string\",\"pattern\": \".*\"}'::json, null);"
+create_schema "context_aware_config" $CAC_SCHEMA
+create_schema "experimentation_platform" $EXP_SCHEMA
+psql "$DB_URL" -c "INSERT INTO $CAC_SCHEMA.dimensions (dimension, priority, created_at, created_by, schema, function_name) VALUES ('variantIds', 1, CURRENT_TIMESTAMP, 'user@example.com', '{\"type\": \"string\",\"pattern\": \".*\"}'::json, null);"
 
 shopt -u extglob


### PR DESCRIPTION
## Problem
The create-tenant script leaves behind `.sql` files that were used to create the tenant schemas - leaving a dirty repository state.

## Solution
This fix removes the temporarily generated sql files and prints the generated sql file in case there is an error.  The script also supports a -k argument that allows one to keep the generated .sql files so as to use it in another environment and delete it manually later.

## Environment variable changes
NA

## Pre-deployment activity
NA

## Post-deployment activity
NA

## API changes
NA

## Possible Issues in the future
NA