### PR TITLE
feat: delete dimension api and ui

### DIFF
--- a/crates/context_aware_config/src/api/dimension/types.rs
+++ b/crates/context_aware_config/src/api/dimension/types.rs
@@ -90,3 +90,19 @@ impl DimensionWithMandatory {
         }
     }
 }
+
+#[derive(Debug, Deserialize, AsRef, Deref, DerefMut, Into)]
+#[serde(try_from = "String")]
+pub struct DeleteReq(String);
+
+impl TryFrom<String> for DeleteReq {
+    type Error = String;
+    fn try_from(name: String) -> Result<Self, Self::Error> {
+        let name = name.trim();
+        if name == "variantIds" {
+            Err("variantIds cannot be deleted".to_string())
+        } else {
+            Ok(Self(name.to_owned()))
+        }
+    }
+}

--- a/crates/context_aware_config/src/api/dimension/utils.rs
+++ b/crates/context_aware_config/src/api/dimension/utils.rs
@@ -1,13 +1,17 @@
-use std::collections::HashMap;
-
-use crate::db::{models::Dimension, schema::dimensions::dsl::*};
-use diesel::RunQueryDsl;
+use crate::db::{
+    models::{Context, Dimension},
+    schema::{contexts::dsl::contexts, dimensions::dsl::*},
+};
 use diesel::{
     r2d2::{ConnectionManager, PooledConnection},
-    PgConnection,
+    PgConnection, RunQueryDsl,
 };
 use jsonschema::{Draft, JSONSchema};
-use superposition_types::result as superposition;
+use serde_json::Map;
+use service_utils::helpers::extract_dimensions;
+use std::collections::HashMap;
+use superposition_macros::{db_error, unexpected_error};
+use superposition_types::{result as superposition, Cac, Condition};
 
 pub fn get_all_dimension_schema_map(
     conn: &mut PooledConnection<ConnectionManager<PgConnection>>,
@@ -27,4 +31,31 @@ pub fn get_all_dimension_schema_map(
         .collect();
 
     Ok(dimension_schema_map)
+}
+
+pub fn get_dimension_usage_context_ids(
+    key: &str,
+    conn: &mut PooledConnection<ConnectionManager<PgConnection>>,
+) -> superposition::Result<Vec<String>> {
+    let result: Vec<Context> = contexts.load(conn).map_err(|err| {
+        log::error!("failed to fetch contexts with error: {}", err);
+        db_error!(err)
+    })?;
+
+    let mut context_ids = vec![];
+    for context in result.iter() {
+        let condition = Cac::<Condition>::try_from_db(
+            context.value.as_object().unwrap_or(&Map::new()).clone(),
+        )
+        .map_err(|err| {
+            log::error!("generate_cac : failed to decode context from db {}", err);
+            unexpected_error!(err)
+        })?
+        .into_inner();
+
+        extract_dimensions(&condition)?
+            .get(key)
+            .map(|_| context_ids.push(context.id.to_owned()));
+    }
+    Ok(context_ids)
 }

--- a/crates/frontend/src/api.rs
+++ b/crates/frontend/src/api.rs
@@ -213,6 +213,21 @@ pub async fn delete_default_config(key: String, tenant: String) -> Result<(), St
     Ok(())
 }
 
+pub async fn delete_dimension(name: String, tenant: String) -> Result<(), String> {
+    let host = get_host();
+    let url = format!("{host}/dimension/{name}");
+
+    request(
+        url,
+        reqwest::Method::DELETE,
+        None::<serde_json::Value>,
+        construct_request_headers(&[("x-tenant", &tenant)])?,
+    )
+    .await?;
+
+    Ok(())
+}
+
 pub async fn fetch_types(
     tenant: String,
     page: i64,

--- a/crates/frontend/src/utils.rs
+++ b/crates/frontend/src/utils.rs
@@ -459,14 +459,29 @@ where
         .map_err(|err| err.to_string())?;
 
     let status = response.status();
-    if status.is_client_error() || status.is_server_error() {
+    if status.is_client_error() {
+        let resp_bytes = response
+            .bytes()
+            .await
+            .map_err(|_| String::from("Something went wrong"))?;
+        let error_msg = serde_json::from_slice::<ErrorResponse>(&resp_bytes).map_or(
+            String::from(
+                std::str::from_utf8(&resp_bytes.to_vec())
+                    .unwrap_or("Something went wrong"),
+            ),
+            |error| error.message,
+        );
+        logging::error!("{}", error_msg);
+        enqueue_alert(error_msg.clone(), AlertType::Error, 5000);
+        return Err(error_msg);
+    }
+    if status.is_server_error() {
         let error_msg = response
             .json::<ErrorResponse>()
             .await
             .map_or(String::from("Something went wrong"), |error| error.message);
         logging::error!("{}", error_msg);
         enqueue_alert(error_msg.clone(), AlertType::Error, 5000);
-
         return Err(error_msg);
     }
 

--- a/postman/cac.postman_collection.json
+++ b/postman/cac.postman_collection.json
@@ -456,6 +456,114 @@
             }
           },
           "response": []
+        },
+        {
+          "name": "Delete Dimension",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "const host = pm.variables.get(\"host\");",
+                  "",
+                  "function add_dimension() {",
+                  "    const options = {",
+                  "        'method': 'PUT',",
+                  "        'url': `${host}/dimension`,",
+                  "        'header': {",
+                  "            'x-tenant': 'test',",
+                  "            'Content-Type': 'application/json'",
+                  "        },",
+                  "        \"body\": {",
+                  "            \"mode\": \"raw\",",
+                  "            \"raw\": JSON.stringify({",
+                  "               \"dimension\": \"dim1\",",
+                  "                \"priority\": 4,",
+                  "                \"schema\": {",
+                  "                    \"type\": \"string\",",
+                  "                    \"pattern\": \".*\"",
+                  "                }",
+                  "            })",
+                  "        }",
+                  "    };",
+                  "    pm.sendRequest(options, function (error, response) {",
+                  "        if (error) {",
+                  "            console.log(`Error creating dimension: dim1`);",
+                  "            console.log(error);",
+                  "            return;",
+                  "        }",
+                  "        console.log(`created dimension: dim1`);",
+                  "    });",
+                  "    ",
+                  "}",
+                  "",
+                  "add_dimension();"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const host = pm.variables.get(\"host\");",
+                  "const token = pm.variables.get(\"token\");",
+                  "",
+                  "pm.test(\"204 check\", function () {",
+                  "    pm.response.to.have.status(204);",
+                  "})",
+                  "",
+                  "pm.test(\"404 check\", function () {",
+                  "  const deleteRequest = {",
+                  "      url: `${host}/dimension/dim1`,",
+                  "      method: 'DELETE',",
+                  "      header: {",
+                  "          'Content-Type': 'application/json',",
+                  "          'x-tenant': 'test',",
+                  "          'Authorization': `Bearer ${token}`",
+                  "      }",
+                  "  };",
+                  "",
+                  "  pm.sendRequest(deleteRequest, (error, response) => {",
+                  "      response.to.have.status(404);",
+                  "  });",
+                  "})"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{token}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              },
+              {
+                "key": "x-tenant",
+                "value": "test",
+                "type": "default"
+              }
+            ],
+            "url": {
+              "raw": "{{host}}/dimension/dim1",
+              "host": [
+                "{{host}}"
+              ],
+              "path": [
+                "dimension",
+                "dim1"
+              ]
+            }
+          },
+          "response": []
         }
       ]
     },

--- a/postman/cac/Dimension/.meta.json
+++ b/postman/cac/Dimension/.meta.json
@@ -1,5 +1,6 @@
 {
   "childrenOrder": [
-    "Create Dimension"
+    "Create Dimension",
+    "Delete Dimension"
   ]
 }

--- a/postman/cac/Dimension/Delete Dimension/.event.meta.json
+++ b/postman/cac/Dimension/Delete Dimension/.event.meta.json
@@ -1,0 +1,7 @@
+{
+  "eventOrder": [
+    "event.prerequest.js",
+    "event.test.js",
+    "event.post"
+  ]
+}

--- a/postman/cac/Dimension/Delete Dimension/event.prerequest.js
+++ b/postman/cac/Dimension/Delete Dimension/event.prerequest.js
@@ -1,0 +1,34 @@
+const host = pm.variables.get("host");
+
+function add_dimension() {
+    const options = {
+        'method': 'PUT',
+        'url': `${host}/dimension`,
+        'header': {
+            'x-tenant': 'test',
+            'Content-Type': 'application/json'
+        },
+        "body": {
+            "mode": "raw",
+            "raw": JSON.stringify({
+                "dimension": "dim1",
+                "priority": 4,
+                "schema": {
+                    "type": "string",
+                    "pattern": ".*"
+                }
+            })
+        }
+    };
+    pm.sendRequest(options, function (error, response) {
+        if (error) {
+            console.log(`Error creating dimension: dim1`);
+            console.log(error);
+            return;
+        }
+        console.log(`created dimension: dim1`);
+    });
+    
+}
+
+add_dimension();

--- a/postman/cac/Dimension/Delete Dimension/event.test.js
+++ b/postman/cac/Dimension/Delete Dimension/event.test.js
@@ -1,0 +1,22 @@
+const host = pm.variables.get("host");
+const token = pm.variables.get("token");
+
+pm.test("204 check", function () {
+    pm.response.to.have.status(204);
+})
+
+pm.test("404 check", function () {
+    const deleteRequest = {
+        url: `${host}/dimension/dim1`,
+        method: 'DELETE',
+        header: {
+            'Content-Type': 'application/json',
+            'x-tenant': 'test',
+            'Authorization': `Bearer ${token}`
+        }
+    };
+
+    pm.sendRequest(deleteRequest, (error, response) => {
+        response.to.have.status(404);
+    });
+})

--- a/postman/cac/Dimension/Delete Dimension/request.json
+++ b/postman/cac/Dimension/Delete Dimension/request.json
@@ -1,0 +1,30 @@
+{
+  "method": "DELETE",
+  "header": [
+    {
+      "key": "Authorization",
+      "value": "Bearer {{token}}",
+      "type": "text"
+    },
+    {
+      "key": "Content-Type",
+      "value": "application/json",
+      "type": "text"
+    },
+    {
+        "key": "x-tenant",
+        "value": "test",
+        "type": "default"
+    }
+  ],
+  "url": {
+    "raw": "{{host}}/dimension/dim1",
+    "host": [
+      "{{host}}"
+    ],
+    "path": [
+      "dimension",
+      "dim1"
+    ]
+  }
+}


### PR DESCRIPTION
## Problem
Implement delete dimension api

## Solution
Implemented delete dimension api and ui , restricted to delete variantIds and also dimensions which are used in any contexts

## Environment variable changes

NA

## Pre-deployment activity
NA

## Post-deployment activity
Things needed to be done after deploying this change (if any)

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
Describe any possible issues that could occur because of this change