### PR TITLE
fix: return default config object when created

### DIFF
--- a/crates/context_aware_config/src/api/default_config/handlers.rs
+++ b/crates/context_aware_config/src/api/default_config/handlers.rs
@@ -35,7 +35,7 @@ use diesel::{
 };
 use diesel::{Connection, SelectableHelper};
 use jsonschema::{Draft, JSONSchema, ValidationError};
-use serde_json::{from_value, json, Map, Value};
+use serde_json::{from_value, Map, Value};
 
 pub fn endpoints() -> Scope {
     Scope::new("").service(create).service(get).service(delete)
@@ -189,9 +189,7 @@ async fn create(
         AppHeader::XConfigVersion.to_string(),
         version_id.to_string(),
     ));
-    Ok(http_resp.json(json!({
-        "message": "DefaultConfig created/updated successfully."
-    })))
+    Ok(http_resp.json(default_config))
 }
 
 fn fetch_default_key(


### PR DESCRIPTION
## Problem
Most APIs return the entity object created, but this is not done for default config

## Solution
return the row that was created/updated in the database


Solves #189 