### PR TITLE
fix: optimised wasm file size

### DIFF
--- a/crates/superposition/src/main.rs
+++ b/crates/superposition/src/main.rs
@@ -1,4 +1,5 @@
 use actix_web::dev::Service;
+use actix_web::middleware::Compress;
 use actix_web::web::PathConfig;
 use actix_web::HttpMessage;
 use actix_web::{web, web::get, web::scope, web::Data, App, HttpResponse, HttpServer};
@@ -155,6 +156,7 @@ async fn main() -> Result<()> {
         let leptos_envs = ui_envs.clone();
         let cac_host = cac_host.to_owned() + base.as_str();
         App::new()
+            .wrap(Compress::default())
             .wrap_fn(|req, srv| {
                 let user = User::default();
                 req.extensions_mut().insert::<User>(user);

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     network_mode: bridge
 
   localstack:
-    build : ./docker-compose/localstack/
+    build: ./docker-compose/localstack/
     container_name: superposition_localstack
     ports:
       - "4510-4559:4510-4559"  # external service port range
@@ -24,3 +24,16 @@ services:
       LOCALSTACK_SERVICES: s3, sns, sqs, logs, cloudwatch, kms
       AWS_DEFAULT_REGION: ap-south-1
       EDGE_PORT: 4566
+
+  # app:
+  #   image: superposition_github:latest  
+  #   container_name: superposition_app
+  #   ports:
+  #     - "8080:8080" 
+  #   env_file:
+  #     - .env
+  #   depends_on:
+  #     - postgres
+  #     - localstack
+  #   network_mode: bridge
+  #   restart: on-failure

--- a/makefile
+++ b/makefile
@@ -106,7 +106,7 @@ superposition_dev:
 
 frontend:
 	cd crates/frontend && \
-		wasm-pack build --target=web --debug --no-default-features --features=hydrate
+		wasm-pack build --target web --dev --no-default-features --features hydrate
 	cd crates/frontend && \
 		npx tailwindcss -i ./styles/tailwind.css -o ./pkg/style.css
 	-rm -rf target/site


### PR DESCRIPTION
## Problem

The size of the WebAssembly (WASM) file used in the application was too large, leading to increased loading times and potentially higher bandwidth usage.

## Solution

To optimize the WASM file size, I used the Actix Web Compress middleware. This middleware automatically compresses the WASM file (and other static assets) using Brotli or Gzip compression, reducing the file size and improving loading times for users.

## Environment Variable Changes

You need to update one ENV variable to run the docker image locally : 

`DB_HOST = host.docker.internal:5432`

Otherwise , No new environment variables are required for this change.

## Post-deployment Activity

Monitor the application’s performance to ensure the compression is working as expected and that there are no issues with asset delivery.

## API Changes

No changes to the API endpoints.
