### PR TITLE
chore: rename upper case enum variants to use `PascalCase` names

### DIFF
--- a/crates/context_aware_config/src/api/context/handlers.rs
+++ b/crates/context_aware_config/src/api/context/handlers.rs
@@ -579,7 +579,7 @@ async fn bulk_operations(
     conn.transaction::<_, superposition::AppError, _>(|transaction_conn| {
         for action in reqs.into_inner().into_iter() {
             match action {
-                ContextAction::PUT(put_req) => {
+                ContextAction::Put(put_req) => {
                     let put_resp = put(Json(put_req), transaction_conn, true, &user)
                         .map_err(|err| {
                             log::error!(
@@ -588,9 +588,9 @@ async fn bulk_operations(
                             );
                             err
                         })?;
-                    response.push(ContextBulkResponse::PUT(put_resp));
+                    response.push(ContextBulkResponse::Put(put_resp));
                 }
-                ContextAction::DELETE(ctx_id) => {
+                ContextAction::Delete(ctx_id) => {
                     let deleted_row =
                         delete(contexts.filter(id.eq(&ctx_id))).execute(transaction_conn);
                     let email: String = user.get_email();
@@ -604,7 +604,7 @@ async fn bulk_operations(
                         }
                         Ok(_) => {
                             log::info!("{ctx_id} context deleted by {email}");
-                            response.push(ContextBulkResponse::DELETE(format!(
+                            response.push(ContextBulkResponse::Delete(format!(
                                 "{ctx_id} deleted succesfully"
                             )))
                         }
@@ -614,7 +614,7 @@ async fn bulk_operations(
                         }
                     };
                 }
-                ContextAction::MOVE((old_ctx_id, move_req)) => {
+                ContextAction::Move((old_ctx_id, move_req)) => {
                     let move_context_resp =
                         r#move(old_ctx_id, Json(move_req), transaction_conn, true, &user)
                             .map_err(|err| {
@@ -624,7 +624,7 @@ async fn bulk_operations(
                                 );
                                 err
                             })?;
-                    response.push(ContextBulkResponse::MOVE(move_context_resp));
+                    response.push(ContextBulkResponse::Move(move_context_resp));
                 }
             }
         }

--- a/crates/context_aware_config/src/api/context/types.rs
+++ b/crates/context_aware_config/src/api/context/types.rs
@@ -1,12 +1,14 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 
+#[cfg_attr(test, derive(Debug, PartialEq))] // Derive traits only when running tests
 #[derive(Deserialize, Clone)]
 pub struct PutReq {
     pub context: Map<String, Value>,
     pub r#override: Map<String, Value>,
 }
 
+#[cfg_attr(test, derive(Debug, PartialEq))] // Derive traits only when running tests
 #[derive(Deserialize, Clone)]
 pub struct MoveReq {
     pub context: Map<String, Value>,
@@ -30,6 +32,7 @@ pub struct PaginationParams {
     pub size: Option<u32>,
 }
 
+#[cfg_attr(test, derive(Debug, PartialEq))] // Derive traits only when running tests
 #[derive(serde::Deserialize, Clone)]
 pub enum ContextAction {
     PUT(PutReq),
@@ -56,4 +59,47 @@ pub struct PriorityRecomputeResponse {
     pub condition: Value,
     pub old_priority: i32,
     pub new_priority: i32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_deserialize_context_action() {
+        let put_request = json!({
+            "context": {
+                "foo": "bar",
+                "bar": {
+                    "baz": "baz"
+                }
+            },
+            "override": {
+                "foo": "baz"
+            }
+        });
+
+        let action_str = json!({
+            "PUT": put_request
+        })
+        .to_string();
+
+        let mut expected_context = Map::new();
+        expected_context.insert("foo".to_string(), json!("bar"));
+        expected_context.insert("bar".to_string(), json!({ "baz": "baz"}));
+
+        let mut expected_override = Map::new();
+        expected_override.insert("foo".to_string(), json!("baz"));
+
+        let expected_action = ContextAction::PUT(PutReq {
+            context: expected_context,
+            r#override: expected_override,
+        });
+
+        let action_deserialized =
+            serde_json::from_str::<ContextAction>(&action_str).unwrap();
+
+        assert_eq!(action_deserialized, expected_action);
+    }
 }

--- a/crates/context_aware_config/src/api/context/types.rs
+++ b/crates/context_aware_config/src/api/context/types.rs
@@ -34,17 +34,19 @@ pub struct PaginationParams {
 
 #[cfg_attr(test, derive(Debug, PartialEq))] // Derive traits only when running tests
 #[derive(serde::Deserialize, Clone)]
+#[serde(rename_all = "UPPERCASE")]
 pub enum ContextAction {
-    PUT(PutReq),
-    DELETE(String),
-    MOVE((String, MoveReq)),
+    Put(PutReq),
+    Delete(String),
+    Move((String, MoveReq)),
 }
 
 #[derive(serde::Serialize)]
+#[serde(rename_all = "UPPERCASE")]
 pub enum ContextBulkResponse {
-    PUT(PutResp),
-    DELETE(String),
-    MOVE(PutResp),
+    Put(PutResp),
+    Delete(String),
+    Move(PutResp),
 }
 
 #[derive(Deserialize, Clone)]
@@ -92,7 +94,7 @@ mod tests {
         let mut expected_override = Map::new();
         expected_override.insert("foo".to_string(), json!("baz"));
 
-        let expected_action = ContextAction::PUT(PutReq {
+        let expected_action = ContextAction::Put(PutReq {
             context: expected_context,
             r#override: expected_override,
         });

--- a/crates/context_aware_config/src/api/functions/handlers.rs
+++ b/crates/context_aware_config/src/api/functions/handlers.rs
@@ -227,8 +227,8 @@ async fn test(
 
     decode_function(&mut function)?;
     let result = match path_params.stage {
-        Stage::DRAFT => execute_fn(&function.draft_code, &req.key, req.value),
-        Stage::PUBLISHED => match function.published_code {
+        Stage::Draft => execute_fn(&function.draft_code, &req.key, req.value),
+        Stage::Published => match function.published_code {
             Some(code) => execute_fn(&code, &req.key, req.value),
             None => {
                 log::error!("Function test failed: function not published yet");

--- a/crates/context_aware_config/src/api/functions/types.rs
+++ b/crates/context_aware_config/src/api/functions/types.rs
@@ -28,10 +28,11 @@ pub struct FunctionResponse {
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, strum_macros::Display)]
+#[serde(rename_all = "UPPERCASE")]
 #[strum(serialize_all = "lowercase")]
 pub enum Stage {
-    DRAFT,
-    PUBLISHED,
+    Draft,
+    Published,
 }
 
 #[derive(Deserialize)]

--- a/crates/experimentation_client/src/lib.rs
+++ b/crates/experimentation_client/src/lib.rs
@@ -62,7 +62,7 @@ impl Client {
                 let mut exp_store = self.experiments.write().await;
                 for (exp_id, experiment) in experiments.into_iter() {
                     match experiment.status {
-                        types::ExperimentStatusType::CONCLUDED => {
+                        types::ExperimentStatusType::Concluded => {
                             exp_store.remove(&exp_id)
                         }
                         _ => exp_store.insert(exp_id, experiment),
@@ -175,7 +175,7 @@ impl Client {
     ) -> Result<Option<Variant>, String> {
         if toss < 0 {
             for variant in applicable_variants.iter() {
-                if variant.variant_type == VariantType::EXPERIMENTAL {
+                if variant.variant_type == VariantType::Experimental {
                     return Ok(Some(variant.clone()));
                 }
             }

--- a/crates/experimentation_client/src/types.rs
+++ b/crates/experimentation_client/src/types.rs
@@ -11,16 +11,18 @@ pub struct Config {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
 pub(crate) enum ExperimentStatusType {
-    CREATED,
-    INPROGRESS,
-    CONCLUDED,
+    Created,
+    InProgress,
+    Concluded,
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "UPPERCASE")]
 pub(crate) enum VariantType {
-    CONTROL,
-    EXPERIMENTAL,
+    Control,
+    Experimental,
 }
 
 #[repr(C)]


### PR DESCRIPTION
## Problem

This PR addresses the `clippy::upper_case_acronyms` lint, which is enabled by default.

## Solution

This PR updates the upper case enum variant names to use idiomatic `PascalCase` names, while ensuring that the API contract is unaffected. This is done by taking advantage of the [`#[serde(rename_all = "UPPERCASE")]`](https://serde.rs/container-attrs.html#rename_all) annotation.

I've added a unit test to verify that the contract was indeed unaffected, by running it before and after making the change. I can remove the unit test if the maintainers don't think it's required.

## Environment variable changes

What ENVs need to be added or changed: N/A

## Pre-deployment activity
Things needed to be done before deploying this change (if any): N/A

## Post-deployment activity
Things needed to be done after deploying this change (if any): N/A

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

There should be no expected API contract changes.

## Possible Issues in the future
Describe any possible issues that could occur because of this change: N/A