### PR TITLE
fix: using ExperimentResponse type for single experiment get response

### DIFF
--- a/crates/frontend/src/api.rs
+++ b/crates/frontend/src/api.rs
@@ -2,8 +2,8 @@ use leptos::ServerFnError;
 
 use crate::{
     types::{
-        Config, DefaultConfig, Dimension, Experiment, ExperimentsResponse,
-        FetchTypeTemplateResponse, FunctionResponse, ListFilters,
+        Config, DefaultConfig, Dimension, Experiment, ExperimentResponse,
+        ExperimentsResponse, FetchTypeTemplateResponse, FunctionResponse, ListFilters,
     },
     utils::{
         construct_request_headers, get_host, parse_json_response, request,
@@ -181,7 +181,7 @@ pub async fn fetch_config(tenant: String) -> Result<Config, ServerFnError> {
 pub async fn fetch_experiment(
     exp_id: String,
     tenant: String,
-) -> Result<Experiment, ServerFnError> {
+) -> Result<ExperimentResponse, ServerFnError> {
     let client = reqwest::Client::new();
     let host = use_host_server();
     let url = format!("{}/experiments/{}", host, exp_id);

--- a/crates/frontend/src/pages/experiment.rs
+++ b/crates/frontend/src/pages/experiment.rs
@@ -51,7 +51,7 @@ pub fn experiment_page() -> impl IntoView {
 
             // Construct the combined result, handling errors as needed
             CombinedResource {
-                experiment: experiments_result.ok(),
+                experiment: experiments_result.ok().map(|v| v.into()),
                 dimensions: dimensions_result
                     .unwrap_or(vec![])
                     .into_iter()

--- a/crates/frontend/src/types.rs
+++ b/crates/frontend/src/types.rs
@@ -4,10 +4,11 @@ use std::{str::FromStr, vec::Vec};
 
 use chrono::{DateTime, NaiveDateTime, Utc};
 use derive_more::{Deref, DerefMut};
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 
 use crate::components::{
-    condition_pills::types::Condition, dropdown::utils::DropdownOption,
+    condition_pills::{types::Condition, utils::extract_conditions},
+    dropdown::utils::DropdownOption,
 };
 
 #[derive(Clone, Debug)]
@@ -191,6 +192,24 @@ pub struct Experiment {
     pub(crate) created_at: DateTime<Utc>,
     pub(crate) last_modified: DateTime<Utc>,
     pub(crate) chosen_variant: Option<String>,
+}
+
+impl From<ExperimentResponse> for Experiment {
+    fn from(value: ExperimentResponse) -> Self {
+        Experiment {
+            name: value.name,
+            id: value.id,
+            traffic_percentage: value.traffic_percentage as u8,
+            status: value.status,
+            override_keys: json!(value.override_keys),
+            created_by: value.created_by,
+            created_at: value.created_at,
+            last_modified: value.last_modified,
+            chosen_variant: value.chosen_variant,
+            variants: serde_json::from_value(value.variants).unwrap_or_default(),
+            context: extract_conditions(&value.context),
+        }
+    }
 }
 
 /*************************** Context-Override types ********************************/


### PR DESCRIPTION
## Problem
Single Experiment page generation failed with error `Error fetching experiment`.
This happened because the API response was expected to be of  `Experiment` type which had `context` as `Vec<Conditions>` wasn't able to de-serialize correctly.

## Solution
The correct expected API response type should have been `ExperimentResponse`, which we overlooked.

## Changes made
- Change `fetch_experiment` return value to `ExperimentResponse`
- implemented `From<ExperimentResponse>` for `Experiment`
  