### PR TITLE
fix: Snapshot version parsing

### DIFF
--- a/crates/context_aware_config/src/api/config/handlers.rs
+++ b/crates/context_aware_config/src/api/config/handlers.rs
@@ -46,16 +46,13 @@ fn validate_version_in_params(
     query_params_map
         .remove("version")
         .map_or(Ok(None), |version| {
-            version
-                .as_str()
-                .and_then(|val| val.to_owned().parse::<i64>().ok())
-                .map_or_else(
-                    || {
-                        log::error!("failed to decode version as integer: {}", version);
-                        Err(bad_argument!("version is not of type integer"))
-                    },
-                    |v| Ok(Some(v)),
-                )
+            version.as_i64().map_or_else(
+                || {
+                    log::error!("failed to decode version as integer: {}", version);
+                    Err(bad_argument!("version is not of type integer"))
+                },
+                |v| Ok(Some(v)),
+            )
         })
 }
 


### PR DESCRIPTION
## Problem
when someone passes `?version=7224713864877502464` as the snapshot version the code currently fails to parse this is as a valid i64 version value and only accepts `?version="7224713864877502464"` as a correct input

## Solution
Replace as_str conversion of version with as_i64
