### PR TITLE
fix: Temporarily disable eclint

### DIFF
--- a/nix/pre-commit.nix
+++ b/nix/pre-commit.nix
@@ -5,7 +5,7 @@
       check.enable = true;
       settings = {
         hooks = {
-            eclint.enable = true;
+          eclint.enable = false;
         };
       };
     };


### PR DESCRIPTION
## Problem
Even after adding separate rule for YAML files, eclint pre-commit hook is failing for yaml files containing array of objects

## Solution
Disable eclint pre-commit hook