### PR TITLE
fix: undo stringify of last_modified timestamp

### DIFF
--- a/crates/context_aware_config/src/api/config/handlers.rs
+++ b/crates/context_aware_config/src/api/config/handlers.rs
@@ -81,10 +81,13 @@ fn add_last_modified_to_header(
 ) {
     if let Some(ele) = max_created_at {
         let datetime_utc: DateTime<Utc> = TimeZone::from_utc_datetime(&Utc, &ele);
-        resp_builder.insert_header((
-            AppHeader::LastModified.to_string(),
-            datetime_utc.to_string(),
-        ));
+        let value = HeaderValue::from_str(&DateTime::to_rfc2822(&datetime_utc));
+        if let Ok(header_value) = value {
+            resp_builder
+                .insert_header((AppHeader::LastModified.to_string(), header_value));
+        } else {
+            log::error!("failed parsing datetime_utc {:?}", value);
+        }
     }
 }
 


### PR DESCRIPTION
## Problem
Stringified last_modified header 

## Solution
parse it as rfc2822

## Environment variable changes
NA

## Pre-deployment activity
NA

## Post-deployment activity
NA

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
NA