### PR TITLE
fix: empty-override-prompt-text

### DIFF
--- a/crates/frontend/src/pages/context_override.rs
+++ b/crates/frontend/src/pages/context_override.rs
@@ -335,20 +335,35 @@ pub fn context_override() -> impl IntoView {
                                 (context.clone(), overrides)
                             })
                             .collect::<Vec<(Context, Map<String, Value>)>>();
-                        ctx_n_overrides
-                            .into_iter()
-                            .map(|(context, overrides)| {
-                                view! {
-                                    <ContextCard
-                                        context=context
-                                        overrides=overrides
-                                        handle_edit=handle_context_edit
-                                        handle_clone=handle_context_clone
-                                        handle_delete=handle_context_delete
-                                    />
-                                }
-                            })
-                            .collect_view()
+                        if ctx_n_overrides.is_empty() {
+                            view! {
+                                <div class="flex-row" style="margin-top:20rem;">
+                                    <div class="flex justify-center text-gray-400">
+                                    <i class="ri-file-add-line ri-xl"></i>
+                                    </div>
+                                    <div class="flex mt-4 font-semibold items-center text-gray-400 text-xl justify-center">
+                                    "Start with creating an override"
+                                    </div>
+                                </div>
+
+                            }.into_view()
+                        } else {
+                            ctx_n_overrides
+                                .into_iter()
+                                .map(|(context, overrides)| {
+                                    view! {
+                                        <ContextCard
+                                            context=context
+                                            overrides=overrides
+                                            handle_edit=handle_context_edit
+                                            handle_clone=handle_context_clone
+                                            handle_delete=handle_context_delete
+                                        />
+                                    }
+                                })
+                                .collect_view()
+                        }
+
                     }}
 
                 </div>


### PR DESCRIPTION
## Problem
In case of empty overrides list , page does not have any prompt text to hint user
 
## Solution
Added prompt text in case of empty page



## Environment variable changes

What ENVs need to be added or changed

## Pre-deployment activity
Things needed to be done before deploying this change (if any)

## Post-deployment activity
Things needed to be done after deploying this change (if any)

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
Describe any possible issues that could occur because of this change

<img width="1698" alt="Screenshot 2024-08-28 at 15 51 30" src="https://github.com/user-attachments/assets/0ccf5638-2188-4e8e-a6e9-219ce1b90f8b">