### PR TITLE
Use self-hosted runners for Nix CI

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,4 +1,4 @@
-name: "CI"
+name: "CI Nix"
 on:
   push:
     branches:

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -7,9 +7,11 @@ on:
 jobs:
   checks:
     runs-on: ${{ matrix.system }}
+    permissions:
+      contents: read
     strategy:
       matrix:
         system: [ x86_64-linux, aarch64-darwin ]
     steps:
       - uses: actions/checkout@v4
-      - run: nixci build --systems "github:nix-systems/${{ matrix.system }}"
+      - run: nixci --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} build --systems "github:nix-systems/${{ matrix.system }}"

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,24 +1,15 @@
-name: "CI Nix"
+name: "CI"
 on:
-    # Run only when pushing to main branch, and making PRs
-    push:
-        branches:
-            - main
-    pull_request:
+  push:
+    branches:
+      - main
+  pull_request:
 jobs:
-    build:
-        runs-on: ${{ matrix.os }}
-        strategy:
-            matrix:
-                os: [ubuntu-latest, macos-14]
-        steps:
-            - uses: actions/checkout@v4
-            - uses: DeterminateSystems/nix-installer-action@main
-              with:
-                  extra-conf: |
-                      trusted-public-keys = cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-                      substituters = https://cache.garnix.io?priority=41 https://cache.nixos.org/
-            - uses: yaxitech/nix-install-pkgs-action@v3
-              with:
-                  packages: "github:srid/nixci"
-            - run: nixci build
+  checks:
+    runs-on: ${{ matrix.system }}
+    strategy:
+      matrix:
+        system: [ x86_64-linux, aarch64-darwin ]
+    steps:
+      - uses: actions/checkout@v4
+      - run: nixci build --systems "github:nix-systems/${{ matrix.system }}"


### PR DESCRIPTION
We are standardizing on using in-office NixOS/mac machines for running CI for Github repos.

- [x] Proof of concept
- [x] Wait until scaling the runners on the machines

