### PR TITLE
fix: align inputs in override form

### DIFF
--- a/crates/frontend/src/components/default_config_form.rs
+++ b/crates/frontend/src/components/default_config_form.rs
@@ -290,7 +290,7 @@ where
 
             </Suspense>
 
-            <div class="form-control grid w-full justify-end">
+            <div class="form-control grid w-full justify-start">
                 <Button
                     class="pl-[70px] pr-[70px]".to_string()
                     text="Submit".to_string()

--- a/crates/frontend/src/components/dimension_form.rs
+++ b/crates/frontend/src/components/dimension_form.rs
@@ -251,7 +251,7 @@ where
 
             </Suspense>
 
-            <div class="form-control grid w-full justify-end">
+            <div class="form-control grid w-full justify-start">
                 <Button
                     class="pl-[70px] pr-[70px]".to_string()
                     text="Submit".to_string()

--- a/crates/frontend/src/components/experiment_form.rs
+++ b/crates/frontend/src/components/experiment_form.rs
@@ -175,7 +175,7 @@ where
                 }
             }}
 
-            <div class="flex justify-end mt-8">
+            <div class="flex justify-start mt-8">
                 <Button text="Submit".to_string() on_click=on_submit/>
             </div>
         </div>

--- a/crates/frontend/src/components/override_form.rs
+++ b/crates/frontend/src/components/override_form.rs
@@ -95,12 +95,10 @@ where
                         view! {
                             <div>
                                 <div class="flex items-center gap-4">
-                                    <div class="form-control">
+                                    <div class="form-control w-3/5">
                                         <label class="label font-medium font-mono text-sm">
-                                            <span class="label-text">{config_key_label} ":"</span>
+                                            <span class="label-text">{config_key_label}</span>
                                         </label>
-                                    </div>
-                                    <div class="form-control w-2/5">
                                         <textarea
                                             type="text"
                                             placeholder="Enter override here"
@@ -129,12 +127,11 @@ where
                                                     });
                                             }
                                         >
-
                                             {config_value}
                                         </textarea>
 
                                     </div>
-                                    <div class="w-1/5">
+                                    <div class="mt-10 w-1/5 items-end">
 
                                         {if !disable_remove {
                                             view! {
@@ -176,7 +173,7 @@ where
 
             </div>
             <Show when=move || is_standalone>
-                <div class="flex justify-end">
+                <div class="flex justify-end mt-4">
                     <button class="btn" on:click:undelegated=on_submit>
                         Save
                     </button>

--- a/crates/frontend/src/components/type_template_form.rs
+++ b/crates/frontend/src/components/type_template_form.rs
@@ -109,7 +109,7 @@ where
 
             </div>
 
-            <div class="form-control grid w-full justify-end">
+            <div class="form-control grid w-full mt-5 justify-start">
                 <Button
                     class="pl-[70px] pr-[70px]".to_string()
                     text="Submit".to_string()

--- a/crates/frontend/src/pages/context_override.rs
+++ b/crates/frontend/src/pages/context_override.rs
@@ -109,7 +109,7 @@ fn form(
             }
         />
 
-        <div class="form-control grid w-full justify-end">
+        <div class="form-control grid w-full mt-10 justify-start">
             <Button
                 class="pl-[70px] pr-[70px]".to_string()
                 text="Submit".to_string()


### PR DESCRIPTION
## Problem
Inputs are not aligned in overrides form

## Solution
Make these inputs aligned
<img width="1840" alt="Screenshot 2024-06-19 at 1 35 03 PM" src="https://github.com/juspay/superposition/assets/15166178/b908aaab-d8e7-49cc-bf0d-dcc879ad3bbe">

