### PR TITLE
fix: add patch_file in diesel.toml

### DIFF
--- a/crates/context_aware_config/diesel.toml
+++ b/crates/context_aware_config/diesel.toml
@@ -1,5 +1,6 @@
 [print_schema]
 file = "src/db/schema.rs"
+patch_file = "src/db/schema.patch"
 
 [migrations_directory]
 dir = "migrations"

--- a/crates/experimentation_platform/src/schema.patch
+++ b/crates/experimentation_platform/src/schema.patch
@@ -22,4 +22,3 @@ index 692c718..46a426c 100644
      experiments,
 -);
 +);
-\ No newline at end of file


### PR DESCRIPTION
## Problem
while running make setup command, changes occurs in schema.rs file because schema.patch is not mentioned in diesel.toml

## Solution
Added schema.patch file path in diesel.toml

## Environment variable changes
NA

## Pre-deployment activity
NA

## Post-deployment activity
NA

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
NA