### PR TITLE
fix: temp fix for override clone operation

### DIFF
--- a/crates/frontend/src/components/condition_pills/types.rs
+++ b/crates/frontend/src/components/condition_pills/types.rs
@@ -92,7 +92,13 @@ impl TryFrom<&Map<String, Value>> for Condition {
             return Ok(Condition {
                 operator,
                 left_operand: dimension_name.to_owned(),
-                right_operand: operands.to_vec(),
+                right_operand: operands
+                    .to_vec()
+                    .into_iter()
+                    .filter(|operand| {
+                        !(operand.is_object() && operand.get("var").is_some())
+                    })
+                    .collect(),
             });
         }
 


### PR DESCRIPTION
## Problem
In case of the override clone event, the changes made to the context value doesn't reflect in `create` request payload.

## Cause
- With an existing context data, operands contains `{"var": <dimension_name>}` we are filtering out this entry from the operands while constructing the form.
- But on input, to update the value, the original context which contains `{"var": <dimension_name>}` is being used.
- There is difference in position where the value should be updated before and after the filtering out `var`.
- The on:input handler prevents this update when the entry at the given certain index is `var`.

Result => The new/updated value is disposed of.

## Solution

As a temporary solution we can remove the `var` from the list of operands at the initial state.