### PR TITLE
fix: x-config-version in get config and experiments response

### DIFF
--- a/crates/experimentation_platform/src/api/experiments/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiments/handlers.rs
@@ -108,7 +108,7 @@ async fn process_cac_http_response(
         Ok(res) if res.status().is_success() => {
             let config_version = res
                 .headers()
-                .get("x-config-tags")
+                .get("x-config-version")
                 .and_then(|val| val.to_str().map_or(None, |v| Some(v.to_string())));
             let bulk_resp =
                 res.json::<Vec<ContextBulkResponse>>()


### PR DESCRIPTION
## Problem
1. x-config-version not being sent in get config or resolve config if the request does not include any config-version
2. experiments wrongly tagging `version` as `tags`

## Solution
fetch latest config version and return response from there if no config version is provided, if there are no snapshots, then fallback to default flow