### PR TITLE
Rework async library in CAC client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,7 @@ test_logs
 .keep
 .vscode
 *.session.sql
-
+.cargo
 # pre-commit config
 .pre-commit-config.yaml
 .cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -666,6 +666,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cac_client_integration_example"
+version = "0.1.0"
+dependencies = [
+ "actix",
+ "actix-web",
+ "cac_client",
+ "chrono",
+ "serde_json",
+]
+
+[[package]]
 name = "cached"
 version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1480,17 +1491,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e757e796a66b54d19fa26de38e75c3351eb7a3755c85d7d181a8c61437ff60c"
 
 [[package]]
-name = "example"
-version = "0.1.0"
-dependencies = [
- "actix",
- "actix-web",
- "chrono",
- "experimentation_client",
- "serde_json",
-]
-
-[[package]]
 name = "experimentation_client"
 version = "0.7.2"
 dependencies = [
@@ -1505,6 +1505,17 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+]
+
+[[package]]
+name = "experimentation_example"
+version = "0.1.0"
+dependencies = [
+ "actix",
+ "actix-web",
+ "chrono",
+ "experimentation_client",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,12 @@ members = [
     "crates/service_utils",
     "crates/experimentation_client",
     "crates/cac_client",
-    "crates/experimentation_client_integration_example",
     "crates/frontend",
     "crates/caclang",
     "crates/superposition",
     "crates/superposition_types",
+    "examples/experimentation_client_integration_example",
+    "examples/cac_client_integration_example"
 ]
 
 [[workspace.metadata.leptos]]

--- a/crates/cac_client/src/interface.rs
+++ b/crates/cac_client/src/interface.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use crate::{utils::core::MapError, Client, MergeStrategy, CLIENT_FACTORY};
+use once_cell::sync::Lazy;
 use serde_json::{Map, Value};
 use std::{
     cell::RefCell,
@@ -16,6 +17,9 @@ use tokio::{runtime::Runtime, task};
 thread_local! {
     static LAST_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
 }
+
+pub static CAC_RUNTIME: Lazy<Runtime> =
+    Lazy::new(|| Runtime::new().expect("The runtime was not intialized"));
 
 macro_rules! null_check {
     ($client: ident, $err: literal, $return: stmt) => {
@@ -105,7 +109,7 @@ pub extern "C" fn cac_new_client(
 
     // println!("Creating cac client thread for tenant {tenant}");
     let local = task::LocalSet::new();
-    local.block_on(&Runtime::new().unwrap(), async move {
+    local.block_on(&CAC_RUNTIME, async move {
         match CLIENT_FACTORY
             .create_client(tenant.clone(), duration, hostname)
             .await
@@ -127,10 +131,7 @@ pub extern "C" fn cac_start_polling_update(tenant: *const c_char) {
         null_check!(client, "CAC client for tenant not found", return);
         let local = task::LocalSet::new();
         // println!("in FFI polling");
-        local.block_on(
-            &Runtime::new().unwrap(),
-            (*client).clone().run_polling_updates(),
-        );
+        local.block_on(&CAC_RUNTIME, (*client).clone().run_polling_updates());
     }
 }
 
@@ -148,12 +149,16 @@ pub extern "C" fn cac_free_client(ptr: *mut Arc<Client>) {
 pub extern "C" fn cac_get_client(tenant: *const c_char) -> *mut Arc<Client> {
     let ten = unwrap_safe!(cstring_to_rstring(tenant), return std::ptr::null_mut());
     // println!("fetching cac client thread for tenant {ten}");
-    unwrap_safe!(
-        CLIENT_FACTORY
-            .get_client(ten)
-            .map(|client| Box::into_raw(Box::new(client))),
-        std::ptr::null_mut()
-    )
+    let local = task::LocalSet::new();
+    local.block_on(&CAC_RUNTIME, async move {
+        unwrap_safe!(
+            CLIENT_FACTORY
+                .get_client(ten)
+                .await
+                .map(|client| Box::into_raw(Box::new(client))),
+            std::ptr::null_mut()
+        )
+    })
 }
 
 #[no_mangle]
@@ -163,14 +168,13 @@ pub extern "C" fn cac_get_last_modified(client: *mut Arc<Client>) -> *const c_ch
         "an invalid null pointer client is being used, please call get_client()",
         return std::ptr::null()
     );
-    unwrap_safe!(
+    let local = task::LocalSet::new();
+    local.block_on(&CAC_RUNTIME, async move {
         unsafe {
-            (*client)
-                .get_last_modified()
-                .map(|date| rstring_to_cstring(date.to_string()).into_raw())
-        },
-        std::ptr::null()
-    )
+            let datetime = (*client).get_last_modified().await;
+            rstring_to_cstring(datetime.to_string()).into_raw()
+        }
+    })
 }
 
 #[no_mangle]
@@ -216,9 +220,8 @@ pub extern "C" fn cac_get_config(
                 .map(|config| {
                     rstring_to_cstring(serde_json::to_value(config).unwrap().to_string())
                         .into_raw()
-                })
-        },
-        std::ptr::null_mut()
+                    }) },
+                std::ptr::null_mut()
     )
 }
 
@@ -238,13 +241,8 @@ pub extern "C" fn cac_get_resolved_config(
     let keys: Option<Vec<String>> = if filter_keys.is_null() {
         None
     } else {
-        let filter_string = match cstring_to_rstring(filter_keys) {
-            Ok(s) => s,
-            Err(err) => {
-                update_last_error(err);
-                return std::ptr::null();
-            }
-        };
+        let filter_string =
+            unwrap_safe!(cstring_to_rstring(filter_keys), return std::ptr::null());
         Some(filter_string.split('|').map(str::to_string).collect())
     };
 
@@ -260,21 +258,28 @@ pub extern "C" fn cac_get_resolved_config(
         serde_json::from_str::<Map<String, Value>>(query.as_str()),
         return std::ptr::null()
     );
-
-    unwrap_safe!(
+    let local = task::LocalSet::new();
+    local.block_on(&CAC_RUNTIME, async move {
         unsafe {
-            (*client)
-                .get_resolved_config(context, keys, MergeStrategy::from(merge_strategem))
-                .map(|ov| {
-                    unwrap_safe!(
+            unwrap_safe!(
+                (*client)
+                    .get_resolved_config(
+                        context,
+                        keys,
+                        MergeStrategy::from(merge_strategem),
+                    )
+                    .await
+                    .map(|ov| {
+                        unwrap_safe!(
                         serde_json::to_string::<Map<String, Value>>(&ov)
                             .map(|overrides| rstring_to_cstring(overrides).into_raw()),
                         std::ptr::null()
                     )
-                })
-        },
-        std::ptr::null()
-    )
+                    }),
+                std::ptr::null()
+            )
+        }
+    })
 }
 
 #[no_mangle]
@@ -294,17 +299,19 @@ pub extern "C" fn cac_get_default_config(
         };
         Some(filter_string.split('|').map(str::to_string).collect())
     };
-
-    unwrap_safe!(
-        unsafe {
-            (*client).get_default_config(keys).map(|ov| {
-                unwrap_safe!(
-                    serde_json::to_string::<Map<String, Value>>(&ov)
-                        .map(|overrides| rstring_to_cstring(overrides).into_raw()),
-                    std::ptr::null()
-                )
-            })
-        },
-        std::ptr::null()
-    )
+    let local = task::LocalSet::new();
+    local.block_on(&CAC_RUNTIME, async move {
+        unwrap_safe!(
+            unsafe {
+                (*client).get_default_config(keys).await.map(|ov| {
+                    unwrap_safe!(
+                        serde_json::to_string::<Map<String, Value>>(&ov)
+                            .map(|overrides| rstring_to_cstring(overrides).into_raw()),
+                        return std::ptr::null()
+                    )
+                })
+            },
+            return std::ptr::null()
+        )
+    })
 }

--- a/crates/cac_client/src/lib.rs
+++ b/crates/cac_client/src/lib.rs
@@ -159,7 +159,8 @@ impl Client {
         query_data: Option<Map<String, Value>>,
         prefix: Option<Vec<String>>,
     ) -> Result<Config, String> {
-        let mut config = self.config.read().map(|c| c.clone()).map_err_to_string()?;
+        let cac = self.config.read().await;
+        let mut config = cac.to_owned();
         if let Some(prefix_list) = prefix {
             config = filter_config_by_prefix(&config, prefix_list).map_err_to_string()?;
         }

--- a/crates/experimentation_client/src/interface.rs
+++ b/crates/experimentation_client/src/interface.rs
@@ -16,7 +16,7 @@ thread_local! {
     static LAST_ERROR: RefCell<Option<String>> = const { RefCell::new(None) };
 }
 
-pub static EXP_RUNTIME: Lazy<Runtime> =
+static EXP_RUNTIME: Lazy<Runtime> =
     Lazy::new(|| Runtime::new().expect("The runtime was not intialized"));
 
 macro_rules! null_check {
@@ -113,8 +113,7 @@ pub extern "C" fn expt_new_client(
     let hostname = unwrap_safe!(cstring_to_rstring(hostname), return 1);
 
     // println!("Creating cac client thread for tenant {tenant}");
-    let local = task::LocalSet::new();
-    local.block_on(&EXP_RUNTIME, async move {
+    EXP_RUNTIME.block_on(async move {
         match CLIENT_FACTORY
             .create_client(tenant.clone(), update_frequency, hostname)
             .await
@@ -151,22 +150,17 @@ pub extern "C" fn expt_free_client(ptr: *mut Arc<Client>) {
 #[no_mangle]
 pub extern "C" fn expt_get_client(tenant: *const c_char) -> *mut Arc<Client> {
     let ten = unwrap_safe!(cstring_to_rstring(tenant), return std::ptr::null_mut());
-    let local = task::LocalSet::new();
-    local.block_on(
-        &EXP_RUNTIME,
-        // println!("fetching exp client thread for tenant {ten}");
-        async move {
-            match CLIENT_FACTORY.get_client(ten).await {
-                Ok(client) => Box::into_raw(Box::new(client)),
-                Err(err) => {
-                    // println!("error occurred {err}");
-                    update_last_error(err);
-                    // println!("error set");
-                    std::ptr::null_mut()
-                }
+    EXP_RUNTIME.block_on(async move {
+        match CLIENT_FACTORY.get_client(ten).await {
+            Ok(client) => Box::into_raw(Box::new(client)),
+            Err(err) => {
+                // println!("error occurred {err}");
+                update_last_error(err);
+                // println!("error set");
+                std::ptr::null_mut()
             }
-        },
-    )
+        }
+    })
 }
 
 #[no_mangle]
@@ -175,17 +169,14 @@ pub extern "C" fn expt_get_applicable_variant(
     c_context: *const c_char,
     toss: c_short,
 ) -> *mut c_char {
-    let context = match cstring_to_rstring(c_context) {
-        Ok(c) => match serde_json::from_str::<Value>(c.as_str()) {
-            Ok(con) => con,
-            Err(err) => return error_block(err.to_string()),
-        },
-        Err(err) => return error_block(err),
-    };
-    let local = task::LocalSet::new();
-    let variants_result = local.block_on(&EXP_RUNTIME, unsafe {
-        (*client).get_applicable_variant(&context, toss as i8)
-    });
+    let context =
+        unwrap_safe!(cstring_to_rstring(c_context), return std::ptr::null_mut());
+    let context = unwrap_safe!(
+        serde_json::from_str::<Value>(context.as_str()),
+        return std::ptr::null_mut()
+    );
+    let variants_result = EXP_RUNTIME
+        .block_on(unsafe { (*client).get_applicable_variant(&context, toss as i8) });
     variants_result
         .map(|result| {
             serde_json::to_string(&result)
@@ -201,24 +192,22 @@ pub extern "C" fn expt_get_satisfied_experiments(
     c_context: *const c_char,
     filter_prefix: *const c_char,
 ) -> *mut c_char {
-    let context = match cstring_to_rstring(c_context) {
-        Ok(c) => match serde_json::from_str::<Value>(c.as_str()) {
-            Ok(con) => con,
-            Err(err) => return error_block(err.to_string()),
-        },
-        Err(err) => return error_block(err),
-    };
+    let context =
+        unwrap_safe!(cstring_to_rstring(c_context), return std::ptr::null_mut());
+
+    let context = unwrap_safe!(
+        serde_json::from_str::<Value>(context.as_str()),
+        return std::ptr::null_mut()
+    );
 
     let prefix_list = if filter_prefix.is_null() {
         None
     } else {
-        let prefix_list = match cstring_to_rstring(filter_prefix) {
-            Ok(filter_string) => filter_string.split(',').map(String::from).collect(),
-            Err(err) => {
-                update_last_error(err);
-                return std::ptr::null_mut();
-            }
-        };
+        let filter_string = unwrap_safe!(
+            cstring_to_rstring(filter_prefix),
+            return std::ptr::null_mut()
+        );
+        let prefix_list = filter_string.split(',').map(String::from).collect();
         Some(prefix_list)
     };
 
@@ -226,10 +215,10 @@ pub extern "C" fn expt_get_satisfied_experiments(
     let experiments = local.block_on(&Runtime::new().unwrap(), unsafe {
         (*client).get_satisfied_experiments(&context, prefix_list)
     });
-    let experiments = match serde_json::to_value(experiments) {
-        Ok(value) => value,
-        Err(err) => return error_block(err.to_string()),
-    };
+    let experiments = unwrap_safe!(
+        serde_json::to_value(experiments),
+        return std::ptr::null_mut()
+    );
     serde_json::to_string(&experiments)
         .map(|exp| rstring_to_cstring(exp).into_raw())
         .unwrap_or_else(|err| error_block(err.to_string()))
@@ -241,14 +230,13 @@ pub extern "C" fn expt_get_filtered_satisfied_experiments(
     c_context: *const c_char,
     filter_prefix: *const c_char,
 ) -> *mut c_char {
-    let context = match cstring_to_rstring(c_context) {
-        Ok(c) => match serde_json::from_str::<Value>(c.as_str()) {
-            Ok(con) => con,
-            Err(err) => return error_block(err.to_string()),
-        },
-        Err(err) => return error_block(err),
-    };
+    let context =
+        unwrap_safe!(cstring_to_rstring(c_context), return std::ptr::null_mut());
 
+    let context = unwrap_safe!(
+        serde_json::from_str::<Value>(context.as_str()),
+        return std::ptr::null_mut()
+    );
     let prefix_list = if filter_prefix.is_null() {
         None
     } else {
@@ -266,10 +254,10 @@ pub extern "C" fn expt_get_filtered_satisfied_experiments(
     let experiments = local.block_on(&Runtime::new().unwrap(), unsafe {
         (*client).get_filtered_satisfied_experiments(&context, prefix_list)
     });
-    let experiments = match serde_json::to_value(experiments) {
-        Ok(value) => value,
-        Err(err) => return error_block(err.to_string()),
-    };
+    let experiments = unwrap_safe!(
+        serde_json::to_value(experiments),
+        return std::ptr::null_mut()
+    );
     serde_json::to_string(&experiments)
         .map(|exp| rstring_to_cstring(exp).into_raw())
         .unwrap_or_else(|err| error_block(err.to_string()))
@@ -277,16 +265,15 @@ pub extern "C" fn expt_get_filtered_satisfied_experiments(
 
 #[no_mangle]
 pub extern "C" fn expt_get_running_experiments(client: *mut Arc<Client>) -> *mut c_char {
-    let local = task::LocalSet::new();
-    let experiments = local.block_on(&EXP_RUNTIME, unsafe {
-        (*client).get_running_experiments()
-    });
-    let experiments = match serde_json::to_value(experiments) {
-        Ok(value) => value,
-        Err(err) => return error_block(err.to_string()),
-    };
-    match serde_json::to_string(&experiments) {
-        Ok(result) => rstring_to_cstring(result).into_raw(),
-        Err(err) => error_block(err.to_string()),
-    }
+    let experiments =
+        EXP_RUNTIME.block_on(unsafe { (*client).get_running_experiments() });
+    let experiments = unwrap_safe!(
+        serde_json::to_value(experiments),
+        return std::ptr::null_mut()
+    );
+    let result = unwrap_safe!(
+        serde_json::to_string(&experiments),
+        return std::ptr::null_mut()
+    );
+    rstring_to_cstring(result).into_raw()
 }

--- a/examples/cac_client_integration_example/Cargo.toml
+++ b/examples/cac_client_integration_example/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "cac_client_integration_example"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+cac_client = { path = "../../crates/cac_client" }
+chrono = { workspace = true }
+
+# Https server framework
+actix = { workspace = true }
+actix-web = { workspace = true }
+serde_json = { workspace = true }
+
+
+[lints]
+workspace = true

--- a/examples/cac_client_integration_example/src/main.rs
+++ b/examples/cac_client_integration_example/src/main.rs
@@ -1,0 +1,107 @@
+use actix_web::{
+    get, rt,
+    web::{get, Query},
+    App, HttpRequest, HttpResponse, HttpServer,
+};
+
+use cac_client as cac;
+use serde_json::{Map, Value};
+use std::time::Duration;
+
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    rt::spawn(
+        cac::CLIENT_FACTORY
+            .create_client(
+                "dev".to_string(),
+                Duration::new(10, 0),
+                "http://localhost:8080".into(),
+            )
+            .await
+            .expect(format!("{}: Failed to acquire cac_client", "dev").as_str())
+            .clone()
+            .run_polling_updates(),
+    );
+    HttpServer::new(move || {
+        App::new()
+            .route(
+                "/health",
+                get().to(|| async { HttpResponse::Ok().body("Health is good :D") }),
+            )
+            .service(get_last_modified)
+            .service(get_full_config)
+            .service(get_resolved_config)
+            .service(get_default_config)
+    })
+    .bind(("127.0.0.1", 8084))?
+    .run()
+    .await
+}
+
+#[get("/last-modified")]
+async fn get_last_modified() -> HttpResponse {
+    let client = cac::CLIENT_FACTORY
+        .get_client("dev".into())
+        .await
+        .expect("No client found for dev tenant");
+    println!(
+        "Last modified time of configs: {:?}",
+        client.get_last_modified().await
+    );
+    HttpResponse::Ok().body("check your console")
+}
+
+#[get("/full-config")]
+async fn get_full_config(request: HttpRequest) -> HttpResponse {
+    let client = cac::CLIENT_FACTORY
+        .get_client("dev".into())
+        .await
+        .expect("No client found for dev tenant");
+    let query_params = Query::<Map<String, Value>>::from_query(request.query_string())
+        .map(Query::into_inner)
+        .unwrap_or(Map::new());
+    let prefix = query_params
+        .get("prefix")
+        .and_then(|item| item.as_str())
+        .and_then(|item| {
+            Some(item.split(',').map(str::to_string).collect::<Vec<String>>())
+        });
+    println!(
+        "full config with filters: {:?}",
+        client
+            .get_full_config_state_with_filter(Some(query_params), prefix)
+            .await
+    );
+    HttpResponse::Ok().body("check your console")
+}
+
+#[get("/resolved-config")]
+async fn get_resolved_config(request: HttpRequest) -> HttpResponse {
+    let client = cac::CLIENT_FACTORY
+        .get_client("dev".into())
+        .await
+        .expect("No client found for dev tenant");
+    let query_params = Query::<Map<String, Value>>::from_query(request.query_string())
+        .map(Query::into_inner)
+        .unwrap_or(Map::new());
+    println!(
+        "resolved config with filters: {:?}",
+        client
+            .get_resolved_config(query_params, None, cac_client::MergeStrategy::MERGE)
+            .await
+    );
+    HttpResponse::Ok().body("check your console")
+}
+
+#[get("/default-config")]
+async fn get_default_config() -> HttpResponse {
+    let client = cac::CLIENT_FACTORY
+        .get_client("dev".into())
+        .await
+        .expect("No client found for dev tenant");
+    println!(
+        "default config: {:?}",
+        client.get_default_config(None).await
+    );
+    HttpResponse::Ok().body("check your console")
+}

--- a/examples/experimentation_client_integration_example/Cargo.toml
+++ b/examples/experimentation_client_integration_example/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
-name = "example"
+name = "experimentation_example"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-experimentation_client = { path = "../experimentation_client" }
+experimentation_client = { path = "../../crates/experimentation_client" }
 chrono = { workspace = true }
 
 # Https server framework

--- a/examples/experimentation_client_integration_example/src/main.rs
+++ b/examples/experimentation_client_integration_example/src/main.rs
@@ -10,7 +10,7 @@ use serde_json::json;
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
     let client_configuration = exp::Config {
-        tenant: "tenant".to_string(),
+        tenant: "dev".to_string(),
         hostname: "http://localhost:8080".to_string(),
         poll_frequency: 10,
     };


### PR DESCRIPTION
## Problem
Clippy while analyzing CAC client shows a error for calling await on a MutexGuard. This happens when we use the standard library RwLock. 

## Solution
Use tokio RwLock that handles this and is better at concurrent and parallel processing. Also add an integration example for cac client that lets implementers test out features of the client

<img width="1200" alt="Screenshot 2024-06-06 at 12 23 39 PM" src="https://github.com/juspay/superposition/assets/15166178/6a6a5134-e2cd-451d-8eae-dd281e0e5e32">
