### PR TITLE
fix: out-of-sync TemplateType struct

### DIFF
--- a/crates/frontend/src/pages/custom_types.rs
+++ b/crates/frontend/src/pages/custom_types.rs
@@ -49,7 +49,7 @@ pub fn types_page() -> impl IntoView {
             Column::default("type_schema".to_string()),
             Column::default("created_by".to_string()),
             Column::default("created_at".to_string()),
-            Column::default("last_modified".to_string()),
+            Column::default("last_modified_at".to_string()),
             Column::new(
                 "actions".into(),
                 None,
@@ -158,8 +158,8 @@ pub fn types_page() -> impl IntoView {
                                     );
                                 ele_map
                                     .insert(
-                                        "last_modified".to_string(),
-                                        json!(ele.last_modified.format("%v").to_string()),
+                                        "last_modified_at".to_string(),
+                                        json!(ele.last_modified_at.format("%v").to_string()),
                                     );
                                 ele_map
                             })

--- a/crates/frontend/src/types.rs
+++ b/crates/frontend/src/types.rs
@@ -273,7 +273,8 @@ pub struct TypeTemplate {
     pub type_schema: Value,
     pub created_by: String,
     pub created_at: NaiveDateTime,
-    pub last_modified: NaiveDateTime,
+    pub last_modified_at: NaiveDateTime,
+    pub last_modified_by: String,
 }
 
 impl DropdownOption for TypeTemplate {


### PR DESCRIPTION
## Problem
Panic in backend due to running wasm32-targeted code in non-wasm32 target

**Cause**
Invoking set_timeout function while SSR the page

**Source**
alert_provider::enqueue function, which invokes set_timeout

NOTE : Issue of running wasm32 target function on non-wasm32 targets should be handled separately in another PR

**Why alert_provider::enqueue is triggered?**
Mismatch in TypeTemplates struct on frontend and backend leading to failure in parsing type templates data.

## Ideal Solution for out-of-sync types:
Move all the types to a single crate, and reuse them across the workspace

## Short-term solution:
Bring frontend type in-sync with the backend one.