### PR TITLE
chore: Add tailwind extension settings to workspace settings for vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,15 @@
+{
+  "tailwindCSS.classAttributes": [
+    "class",
+    "className",
+    "ngClass",
+    "[\\S]*[cC]lass[\\S]*"
+  ],
+  "files.associations": {
+    "*.rs": "rust"
+  },
+  "tailwindCSS.includeLanguages": {
+    "rust": "html",
+    "*.rs": "html"
+  }
+}


### PR DESCRIPTION
## Problem
Tailwind extension fails to show the value of the tailwind classes on hover

## Solution
Add tailwind extension settings to workspace settings for vscode