### PR TITLE
fix: Add prefix to client's methods

### DIFF
--- a/clients/haskell/hs-cac-client/src/Client.hs
+++ b/clients/haskell/hs-cac-client/src/Client.hs
@@ -34,34 +34,34 @@ type Tenant = String
 
 type Error = String
 
-foreign import ccall unsafe "new_client"
+foreign import ccall unsafe "cac_new_client"
     c_new_cac_client :: CTenant -> CULong -> CString -> IO CInt
 
-foreign import ccall unsafe "&free_client"
+foreign import ccall unsafe "&cac_free_client"
     c_free_cac_client :: FunPtr (Ptr CacClient -> IO ())
 
-foreign import ccall unsafe "get_client"
+foreign import ccall unsafe "cac_get_client"
     c_get_cac_client :: CTenant -> IO (Ptr CacClient)
 
-foreign import ccall unsafe "last_error_message"
+foreign import ccall unsafe "cac_last_error_message"
     c_last_error_message :: IO CString
 
-foreign import ccall unsafe "get_last_modified"
+foreign import ccall unsafe "cac_get_last_modified"
     c_get_last_modified_time :: Ptr CacClient -> IO CString
 
-foreign import ccall unsafe "get_config"
+foreign import ccall unsafe "cac_get_config"
     c_get_config :: Ptr CacClient -> CString -> IO CString
 
-foreign import ccall unsafe "get_resolved_config"
+foreign import ccall unsafe "cac_get_resolved_config"
     c_cac_get_resolved_config :: Ptr CacClient -> CString -> CString -> CString -> IO CString
 
-foreign import ccall unsafe "get_default_config"
+foreign import ccall unsafe "cac_get_default_config"
     c_cac_get_default_config :: Ptr CacClient -> CString -> IO CString
 
-foreign import ccall safe "start_polling_update"
+foreign import ccall safe "cac_start_polling_update"
     c_cac_poll :: CTenant -> IO ()
 
-foreign import ccall unsafe "&free_string"
+foreign import ccall unsafe "&cac_free_string"
     c_free_string :: FunPtr (CString -> IO ())
 
 data MergeStrategy = MERGE | REPLACE deriving (Show, Eq, Ord, Enum)

--- a/clients/haskell/hs-exp-client/src/Client.hs
+++ b/clients/haskell/hs-exp-client/src/Client.hs
@@ -31,31 +31,31 @@ type Tenant = String
 
 type Error = String
 
-foreign import ccall unsafe "new_client"
-    c_new_exp_client :: CTenant -> CULong -> CString -> IO CInt
+foreign import ccall unsafe "expt_new_client"
+    c_new_expt_client :: CTenant -> CULong -> CString -> IO CInt
 
-foreign import ccall unsafe "&free_client"
-    c_free_exp_client :: FunPtr (Ptr ExpClient -> IO ())
+foreign import ccall unsafe "&expt_free_client"
+    c_free_expt_client :: FunPtr (Ptr ExpClient -> IO ())
 
-foreign import ccall unsafe "get_client"
-    c_get_exp_client :: CTenant -> IO (Ptr ExpClient)
+foreign import ccall unsafe "expt_get_client"
+    c_get_expt_client :: CTenant -> IO (Ptr ExpClient)
 
-foreign import ccall unsafe "last_error_message"
+foreign import ccall unsafe "expt_last_error_message"
     c_last_error_message :: IO CString
 
-foreign import ccall unsafe "&free_string"
+foreign import ccall unsafe "&expt_free_string"
     c_free_string :: FunPtr (CString -> IO ())
 
-foreign import ccall unsafe "start_polling_update"
+foreign import ccall unsafe "expt_start_polling_update"
     c_start_polling_update :: CTenant -> IO ()
 
-foreign import ccall unsafe "get_applicable_variant"
+foreign import ccall unsafe "expt_get_applicable_variant"
     c_get_applicable_variants :: Ptr ExpClient -> CString -> CShort -> IO CString
 
-foreign import ccall unsafe "get_satisfied_experiments"
+foreign import ccall unsafe "expt_get_satisfied_experiments"
     c_get_satisfied_experiments :: Ptr ExpClient -> CString -> IO CString
 
-foreign import ccall unsafe "get_running_experiments"
+foreign import ccall unsafe "expt_get_running_experiments"
     c_get_running_experiments :: Ptr ExpClient -> IO CString
 
 expStartPolling :: Tenant -> IO ()
@@ -77,7 +77,7 @@ createExpClient tenant frequency hostname = do
     let duration = fromInteger frequency
     cTenant   <- newCAString tenant
     cHostname <- newCAString hostname
-    resp      <- c_new_exp_client cTenant duration cHostname
+    resp      <- c_new_expt_client cTenant duration cHostname
     _         <- cleanup [cTenant, cHostname]
     case resp of
         0 -> pure $ Right ()
@@ -86,11 +86,11 @@ createExpClient tenant frequency hostname = do
 getExpClient :: Tenant -> IO (Either Error (ForeignPtr ExpClient))
 getExpClient tenant = do
     cTenant   <- newCAString tenant
-    cacClient <- c_get_exp_client cTenant
+    cacClient <- c_get_expt_client cTenant
     _         <- cleanup [cTenant]
     if cacClient == nullPtr
         then Left <$> getError
-        else Right <$> newForeignPtr c_free_exp_client cacClient
+        else Right <$> newForeignPtr c_free_expt_client cacClient
 
 getApplicableVariants :: ForeignPtr ExpClient -> String -> Integer -> IO (Either Error String)
 getApplicableVariants client query toss = do

--- a/crates/cac_client/src/interface.rs
+++ b/crates/cac_client/src/interface.rs
@@ -65,7 +65,7 @@ pub fn take_last_error() -> Option<Box<String>> {
 }
 
 #[no_mangle]
-pub extern "C" fn last_error_length() -> c_int {
+pub extern "C" fn cac_last_error_length() -> c_int {
     LAST_ERROR.with(|prev| match *prev.borrow() {
         Some(ref err) => err.to_string().len() as c_int + 1,
         None => 0,
@@ -73,7 +73,7 @@ pub extern "C" fn last_error_length() -> c_int {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn last_error_message() -> *const c_char {
+pub unsafe extern "C" fn cac_last_error_message() -> *const c_char {
     let last_error = unwrap_safe!(
         take_last_error().ok_or("No error found"),
         return std::ptr::null_mut()
@@ -85,7 +85,7 @@ pub unsafe extern "C" fn last_error_message() -> *const c_char {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn free_string(s: *mut c_char) {
+pub unsafe extern "C" fn cac_free_string(s: *mut c_char) {
     if s.is_null() {
         return;
     }
@@ -95,7 +95,7 @@ pub unsafe extern "C" fn free_string(s: *mut c_char) {
 }
 
 #[no_mangle]
-pub extern "C" fn new_client(
+pub extern "C" fn cac_new_client(
     tenant: *const c_char,
     update_frequency: c_ulong,
     hostname: *const c_char,
@@ -122,10 +122,10 @@ pub extern "C" fn new_client(
 }
 
 #[no_mangle]
-pub extern "C" fn start_polling_update(tenant: *const c_char) {
+pub extern "C" fn cac_start_polling_update(tenant: *const c_char) {
     null_check!(tenant, "NULL pointer provided for tenant", return ());
     unsafe {
-        let client = get_client(tenant);
+        let client = cac_get_client(tenant);
         null_check!(client, "CAC client for tenant not found", return ());
         let local = task::LocalSet::new();
         // println!("in FFI polling");
@@ -137,7 +137,7 @@ pub extern "C" fn start_polling_update(tenant: *const c_char) {
 }
 
 #[no_mangle]
-pub extern "C" fn free_client(ptr: *mut Arc<Client>) {
+pub extern "C" fn cac_free_client(ptr: *mut Arc<Client>) {
     if ptr.is_null() {
         return;
     }
@@ -147,7 +147,7 @@ pub extern "C" fn free_client(ptr: *mut Arc<Client>) {
 }
 
 #[no_mangle]
-pub extern "C" fn get_client(tenant: *const c_char) -> *mut Arc<Client> {
+pub extern "C" fn cac_get_client(tenant: *const c_char) -> *mut Arc<Client> {
     let ten = unwrap_safe!(cstring_to_rstring(tenant), return std::ptr::null_mut());
     // println!("fetching cac client thread for tenant {ten}");
     unwrap_safe!(
@@ -159,7 +159,7 @@ pub extern "C" fn get_client(tenant: *const c_char) -> *mut Arc<Client> {
 }
 
 #[no_mangle]
-pub extern "C" fn get_last_modified(client: *mut Arc<Client>) -> *const c_char {
+pub extern "C" fn cac_get_last_modified(client: *mut Arc<Client>) -> *const c_char {
     null_check!(
         client,
         "an invalid null pointer client is being used, please call get_client()",
@@ -176,7 +176,7 @@ pub extern "C" fn get_last_modified(client: *mut Arc<Client>) -> *const c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn get_config(
+pub extern "C" fn cac_get_config(
     client: *mut Arc<Client>,
     query: *const c_char,
 ) -> *const c_char {
@@ -220,7 +220,7 @@ pub extern "C" fn get_config(
 }
 
 #[no_mangle]
-pub extern "C" fn get_resolved_config(
+pub extern "C" fn cac_get_resolved_config(
     client: *mut Arc<Client>,
     query: *const c_char,
     filter_keys: *const c_char,
@@ -275,7 +275,7 @@ pub extern "C" fn get_resolved_config(
 }
 
 #[no_mangle]
-pub extern "C" fn get_default_config(
+pub extern "C" fn cac_get_default_config(
     client: *mut Arc<Client>,
     filter_keys: *const c_char,
 ) -> *const c_char {

--- a/crates/experimentation_client/src/interface.rs
+++ b/crates/experimentation_client/src/interface.rs
@@ -49,7 +49,7 @@ pub fn take_last_error() -> Option<String> {
 }
 
 #[no_mangle]
-pub extern "C" fn last_error_length() -> c_int {
+pub extern "C" fn expt_last_error_length() -> c_int {
     LAST_ERROR.with(|prev| match *prev.borrow() {
         Some(ref err) => err.to_string().len() as c_int + 1,
         None => 0,
@@ -57,7 +57,7 @@ pub extern "C" fn last_error_length() -> c_int {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn last_error_message() -> *const c_char {
+pub unsafe extern "C" fn expt_last_error_message() -> *const c_char {
     let last_error = match take_last_error() {
         Some(err) => err,
         None => return std::ptr::null_mut(),
@@ -69,7 +69,7 @@ pub unsafe extern "C" fn last_error_message() -> *const c_char {
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn free_string(s: *mut c_char) {
+pub unsafe extern "C" fn expt_free_string(s: *mut c_char) {
     if s.is_null() {
         return;
     }
@@ -79,7 +79,7 @@ pub unsafe extern "C" fn free_string(s: *mut c_char) {
 }
 
 #[no_mangle]
-pub extern "C" fn new_client(
+pub extern "C" fn expt_new_client(
     tenant: *const c_char,
     update_frequency: c_ulong,
     hostname: *const c_char,
@@ -117,12 +117,12 @@ pub extern "C" fn new_client(
 }
 
 #[no_mangle]
-pub extern "C" fn start_polling_update(tenant: *const c_char) {
+pub extern "C" fn expt_start_polling_update(tenant: *const c_char) {
     if tenant.is_null() {
         return ();
     }
     unsafe {
-        let client = get_client(tenant);
+        let client = expt_get_client(tenant);
         let local = task::LocalSet::new();
         // println!("in FFI polling");
         local.block_on(
@@ -133,7 +133,7 @@ pub extern "C" fn start_polling_update(tenant: *const c_char) {
 }
 
 #[no_mangle]
-pub extern "C" fn free_client(ptr: *mut Arc<Client>) {
+pub extern "C" fn expt_free_client(ptr: *mut Arc<Client>) {
     if ptr.is_null() {
         return;
     }
@@ -143,7 +143,7 @@ pub extern "C" fn free_client(ptr: *mut Arc<Client>) {
 }
 
 #[no_mangle]
-pub extern "C" fn get_client(tenant: *const c_char) -> *mut Arc<Client> {
+pub extern "C" fn expt_get_client(tenant: *const c_char) -> *mut Arc<Client> {
     let ten = match cstring_to_rstring(tenant) {
         Ok(t) => t,
         Err(err) => {
@@ -170,7 +170,7 @@ pub extern "C" fn get_client(tenant: *const c_char) -> *mut Arc<Client> {
 }
 
 #[no_mangle]
-pub extern "C" fn get_applicable_variant(
+pub extern "C" fn expt_get_applicable_variant(
     client: *mut Arc<Client>,
     c_context: *const c_char,
     toss: c_short,
@@ -196,7 +196,7 @@ pub extern "C" fn get_applicable_variant(
 }
 
 #[no_mangle]
-pub extern "C" fn get_satisfied_experiments(
+pub extern "C" fn expt_get_satisfied_experiments(
     client: *mut Arc<Client>,
     c_context: *const c_char,
 ) -> *mut c_char {
@@ -222,7 +222,7 @@ pub extern "C" fn get_satisfied_experiments(
 }
 
 #[no_mangle]
-pub extern "C" fn get_running_experiments(client: *mut Arc<Client>) -> *mut c_char {
+pub extern "C" fn expt_get_running_experiments(client: *mut Arc<Client>) -> *mut c_char {
     let local = task::LocalSet::new();
     let experiments = local.block_on(&Runtime::new().unwrap(), unsafe {
         (*client).get_running_experiments()

--- a/headers/libcac_client.h
+++ b/headers/libcac_client.h
@@ -5,27 +5,27 @@
 
 typedef struct Arc_Client Arc_Client;
 
-int last_error_length(void);
+int cac_last_error_length(void);
 
-const char *last_error_message(void);
+const char *cac_last_error_message(void);
 
-void free_string(char *s);
+void cac_free_string(char *s);
 
-int new_client(const char *tenant, unsigned long update_frequency, const char *hostname);
+int cac_new_client(const char *tenant, unsigned long update_frequency, const char *hostname);
 
-void start_polling_update(const char *tenant);
+void cac_start_polling_update(const char *tenant);
 
-void free_client(struct Arc_Client *ptr);
+void cac_free_client(struct Arc_Client *ptr);
 
-struct Arc_Client *get_client(const char *tenant);
+struct Arc_Client *cac_get_client(const char *tenant);
 
-const char *get_last_modified(struct Arc_Client *client);
+const char *cac_get_last_modified(struct Arc_Client *client);
 
-const char *get_config(struct Arc_Client *client, const char *query);
+const char *cac_get_config(struct Arc_Client *client, const char *query);
 
-const char *get_resolved_config(struct Arc_Client *client,
-                                const char *query,
-                                const char *filter_keys,
-                                const char *merge_strategy);
+const char *cac_get_resolved_config(struct Arc_Client *client,
+                                    const char *query,
+                                    const char *filter_keys,
+                                    const char *merge_strategy);
 
-const char *get_default_config(struct Arc_Client *client, const char *filter_keys);
+const char *cac_get_default_config(struct Arc_Client *client, const char *filter_keys);

--- a/headers/libexperimentation_client.h
+++ b/headers/libexperimentation_client.h
@@ -5,22 +5,22 @@
 
 typedef struct Arc_Client Arc_Client;
 
-int last_error_length(void);
+int expt_last_error_length(void);
 
-const char *last_error_message(void);
+const char *expt_last_error_message(void);
 
-void free_string(char *s);
+void expt_free_string(char *s);
 
-int new_client(const char *tenant, unsigned long update_frequency, const char *hostname);
+int expt_new_client(const char *tenant, unsigned long update_frequency, const char *hostname);
 
-void start_polling_update(const char *tenant);
+void expt_start_polling_update(const char *tenant);
 
-void free_client(struct Arc_Client *ptr);
+void expt_free_client(struct Arc_Client *ptr);
 
-struct Arc_Client *get_client(const char *tenant);
+struct Arc_Client *expt_get_client(const char *tenant);
 
-char *get_applicable_variant(struct Arc_Client *client, const char *c_context, short toss);
+char *expt_get_applicable_variant(struct Arc_Client *client, const char *c_context, short toss);
 
-char *get_satisfied_experiments(struct Arc_Client *client, const char *c_context);
+char *expt_get_satisfied_experiments(struct Arc_Client *client, const char *c_context);
 
-char *get_running_experiments(struct Arc_Client *client);
+char *expt_get_running_experiments(struct Arc_Client *client);


### PR DESCRIPTION
## Problem
When running client in jenkins it shows `multiple definition of `several client's functions as exp_client and cac_client' s functions had similar name.

## Solution
Added prefix to the extern function for both cac and exp clients as `cac_` and `exp_` respectively.
