### PR TITLE
chore(nix): Switch to omnix

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -14,4 +14,4 @@ jobs:
         system: [ x86_64-linux, aarch64-darwin ]
     steps:
       - uses: actions/checkout@v4
-      - run: om ci run --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} --systems "${{ matrix.system }}"
+      - run: om ci --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} run --systems "${{ matrix.system }}"

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -14,4 +14,4 @@ jobs:
         system: [ x86_64-linux, aarch64-darwin ]
     steps:
       - uses: actions/checkout@v4
-      - run: nixci --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} build --systems "github:nix-systems/${{ matrix.system }}"
+      - run: om ci run --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} --systems "${{ matrix.system }}"


### PR DESCRIPTION
Use https://omnix.page/om/ci.html to build Nix outputs.

`omnix` is now installed in self-hosted runners.
