### PR TITLE
fix: remove process, filter env variables

### DIFF
--- a/crates/frontend/src/pages/function/function_create.rs
+++ b/crates/frontend/src/pages/function/function_create.rs
@@ -25,7 +25,7 @@ pub fn create_function_view() -> impl IntoView {
                     window.editor = monaco.editor.create(document.querySelector('.monaco'), {
 
                         value: [
-                            'async function validate(value, key) {',
+                            'async function validate(key, value) {',
                             '   return true;',
                             '}'
                         ].join('\n'),


### PR DESCRIPTION
## Problem
First process was allowed in js_function sandbox environment
we need to enable env variables that is required for js_functions only

## Solution
Remove process from vm , delete all env variable keys except keys mentioned under `FUNCTION_ENV_VARIABLES`

## Environment variable changes
NA

## Pre-deployment activity
Add FUNCTION_ENV_VARIABLES and mention all env that is required for js_function

## Post-deployment activity
NA

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
NA