### PR TITLE
fix: Frontend related issues and warnings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.78.0 as builder
+FROM rust:1.76.0 as builder
 
 WORKDIR /build
 

--- a/crates/frontend/src/api.rs
+++ b/crates/frontend/src/api.rs
@@ -2,8 +2,8 @@ use leptos::ServerFnError;
 
 use crate::{
     types::{
-        Config, DefaultConfig, Dimension, Experiment, ExperimentResponse,
-        ExperimentsResponse, FetchTypeTemplateResponse, FunctionResponse, ListFilters,
+        Config, DefaultConfig, Dimension, ExperimentResponse, ExperimentsResponse,
+        FetchTypeTemplateResponse, FunctionResponse, ListFilters,
     },
     utils::{
         construct_request_headers, get_host, parse_json_response, request,

--- a/crates/frontend/src/components/default_config_form.rs
+++ b/crates/frontend/src/components/default_config_form.rs
@@ -141,7 +141,7 @@ where
                     type="text"
                     placeholder="Key"
                     class="input input-bordered w-full max-w-md"
-                    value=config_key.get()
+                    value=config_key.get_untracked()
                     on:change=move |ev| {
                         let value = event_target_value(&ev);
                         set_config_key.set(value);

--- a/crates/frontend/src/components/experiment_ramp_form.rs
+++ b/crates/frontend/src/components/experiment_ramp_form.rs
@@ -19,6 +19,7 @@ where
     let (traffic, set_traffic) = create_signal(experiment.traffic_percentage);
     let tenant_rs = use_context::<ReadSignal<String>>().unwrap();
     let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
+    let range_max = 100 / experiment.variants.len();
     let experiment_rc = Rc::new(experiment);
     let handle_ramp_experiment = move |event: MouseEvent| {
         req_inprogress_ws.set(true);
@@ -41,7 +42,7 @@ where
             <input
                 type="range"
                 min="0"
-                max="100"
+                max={range_max.to_string()}
                 value=move || traffic.get()
                 class="range"
                 on:input=move |event| {

--- a/crates/frontend/src/components/side_nav.rs
+++ b/crates/frontend/src/components/side_nav.rs
@@ -65,7 +65,7 @@ pub fn side_nav(
     let tenant_rs = use_context::<ReadSignal<String>>().unwrap();
     let tenant_ws = use_context::<WriteSignal<String>>().unwrap();
     let (app_routes, set_app_routes) =
-        create_signal(create_routes(tenant_rs.get().as_str()));
+        create_signal(create_routes(tenant_rs.get_untracked().as_str()));
 
     let resolved_path = create_rw_signal(resolved_path);
     let original_path = create_rw_signal(original_path);

--- a/crates/frontend/src/hoc/layout.rs
+++ b/crates/frontend/src/hoc/layout.rs
@@ -8,14 +8,14 @@ use leptos_router::*;
 pub fn use_tenant() -> String {
     let params_map = use_params_map();
     let route_context = use_route();
-    logging::log!("use_route-params_map {:?}", params_map.get());
+    logging::log!("use_route-params_map {:?}", params_map.get_untracked());
     logging::log!(
         "use_route-original_path {:?}",
         route_context.original_path()
     );
     logging::log!("use_route-path {:?}", route_context.path());
 
-    match params_map.get().get("tenant") {
+    match params_map.get_untracked().get("tenant") {
         Some(tenant) => tenant.clone(),
         None => String::from("no-tenant"),
     }

--- a/crates/frontend/src/pages/context_override.rs
+++ b/crates/frontend/src/pages/context_override.rs
@@ -285,7 +285,7 @@ pub fn context_override() -> impl IntoView {
                             >
 
                                 <EditorProvider>
-                                    {match (form_mode.get(), data) {
+                                    {match (form_mode.get_untracked(), data) {
                                         (Some(FormMode::Edit), Some(data)) => {
                                             view! {
                                                 <Form

--- a/crates/frontend/src/pages/experiment.rs
+++ b/crates/frontend/src/pages/experiment.rs
@@ -74,7 +74,7 @@ pub fn experiment_page() -> impl IntoView {
     let handle_edit = move || show_modal("experiment_edit_form_modal");
 
     view! {
-        <Transition fallback=move || {
+        <Suspense fallback=move || {
             view! {
                 <div class="m-4">
                     <Skeleton variant=SkeletonVariant::DetailPage/>
@@ -150,6 +150,6 @@ pub fn experiment_page() -> impl IntoView {
                 }
             }}
 
-        </Transition>
+        </Suspense>
     }
 }

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -42,7 +42,7 @@ pub fn experiment_list() -> impl IntoView {
     });
 
     let (reset_exp_form, set_exp_form) = create_signal(0);
-    let table_columns = create_memo(move |_| experiment_table_columns());
+    let table_columns = store_value(experiment_table_columns());
 
     let combined_resource: Resource<(String, ListFilters), CombinedResource> =
         create_blocking_resource(
@@ -177,7 +177,7 @@ pub fn experiment_list() -> impl IntoView {
                                                     cell_class="min-w-48 font-mono".to_string()
                                                     rows=data
                                                     key_column="id".to_string()
-                                                    columns=table_columns.get()
+                                                    columns=table_columns.get_value()
                                                     pagination=pagination_props
                                                 />
                                             </ConditionCollapseProvider>

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -301,10 +301,13 @@ pub fn home() -> impl IntoView {
                 .class_list()
                 .add_2("text-gray-300", "line-through");
         }
+        let context_updated = context_rs.get();
         // resolve the context and get the config that would apply
         spawn_local(async move {
-            let context = gen_query_context(context_rs.get());
-            let mut config = match resolve_config(tenant_rs.get(), context).await.unwrap()
+            let context = gen_query_context(context_updated);
+            let mut config = match resolve_config(tenant_rs.get_untracked(), context)
+                .await
+                .unwrap()
             {
                 Value::Object(m) => m,
                 _ => Map::new(),

--- a/example.Dockerfile
+++ b/example.Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.78.0 as builder
+FROM rust:1.76.0 as builder
 
 WORKDIR /build
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.78.0"
+channel = "1.76.0"
 targets = ["wasm32-unknown-unknown"]
 components = ["rust-src", "rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
## Problem

1. `dlmalloc` failing in FE after upgrading to rust 1.78.0
2. unhandled warnings use of signals in non-reactive sections
3. content mismatch issue while using key grouping
4. range for ramp is allowed till 100

## Solution

1. Revert back to rust 1.76.0
2. convert `get` to `get_untracked` and other similar fixes (might not have solved all)
3. move the check of local storage value to a `create_effect` to avoid initial value mismatch between client and SSR
4. limit the max value of ramp based on the allowed max value
