### PR TITLE
Use jsonlogic's partial_apply for config and experiment filtering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,6 +975,7 @@ dependencies = [
  "futures",
  "futures-util",
  "itertools 0.10.5",
+ "jsonlogic",
  "jsonschema",
  "leptos 0.5.7",
  "leptos_actix",
@@ -2216,8 +2217,8 @@ dependencies = [
 
 [[package]]
 name = "jsonlogic"
-version = "0.5.2"
-source = "git+https://github.com/juspay/jsonlogic_rs.git#bbae9a833aed0f48c97bac1e2d88b353d330e66e"
+version = "0.5.3"
+source = "git+https://github.com/juspay/jsonlogic_rs.git#9e9daf93185996ce4285591cdb415dcdad71d282"
 dependencies = [
  "regex",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ members = [
     "crates/frontend",
     "crates/caclang",
     "crates/superposition",
-    "crates/superposition_types"
-    ]
+    "crates/superposition_types",
+]
 
 [[workspace.metadata.leptos]]
 name = "cac"
@@ -29,20 +29,27 @@ assets-dir = "crates/frontend/assets"
 dotenv = "0.15.0"
 actix = "0.13.0"
 actix-web = "4.5.0"
-diesel = { version = "2.1.0", features = ["postgres", "r2d2", "serde_json", "chrono", "uuid", "postgres_backend"] }
+diesel = { version = "2.1.0", features = [
+    "postgres",
+    "r2d2",
+    "serde_json",
+    "chrono",
+    "uuid",
+    "postgres_backend",
+] }
 env_logger = "0.8"
-log = { version="0.4.20", features = ["kv_unstable_serde"] }
-serde = {version = "^1", features = ["derive"]}
-serde_json = {version = "1.0"}
+log = { version = "0.4.20", features = ["kv_unstable_serde"] }
+serde = { version = "^1", features = ["derive"] }
+serde_json = { version = "1.0" }
 derive_more = "^0.99"
 base64 = "0.21.2"
 urlencoding = "~2.1.2"
 regex = "1.9.1"
 chrono = { version = "0.4.26", features = ["serde"] }
-uuid = {version = "1.3.4", features = ["v4", "serde"]}
-reqwest = { version = "0.11.18", features = ["json"]}
+uuid = { version = "1.3.4", features = ["v4", "serde"] }
+reqwest = { version = "0.11.18", features = ["json"] }
 jsonschema = "~0.17"
-jsonlogic = { git = "https://github.com/juspay/jsonlogic_rs.git", version = "0.5.2" }
+jsonlogic = { git = "https://github.com/juspay/jsonlogic_rs.git", version = "0.5.3" }
 rs-snowflake = "0.6.0"
 rusoto_kms = "0.48.0"
 rusoto_signature = "0.48.0"

--- a/clients/haskell/hs-cac-client/src/Main.hs
+++ b/clients/haskell/hs-cac-client/src/Main.hs
@@ -1,8 +1,11 @@
 {-# LANGUAGE LambdaCase #-}
 module Main (main) where
 
-import           Client             (getResolvedConfig, createCacClient, getCacClient,
-                                     getFullConfigStateWithFilter, getCacLastModified, cacStartPolling, getDefaultConfig)
+import           Client             (cacStartPolling, createCacClient,
+                                     getCacClient, getCacLastModified,
+                                     getDefaultConfig,
+                                     getFullConfigStateWithFilter,
+                                     getResolvedConfig)
 import           Control.Concurrent
 import           Prelude
 
@@ -16,11 +19,11 @@ main = do
     getCacClient "dev" >>= \case
         Left err     -> putStrLn err
         Right client -> do
-            config          <- getFullConfigStateWithFilter client Nothing
+            config          <- getFullConfigStateWithFilter client Nothing Nothing
             lastModified    <- getCacLastModified client
             overrides       <- getResolvedConfig client "{\"country\": \"India\"}" $ Just ["country_image_url", "hyperpay_version"]
             defaults        <- getDefaultConfig client $ Just ["country_image_url", "hyperpay_version"]
-            filteredConfig  <- getFullConfigStateWithFilter client $ Just "{\"prefix\": \"hyperpay\", \"os\": \"android\"}"
+            filteredConfig  <- getFullConfigStateWithFilter client (Just "{\"os\": \"android\"}") (Just "hyperpay")
             print config
             print lastModified
             print overrides

--- a/clients/haskell/hs-exp-client/src/Main.hs
+++ b/clients/haskell/hs-exp-client/src/Main.hs
@@ -3,6 +3,7 @@ module Main (main) where
 
 import           Client             (createExpClient, expStartPolling,
                                      getApplicableVariants, getExpClient,
+                                     getFilteredSatisfiedExperiments,
                                      getRunningExperiments,
                                      getSatisfiedExperiments)
 import           Control.Concurrent
@@ -22,12 +23,15 @@ main = do
     where
         loop client = do
             runningExperiments   <- getRunningExperiments client
-            satisfiedExperiments <- getSatisfiedExperiments client "{\"os\": \"android\", \"client\": \"1mg\"}"
+            satisfiedExperiments <- getSatisfiedExperiments client "{\"os\": \"android\", \"client\": \"1mg\"}" Nothing
+            filteredExperiments <- getFilteredSatisfiedExperiments client (Just "{\"os\": \"android\"}") (Just "hyperpay")
             variants             <- getApplicableVariants client "{\"os\": \"android\", \"client\": \"1mg\"}" 9
             print "Running experiments"
             print runningExperiments
             print "experiments that satisfy context"
             print satisfiedExperiments
+            print "experiments after filtering"
+            print filteredExperiments
             print "variant ID applied"
             print variants
             -- threadDelay 10000000

--- a/crates/context_aware_config/Cargo.toml
+++ b/crates/context_aware_config/Cargo.toml
@@ -62,6 +62,7 @@ anyhow = { workspace = true }
 superposition_types = { path = "../superposition_types" }
 regex = { workspace = true }
 mime = { workspace = true }
+jsonlogic = { workspace = true }
 
 [lints]
 workspace = true

--- a/headers/libcac_client.h
+++ b/headers/libcac_client.h
@@ -21,7 +21,9 @@ struct Arc_Client *cac_get_client(const char *tenant);
 
 const char *cac_get_last_modified(struct Arc_Client *client);
 
-const char *cac_get_config(struct Arc_Client *client, const char *query);
+const char *cac_get_config(struct Arc_Client *client,
+                           const char *filter_query,
+                           const char *filter_prefix);
 
 const char *cac_get_resolved_config(struct Arc_Client *client,
                                     const char *query,

--- a/headers/libexperimentation_client.h
+++ b/headers/libexperimentation_client.h
@@ -21,6 +21,12 @@ struct Arc_Client *expt_get_client(const char *tenant);
 
 char *expt_get_applicable_variant(struct Arc_Client *client, const char *c_context, short toss);
 
-char *expt_get_satisfied_experiments(struct Arc_Client *client, const char *c_context);
+char *expt_get_satisfied_experiments(struct Arc_Client *client,
+                                     const char *c_context,
+                                     const char *filter_prefix);
+
+char *expt_get_filtered_satisfied_experiments(struct Arc_Client *client,
+                                              const char *c_context,
+                                              const char *filter_prefix);
 
 char *expt_get_running_experiments(struct Arc_Client *client);


### PR DESCRIPTION
## Issue
#117 

## Problem
1. Filter currently works only for in operator with array and for all other types it checks direct equality
2. Experiment filtering was not doing actual filter, rather it was applying the entire context
3. Config prefix filtering was sent in context
4. Prefix filter param of expt filtering not exposed to hs-client

## Solution
1. Use jsonlogic's partial_apply for config and experiment filtering
2. Add separate function for Experiment filtering just like the filter function for config - also exposed to hs-client.
3. Introduce separate param for prefix in config filtering.
4. Exposed prefix filter param of expt filtering to hs-client.