### PR TITLE
feat: Add get_applicable_variants as expt endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1928,6 +1928,7 @@ dependencies = [
  "diesel-derive-enum",
  "dotenv",
  "env_logger",
+ "jsonlogic",
  "log",
  "reqwest",
  "rs-snowflake",

--- a/crates/experimentation_platform/Cargo.toml
+++ b/crates/experimentation_platform/Cargo.toml
@@ -34,6 +34,7 @@ superposition_types = { path = "../superposition_types" }
 reqwest = { workspace = true }
 anyhow = { workspace = true }
 superposition_macros = { path = "../superposition_macros" }
+jsonlogic = { workspace = true }
 
 [features]
 disable_db_data_validation = ["superposition_types/disable_db_data_validation"]


### PR DESCRIPTION
## Problem
get_applicable_variants only exist as a functionality inside client

## Solution
Add get_applicable_variants as  an endpoint in experimentation


## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| /experiments/applicable_variants      | POST | {context: Value, toss: i8} | Vec<Variants> |

## Possible Issues in the future
Code duplication