### PR TITLE
fix(cac_client): Run `fixDarwinDylibNames` during `postInstall`

### DIFF
--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -20,12 +20,19 @@
             crane = {
               args = {
                 buildInputs = lib.optionals isDarwin
-                  (with apple_sdk.frameworks; [
-                    Security
+                  ([
+                    apple_sdk.frameworks.Security
+                    pkgs.fixDarwinDylibNames
                   ]) ++ [
                   pkgs.postgresql_12
                   pkgs.openssl
                 ];
+              };
+              extraBuildArgs = {
+                # https://discourse.nixos.org/t/how-to-use-install-name-tool-on-darwin/9931/2
+                postInstall = ''
+                  ${if isDarwin then "fixDarwinDylibNames" else ""}
+                '';
               };
             };
           };


### PR DESCRIPTION

## Problem

`.dylib` files contain information about their location. When the rust library is built using Nix, the build happens in a temporary build directory, which is removed after the build and once a corresponding `/nix/store/…` path is created. In the metadata of the `.dylib` files is the path to the temporary build directory, which needs to be patched.

## Solution

This PR ensures the `.dylib` files are always searched for in the respective `/nix/store/...` path, instead of the temporary build directory.