### PR TITLE
feat: delete support for default config in UI

### DIFF
--- a/crates/frontend/src/api.rs
+++ b/crates/frontend/src/api.rs
@@ -205,5 +205,7 @@ pub async fn delete_default_config(key: String, tenant: String) -> Result<(), St
         None::<serde_json::Value>,
         construct_request_headers(&[("x-tenant", &tenant)])?,
     )
-    .await
+    .await?;
+
+    Ok(())
 }

--- a/crates/frontend/src/api.rs
+++ b/crates/frontend/src/api.rs
@@ -5,7 +5,7 @@ use crate::{
         Config, DefaultConfig, Dimension, Experiment, ExperimentsResponse,
         FunctionResponse, ListFilters,
     },
-    utils::use_host_server,
+    utils::{construct_request_headers, get_host, request, use_host_server},
 };
 
 // #[server(GetDimensions, "/fxn", "GetJson")]
@@ -193,4 +193,17 @@ pub async fn fetch_experiment(
         }
         Err(e) => Err(ServerFnError::ServerError(e.to_string())),
     }
+}
+
+pub async fn delete_default_config(key: String, tenant: String) -> Result<(), String> {
+    let host = get_host();
+    let url = format!("{host}/default-config/{key}");
+
+    request(
+        url,
+        reqwest::Method::DELETE,
+        None::<serde_json::Value>,
+        construct_request_headers(&[("x-tenant", &tenant)])?,
+    )
+    .await
 }

--- a/crates/frontend/src/components/alert/mod.rs
+++ b/crates/frontend/src/components/alert/mod.rs
@@ -58,12 +58,13 @@ impl AlertType {
 
 #[component]
 pub fn alert(alert: Alert) -> impl IntoView {
-    let outer_div_class = format!("alert {}", alert.alert_type.to_css_class());
+    let outer_div_class =
+        format!("alert max-w-[90vw] {}", alert.alert_type.to_css_class());
     let content_icon = alert.alert_type.to_icon_class();
     view! {
         <div role="alert" class=outer_div_class>
             <i class=content_icon></i>
-            <span>{alert.text}</span>
+            <span class="w-full text-ellipsis">{alert.text}</span>
         </div>
     }
 }

--- a/crates/frontend/src/components/context_form/utils.rs
+++ b/crates/frontend/src/components/context_form/utils.rs
@@ -1,6 +1,7 @@
 use crate::types::Dimension;
 use crate::utils::{
-    construct_request_headers, get_config_value, get_host, request, ConfigType,
+    construct_request_headers, get_config_value, get_host, parse_json_response, request,
+    ConfigType,
 };
 use anyhow::Result;
 use serde_json::{json, Map, Value};
@@ -108,13 +109,15 @@ pub async fn create_context(
     let host = get_host();
     let url = format!("{host}/context");
     let request_payload = construct_request_payload(overrides, conditions, dimensions);
-    request(
+    let response = request(
         url,
         reqwest::Method::PUT,
         Some(request_payload),
         construct_request_headers(&[("x-tenant", &tenant)])?,
     )
-    .await
+    .await?;
+
+    parse_json_response(response).await
 }
 
 pub async fn update_context(
@@ -126,11 +129,13 @@ pub async fn update_context(
     let host = get_host();
     let url = format!("{host}/context/overrides");
     let request_payload = construct_request_payload(overrides, conditions, dimensions);
-    request(
+    let response = request(
         url,
         reqwest::Method::PUT,
         Some(request_payload),
         construct_request_headers(&[("x-tenant", &tenant)])?,
     )
-    .await
+    .await?;
+
+    parse_json_response(response).await
 }

--- a/crates/frontend/src/components/default_config_form/utils.rs
+++ b/crates/frontend/src/components/default_config_form/utils.rs
@@ -1,5 +1,5 @@
 use super::types::DefaultConfigCreateReq;
-use crate::utils::{construct_request_headers, get_host, request};
+use crate::utils::{construct_request_headers, get_host, parse_json_response, request};
 
 pub async fn create_default_config(
     key: String,
@@ -9,11 +9,13 @@ pub async fn create_default_config(
     let host = get_host();
     let url = format!("{host}/default-config/{key}");
 
-    request(
+    let response = request(
         url,
         reqwest::Method::PUT,
         Some(payload),
         construct_request_headers(&[("x-tenant", &tenant)])?,
     )
-    .await
+    .await?;
+
+    parse_json_response(response).await
 }

--- a/crates/frontend/src/components/dimension_form/utils.rs
+++ b/crates/frontend/src/components/dimension_form/utils.rs
@@ -1,7 +1,7 @@
 use super::types::DimensionCreateReq;
 use crate::{
     types::Dimension,
-    utils::{construct_request_headers, get_host, request},
+    utils::{construct_request_headers, get_host, parse_json_response, request},
 };
 
 pub async fn create_dimension(
@@ -11,11 +11,13 @@ pub async fn create_dimension(
     let host = get_host();
     let url = format!("{host}/dimension");
 
-    request(
+    let response = request(
         url,
         reqwest::Method::PUT,
         Some(payload),
         construct_request_headers(&[("x-tenant", &tenant)])?,
     )
-    .await
+    .await?;
+
+    parse_json_response(response).await
 }

--- a/crates/frontend/src/components/experiment_form/utils.rs
+++ b/crates/frontend/src/components/experiment_form/utils.rs
@@ -3,7 +3,7 @@ use super::types::{
 };
 use crate::components::context_form::utils::construct_context;
 use crate::types::{Dimension, Variant};
-use crate::utils::{construct_request_headers, get_host, request};
+use crate::utils::{construct_request_headers, get_host, parse_json_response, request};
 use serde_json::Value;
 
 pub fn validate_experiment(experiment: &ExperimentCreateRequest) -> Result<bool, String> {
@@ -30,13 +30,15 @@ pub async fn create_experiment(
 
     let host = get_host();
     let url = format!("{host}/experiments");
-    request(
+    let response = request(
         url,
         reqwest::Method::POST,
         Some(payload),
         construct_request_headers(&[("x-tenant", &tenant)])?,
     )
-    .await
+    .await?;
+
+    parse_json_response(response).await
 }
 
 pub async fn update_experiment(
@@ -57,11 +59,13 @@ pub async fn update_experiment(
     let host = get_host();
     let url = format!("{}/experiments/{}/overrides", host, experiment_id);
 
-    request(
+    let response = request(
         url,
         reqwest::Method::PUT,
         Some(payload),
         construct_request_headers(&[("x-tenant", &tenant)])?,
     )
-    .await
+    .await?;
+
+    parse_json_response(response).await
 }

--- a/crates/frontend/src/components/function_form/utils.rs
+++ b/crates/frontend/src/components/function_form/utils.rs
@@ -1,7 +1,7 @@
 use super::types::{FunctionCreateRequest, FunctionUpdateRequest};
 use crate::{
     types::{FunctionResponse, FunctionTestResponse},
-    utils::{construct_request_headers, get_host, request},
+    utils::{construct_request_headers, get_host, parse_json_response, request},
 };
 use serde_json::Value;
 
@@ -21,13 +21,15 @@ pub async fn create_function(
 
     let host = get_host();
     let url = format!("{host}/function");
-    request(
+    let response = request(
         url,
         reqwest::Method::POST,
         Some(payload),
         construct_request_headers(&[("x-tenant", &tenant)])?,
     )
-    .await
+    .await?;
+
+    parse_json_response(response).await
 }
 
 pub async fn update_function(
@@ -46,13 +48,14 @@ pub async fn update_function(
     let host = get_host();
     let url = format!("{host}/function/{function_name}");
 
-    request(
+    let response = request(
         url,
         reqwest::Method::PATCH,
         Some(payload),
         construct_request_headers(&[("x-tenant", &tenant)])?,
     )
-    .await
+    .await?;
+    parse_json_response(response).await
 }
 
 pub async fn test_function(
@@ -64,11 +67,13 @@ pub async fn test_function(
     let host = get_host();
     let url = format!("{host}/function/{function_name}/{stage}/test");
 
-    request(
+    let response = request(
         url,
         reqwest::Method::PUT,
         Some(val),
         construct_request_headers(&[("x-tenant", &tenant)])?,
     )
-    .await
+    .await?;
+
+    parse_json_response(response).await
 }


### PR DESCRIPTION
## Problem
No delete support for default config from UI

## Solution
Add delete button for each row in default config table, which calls `DELETE /default-config/{key}` endpoint.

### Additional changes
Refactored request function in `frontend/utils.rs` to return raw response instead of parsing it to a type.
Reason:
- Responses can be empty, not necessarily have a content.
- Parsing no-content to a type will always fail even if we are parsing it to `()` (unit), because `no-content` is not a valid JSON.
- Separating parsing of the response from the actual request part, will be bit cleaner, as request function will get bloated with conditionals to handle the `no-content` or any other scenario that I am not currently aware of.