### PR TITLE
fix: row numbering in paginated table

### DIFF
--- a/crates/frontend/src/components/pagination/pagination.rs
+++ b/crates/frontend/src/components/pagination/pagination.rs
@@ -1,25 +1,21 @@
 use leptos::*;
 
 #[component]
-pub fn pagination<NF, PF>(
+pub fn pagination(
     current_page: i64,
     total_pages: i64,
-    next: NF,
-    previous: PF,
-) -> impl IntoView
-where
-    NF: Fn() + 'static,
-    PF: Fn() + 'static,
-{
+    next: Callback<i64>,
+    previous: Callback<()>,
+) -> impl IntoView {
     view! {
         <div class="join">
-            <button class="join-item btn" on:click=move |_| previous()>
+            <button class="join-item btn" on:click=move |_| previous.call(())>
                 "«"
             </button>
             <button class="join-item btn">
                 {format!("Page {} / {}", current_page, total_pages)}
             </button>
-            <button class="join-item btn" on:click=move |_| next()>
+            <button class="join-item btn" on:click=move |_| next.call(total_pages)>
                 "»"
             </button>
         </div>

--- a/crates/frontend/src/components/table/table.rs
+++ b/crates/frontend/src/components/table/table.rs
@@ -1,4 +1,6 @@
-use super::types::Column;
+use crate::components::pagination::pagination::Pagination;
+
+use super::types::{Column, TablePaginationProps};
 use leptos::*;
 use serde_json::{json, Map, Value};
 
@@ -23,7 +25,9 @@ pub fn table(
     cell_style: String,
     columns: Vec<Column>,
     rows: Vec<Map<String, Value>>,
+    #[prop(default = TablePaginationProps::default())] pagination: TablePaginationProps,
 ) -> impl IntoView {
+    let pagination_props = StoredValue::new(pagination);
     view! {
         <div class="overflow-x-auto">
             <table class="table table-zebra">
@@ -55,9 +59,16 @@ pub fn table(
                                 .as_str()
                                 .unwrap()
                                 .to_string();
+                            let TablePaginationProps { enabled, current_page, count, .. } = pagination_props
+                                .get_value();
+                            let row_num = if enabled {
+                                index as i64 + 1 + ((current_page - 1) * count)
+                            } else {
+                                index as i64 + 1
+                            };
                             view! {
                                 <tr id=row_id>
-                                    <th>{index + 1}</th>
+                                    <th>{row_num}</th>
 
                                     {columns
                                         .iter()
@@ -81,6 +92,26 @@ pub fn table(
 
                 </tbody>
             </table>
+            <Show when=move || {
+                pagination_props.get_value().enabled
+            }>
+
+                {move || {
+                    let TablePaginationProps { current_page, total_pages, on_prev, on_next, .. } = pagination_props
+                        .get_value();
+                    view! {
+                        <div class="mt-2 flex justify-end">
+                            <Pagination
+                                current_page=current_page
+                                total_pages=total_pages
+                                next=on_next
+                                previous=on_prev
+                            />
+                        </div>
+                    }
+                }}
+
+            </Show>
         </div>
     }
 }

--- a/crates/frontend/src/components/table/types.rs
+++ b/crates/frontend/src/components/table/types.rs
@@ -1,6 +1,6 @@
 use std::rc::Rc;
 
-use leptos::{view, IntoView, View};
+use leptos::{view, Callback, IntoView, View};
 use serde_json::{Map, Value};
 
 pub type CellFormatter = Box<Rc<dyn Fn(&str, &Map<String, Value>) -> View>>;
@@ -43,6 +43,29 @@ impl Column {
             name,
             hidden: hidden.unwrap_or(false),
             formatter: Box::new(Rc::new(formatter)),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TablePaginationProps {
+    pub enabled: bool,
+    pub current_page: i64,
+    pub total_pages: i64,
+    pub count: i64,
+    pub on_next: Callback<i64>,
+    pub on_prev: Callback<()>,
+}
+
+impl Default for TablePaginationProps {
+    fn default() -> Self {
+        TablePaginationProps {
+            enabled: false,
+            current_page: 0,
+            total_pages: 0,
+            count: 0,
+            on_next: Callback::new(move |_| {}),
+            on_prev: Callback::new(move |_| {}),
         }
     }
 }


### PR DESCRIPTION
## Problem
In paginated tables, the rows number was always from 1 upto the row count for the particular page. For example, if row count is 10 for each page, rows on 2nd page of the table too had sr number `1,2,3,..,10`, which should have been `11,12,..20`.

## Solution
Move the pagination state inside the table, so that the row number can be calculated based on `current_page` and `count` of rows per page