### PR TITLE
fix: parse type when submitting overrides, not on input

### DIFF
--- a/crates/frontend/src/components/override_form.rs
+++ b/crates/frontend/src/components/override_form.rs
@@ -106,8 +106,9 @@ where
                                             placeholder="Enter override here"
                                             name="override"
                                             class="input input-bordered w-full bg-white text-gray-700 shadow-md"
-                                            on:input=move |event| {
+                                            on:change=move |event| {
                                                 let input_value = event_target_value(&event);
+                                                logging::log!("Changed the override");
                                                 let default_config_val = get_config_value(
                                                         &config_key_value,
                                                         &input_value,
@@ -117,7 +118,7 @@ where
                                                             .map(ConfigType::DefaultConfig)
                                                             .collect::<Vec<_>>(),
                                                     )
-                                                    .expect("can't parse default config key");
+                                                    .unwrap_or(json!(input_value));
                                                 set_overrides
                                                     .update(|curr_overrides| {
                                                         let position = curr_overrides


### PR DESCRIPTION
## Problem
When you edit an override, the textarea sets the 'type' of values as String(value). On input in the field, the value is parsed to the correct type using the function `get_config_value`. Hence, if you are editing an input but leave the others as is, the submit request will fail because all types are sent as strings, even if they are not.

## Solution
Parse the type at the time of submitting the form, not on ever input