### PR TITLE
feat: add button loader when network requests are in progress

### DIFF
--- a/crates/frontend/src/components/button.rs
+++ b/crates/frontend/src/components/button.rs
@@ -7,18 +7,29 @@ pub fn button<F: Fn(MouseEvent) + 'static>(
     on_click: F,
     #[prop(default = String::new())] class: String,
     #[prop(default = String::new())] id: String,
+    #[prop(default = false)] loading: bool,
 ) -> impl IntoView {
+    let mut button_class = format!("btn-purple font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 {class}");
+    if loading {
+        button_class = button_class + "hover:cursor-not-allowed";
+    }
     view! {
         <button
-            class=format!(
-                "btn-purple font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 {class}",
-            )
-
+            class=button_class
             id=id
             on:click=on_click
+            disabled=loading
         >
-            {text}
-            <i class="ri-edit-2-line ml-2"></i>
+            {if loading {
+                view! { <><span class="loading loading-dots loading-sm"></span></> }
+            } else {
+                view! {
+                    <>
+                        {text}
+                        <i class="ri-edit-2-line ml-2"></i>
+                    </>
+                }
+            }}
         </button>
     }
 }

--- a/crates/frontend/src/components/default_config_form.rs
+++ b/crates/frontend/src/components/default_config_form.rs
@@ -40,7 +40,7 @@ where
     let (config_schema_rs, config_schema_ws) = create_signal(type_schema);
     let (config_value, set_config_value) = create_signal(config_value);
     let (function_name, set_function_name) = create_signal(function_name);
-
+    let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
     let string_to_value_closure = |val: String| {
         Value::from_str(&val).unwrap_or_else(|_| {
             // do this for Value::String, since for some reason from_str
@@ -87,6 +87,7 @@ where
     let (error_message, set_error_message) = create_signal("".to_string());
 
     let on_submit = move |ev: MouseEvent| {
+        req_inprogress_ws.set(true);
         ev.prevent_default();
         let f_name = prefix
             .clone()
@@ -124,6 +125,7 @@ where
                         // Consider logging or displaying the error
                     }
                 }
+                req_inprogress_ws.set(false);
             }
         });
     };
@@ -329,11 +331,17 @@ where
             </Suspense>
 
             <div class="form-control grid w-full justify-start">
-                <Button
-                    class="pl-[70px] pr-[70px]".to_string()
-                    text="Submit".to_string()
-                    on_click=on_submit
-                />
+            { move || {
+                let loading = req_inprogess_rs.get();
+                view! {
+                    <Button
+                        class="pl-[70px] pr-[70px] w-48 h-12".to_string()
+                        text="Submit".to_string()
+                        on_click=on_submit.clone()
+                        loading
+                    />
+                }
+            }}
             </div>
 
             {

--- a/crates/frontend/src/components/dimension_form.rs
+++ b/crates/frontend/src/components/dimension_form.rs
@@ -32,7 +32,7 @@ where
     let (dimension_type_rs, dimension_type_ws) = create_signal(dimension_type);
     let (dimension_schema_rs, dimension_schema_ws) = create_signal(dimension_schema);
     let (function_name, set_function_name) = create_signal(function_name);
-
+    let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
     let string_to_value_closure = |val: String| {
         Value::from_str(&val).unwrap_or_else(|_| {
             // do this for Value::String, since for some reason from_str
@@ -79,6 +79,7 @@ where
     let (error_message, set_error_message) = create_signal("".to_string());
 
     let on_submit = move |ev: MouseEvent| {
+        req_inprogress_ws.set(true);
         ev.prevent_default();
         let f_priority = priority.get();
         let f_name = dimension_name_rs.get();
@@ -109,6 +110,7 @@ where
                         // Consider logging or displaying the error
                     }
                 }
+                req_inprogress_ws.set(false);
             }
         });
     };
@@ -271,11 +273,17 @@ where
             </Suspense>
 
             <div class="form-control grid w-full justify-start">
-                <Button
-                    class="pl-[70px] pr-[70px]".to_string()
-                    text="Submit".to_string()
-                    on_click=on_submit
-                />
+            { move || {
+                let loading = req_inprogess_rs.get();
+                view! {
+                    <Button
+                        class="pl-[70px] pr-[70px] w-48 h-12".to_string()
+                        text="Submit".to_string()
+                        on_click=on_submit.clone()
+                        loading
+                    />
+                }
+            }}
             </div>
 
             {

--- a/crates/frontend/src/components/experiment_form.rs
+++ b/crates/frontend/src/components/experiment_form.rs
@@ -64,6 +64,7 @@ where
     let (experiment_name, set_experiment_name) = create_signal(name);
     let (f_context, set_context) = create_signal(context.clone());
     let (f_variants, set_variants) = create_signal(init_variants);
+    let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
 
     let handle_context_form_change = move |updated_ctx: Vec<(String, String, String)>| {
         set_context.set_untracked(updated_ctx);
@@ -76,6 +77,7 @@ where
 
     let dimensions = StoredValue::new(dimensions);
     let on_submit = move |event: MouseEvent| {
+        req_inprogress_ws.set(true);
         event.prevent_default();
         logging::log!("Submitting experiment form");
         logging::log!("{:?}", f_variants.get());
@@ -118,6 +120,7 @@ where
                         // We can consider logging or displaying the error
                     }
                 }
+                req_inprogress_ws.set(false);
             }
         });
     };
@@ -176,7 +179,17 @@ where
             }}
 
             <div class="flex justify-start mt-8">
-                <Button text="Submit".to_string() on_click=on_submit/>
+            { move || {
+                let loading = req_inprogess_rs.get();
+                view! {
+                    <Button
+                        class="pl-[70px] pr-[70px] w-48 h-12".to_string()
+                        text="Submit".to_string()
+                        on_click=on_submit.clone()
+                        loading
+                    />
+                }
+            }}
             </div>
         </div>
     }

--- a/crates/frontend/src/components/function_form.rs
+++ b/crates/frontend/src/components/function_form.rs
@@ -33,10 +33,12 @@ where
     let (runtime_version, set_runtime_version) = create_signal(runtime_version);
     let (error_message, set_error_message) = create_signal("".to_string());
     let (description, set_description) = create_signal(description);
+    let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
     if !edit {
         set_runtime_version.set("1.0.0".to_string())
     };
     let on_submit = move |event: MouseEvent| {
+        req_inprogress_ws.set(true);
         event.prevent_default();
         logging::log!("Submitting function form");
 
@@ -79,6 +81,7 @@ where
                         set_error_message.set(e);
                     }
                 }
+                req_inprogress_ws.set(false);
             }
         });
     };
@@ -158,7 +161,17 @@ where
                         </div>
 
                         <div class="flex justify-end mt-8">
-                            <Button text="Submit".to_string() on_click=on_submit/>
+                        { move || {
+                            let loading = req_inprogess_rs.get();
+                            view! {
+                                <Button
+                                    class="pl-[70px] pr-[70px] w-48 h-12".to_string()
+                                    text="Submit".to_string()
+                                    on_click=on_submit.clone()
+                                    loading
+                                />
+                            }
+                        }}
                         </div>
 
                         <div class="flex">
@@ -180,8 +193,9 @@ pub fn test_form(function_name: String, stage: String) -> impl IntoView {
         create_signal::<Option<FunctionTestResponse>>(None);
     let (val, set_val) = create_signal(json!({}));
     let (key, set_key) = create_signal(String::new());
-
+    let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
     let on_submit = move |event: MouseEvent| {
+        req_inprogress_ws.set(true);
         event.prevent_default();
         logging::log!("Submitting function form");
 
@@ -210,6 +224,7 @@ pub fn test_form(function_name: String, stage: String) -> impl IntoView {
                         set_error_message.set(e);
                     }
                 }
+                req_inprogress_ws.set(false);
             }
         });
     };
@@ -269,7 +284,17 @@ pub fn test_form(function_name: String, stage: String) -> impl IntoView {
                     </div>
 
                     <div class="flex justify-end mt-8">
-                        <Button text="Submit".to_string() on_click=on_submit/>
+                    { move || {
+                        let loading = req_inprogess_rs.get();
+                        view! {
+                            <Button
+                                class="pl-[70px] pr-[70px] w-48 h-12".to_string()
+                                text="Submit".to_string()
+                                on_click=on_submit.clone()
+                                loading
+                            />
+                        }
+                    }}
                     </div>
 
                     <div class="mt-7">

--- a/crates/frontend/src/components/type_template_form.rs
+++ b/crates/frontend/src/components/type_template_form.rs
@@ -21,8 +21,10 @@ where
     let (error_message, set_error_message) = create_signal("".to_string());
     let (type_name_rs, type_name_ws) = create_signal(type_name);
     let (type_schema_rs, type_schema_ws) = create_signal(type_schema);
+    let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
 
     let on_submit = move |ev: MouseEvent| {
+        req_inprogress_ws.set(true);
         ev.prevent_default();
         let type_name = type_name_rs.get();
         let type_schema = type_schema_rs.get();
@@ -48,6 +50,7 @@ where
                         set_error_message.set(e);
                     }
                 }
+                req_inprogress_ws.set(false);
             }
         });
     };
@@ -110,11 +113,17 @@ where
             </div>
 
             <div class="form-control grid w-full mt-5 justify-start">
-                <Button
-                    class="pl-[70px] pr-[70px]".to_string()
-                    text="Submit".to_string()
-                    on_click=on_submit
-                />
+                { move || {
+                    let loading = req_inprogess_rs.get();
+                    view! {
+                        <Button
+                            class="pl-[70px] pr-[70px] w-48 h-12".to_string()
+                            text="Submit".to_string()
+                            on_click=on_submit.clone()
+                            loading
+                        />
+                    }
+                }}
             </div>
             <div>
                 <p class="text-red-500">{move || error_message.get()}</p>

--- a/crates/frontend/src/pages/context_override.rs
+++ b/crates/frontend/src/pages/context_override.rs
@@ -51,8 +51,10 @@ fn form(
     let (context, set_context) = create_signal(context);
     let (overrides, set_overrides) = create_signal(overrides);
     let dimensions = StoredValue::new(dimensions);
+    let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
 
     let on_submit = move |_| {
+        req_inprogress_ws.set(true);
         spawn_local(async move {
             let f_context = context.get();
             let f_overrides = overrides.get();
@@ -84,6 +86,7 @@ fn form(
                     logging::log!("Error submitting context and overrides: {:?}", e);
                 }
             }
+            req_inprogress_ws.set(false);
         });
     };
     view! {
@@ -113,11 +116,17 @@ fn form(
         />
 
         <div class="flex justify-start w-full mt-10">
-            <Button
-                class="pl-[70px] pr-[70px]".to_string()
-                text="Submit".to_string()
-                on_click=on_submit
-            />
+        { move || {
+            let loading = req_inprogess_rs.get();
+            view! {
+                <Button
+                    class="pl-[70px] pr-[70px] w-48 h-12".to_string()
+                    text="Submit".to_string()
+                    on_click=on_submit.clone()
+                    loading
+                />
+            }
+        }}
         </div>
     }
 }

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -182,6 +182,7 @@ pub fn home() -> impl IntoView {
 
     let (context_rs, context_ws) = create_signal::<Vec<(String, String, String)>>(vec![]);
     let (selected_tab_rs, selected_tab_ws) = create_signal(ResolveTab::AllConfig);
+    let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
 
     let unstrike = |search_field_prefix: &String, config: &Map<String, Value>| {
         for (dimension, value) in config.into_iter() {
@@ -251,6 +252,7 @@ pub fn home() -> impl IntoView {
 
     let resolve_click = move |ev: MouseEvent| {
         ev.prevent_default();
+        req_inprogress_ws.set(true);
         // strike out all config elements on the page
         let config_name_elements = document().get_elements_by_class_name("config-name");
         let config_value_elements = document().get_elements_by_class_name("config-value");
@@ -330,6 +332,7 @@ pub fn home() -> impl IntoView {
                 }
                 resolution_card.set_inner_html(&table_rows);
             }
+            req_inprogress_ws.set(false);
         });
     };
     view! {
@@ -363,11 +366,17 @@ pub fn home() -> impl IntoView {
                                                 />
 
                                                 <div class="card-actions mt-6 justify-end">
-                                                    <Button
-                                                        id="resolve_btn".to_string()
-                                                        text="Resolve".to_string()
-                                                        on_click=resolve_click
-                                                    />
+                                                    { move || {
+                                                        let loading = req_inprogess_rs.get();
+                                                        view! {
+                                                            <Button
+                                                            id="resolve_btn".to_string()
+                                                            text="Resolve".to_string()
+                                                            on_click=resolve_click.clone()
+                                                            loading=loading
+                                                            />
+                                                        }
+                                                    }}
                                                 </div>
                                             </div>
                                         </div>


### PR DESCRIPTION
## Problem
There is no indication of an event happening when forms are submitted

## Solution
Provide a loader and disable the button on click of the submit button

closes #14 



https://github.com/user-attachments/assets/f901ac52-416c-483e-8db1-faa110bb3779



