### PR TITLE
add cache control headers for all routes

### DIFF
--- a/crates/superposition/src/main.rs
+++ b/crates/superposition/src/main.rs
@@ -167,6 +167,7 @@ async fn main() -> Result<()> {
             .wrap(
                 actix_web::middleware::DefaultHeaders::new()
                     .add(("X-SERVER-VERSION", cac_version.to_string()))
+                    .add(("Cache-Control", "no-store".to_string()))
             )
             .service(web::redirect("/", ui_redirect_path.to_string()))
             .service(web::redirect("/admin", ui_redirect_path.to_string()))


### PR DESCRIPTION
## Problem
Api response are getting cached on the client side, which gives inconsistent results

## Solution
Add cache-control: no-store headers , so that response should not cached in private and shared cache

## Environment variable changes
NA

## Pre-deployment activity
NA

## Post-deployment activity
NA

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
NA