### PR TITLE
Dependency pruning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,30 +3,6 @@
 version = 3
 
 [[package]]
-name = "actix"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f728064aca1c318585bf4bb04ffcfac9e75e508ab4e8b1bd9ba5dfe04e2cbed5"
-dependencies = [
- "actix-rt",
- "actix_derive",
- "bitflags 1.3.2",
- "bytes",
- "crossbeam-channel",
- "futures-core",
- "futures-sink",
- "futures-task",
- "futures-util",
- "log",
- "once_cell",
- "parking_lot",
- "pin-project-lite",
- "smallvec",
- "tokio",
- "tokio-util",
-]
-
-[[package]]
 name = "actix-codec"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,17 +225,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix_derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d44b8fee1ced9671ba043476deddef739dd0959bf77030b26b738cc591737a7"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,15 +250,6 @@ dependencies = [
  "once_cell",
  "serde",
  "version_check",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -935,16 +891,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bstr"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,10 +956,8 @@ dependencies = [
 name = "cac_client_integration_example"
 version = "0.1.0"
 dependencies = [
- "actix",
  "actix-web",
  "cac_client",
- "chrono",
  "serde_json",
 ]
 
@@ -1113,28 +1057,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-targets 0.52.0",
-]
-
-[[package]]
-name = "chrono-tz"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93698b29de5e97ad0ae26447b344c482a7284c737d9ddc5f9e52b74a336671bb"
-dependencies = [
- "chrono",
- "chrono-tz-build",
- "phf",
-]
-
-[[package]]
-name = "chrono-tz-build"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c088aee841df9c3041febbb73934cfc39708749bf96dc827e3359cd39ef11b1"
-dependencies = [
- "parse-zoneinfo",
- "phf",
- "phf_codegen",
 ]
 
 [[package]]
@@ -1390,25 +1312,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-channel"
-version = "0.5.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33c2bf77f2df06183c3aa30d1e96c0695a313d4f9c453cc3762a6db39f99200"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c063cd8cc95f5c377ed0d4b49a4b21f632396ff690e8470c29b3359b346984b"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1533,12 +1436,6 @@ dependencies = [
  "rustc_version",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "deunicode"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "339544cc9e2c4dc3fc7149fd630c5f22263a4fdf18a98afd0075784968b5cf00"
 
 [[package]]
 name = "diesel"
@@ -1696,9 +1593,7 @@ dependencies = [
 name = "experimentation_example"
 version = "0.1.0"
 dependencies = [
- "actix",
  "actix-web",
- "chrono",
  "experimentation_client",
  "serde_json",
 ]
@@ -1944,30 +1839,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
 
 [[package]]
-name = "globset"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
-dependencies = [
- "aho-corasick 0.7.20",
- "bstr",
- "fnv",
- "log",
- "regex",
-]
-
-[[package]]
-name = "globwalk"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf760ebf69878d9fd8f110c89703d90ce35095324d1f1edcb595c63945ee757"
-dependencies = [
- "bitflags 2.3.1",
- "ignore",
- "walkdir",
-]
-
-[[package]]
 name = "gloo-net"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2177,15 +2048,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
-name = "humansize"
-version = "2.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
-dependencies = [
- "libm",
-]
-
-[[package]]
 name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2282,23 +2144,6 @@ checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
-]
-
-[[package]]
-name = "ignore"
-version = "0.4.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbe7873dab538a9a44ad79ede1faf5f30d49f9a5c883ddbab48bce81b64b7492"
-dependencies = [
- "globset",
- "lazy_static",
- "log",
- "memchr",
- "regex",
- "same-file",
- "thread_local",
- "walkdir",
- "winapi-util",
 ]
 
 [[package]]
@@ -2716,12 +2561,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
-name = "libm"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
-
-[[package]]
 name = "linear-map"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3106,15 +2945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "parse-zoneinfo"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
-dependencies = [
- "regex",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3175,44 +3005,6 @@ dependencies = [
  "once_cell",
  "pest",
  "sha2",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
-dependencies = [
- "siphasher",
 ]
 
 [[package]]
@@ -3431,7 +3223,7 @@ version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12de2eff854e5fa4b1295edd650e227e9d8fb0c9e90b12e7f36d6a6811791a29"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick",
  "memchr",
  "regex-automata",
  "regex-syntax",
@@ -3443,7 +3235,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49530408a136e16e5b486e883fbb6ba058e8e4e8ae6621a77b048b314336e629"
 dependencies = [
- "aho-corasick 1.0.1",
+ "aho-corasick",
  "memchr",
  "regex-syntax",
 ]
@@ -3934,12 +3726,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
-
-[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3956,16 +3742,6 @@ checksum = "e1e08e261d0e8f5c43123b7adf3e4ca1690d655377ac93a03b2c9d3e98de1342"
 dependencies = [
  "serde",
  "version_check",
-]
-
-[[package]]
-name = "slug"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "882a80f72ee45de3cc9a5afeb2da0331d58df69e4e7d8eeb5d3c7784ae67e724"
-dependencies = [
- "deunicode",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -4065,7 +3841,6 @@ dependencies = [
  "awc",
  "serde",
  "serde_json",
- "tera",
 ]
 
 [[package]]
@@ -4076,7 +3851,6 @@ version = "0.1.0"
 name = "superposition_types"
 version = "0.3.2"
 dependencies = [
- "actix",
  "actix-web",
  "anyhow",
  "derive_more",
@@ -4206,28 +3980,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tera"
-version = "1.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d851b45e865f178319da0abdbfe6acbc4328759ff18dafc3a41c16b4cd2ee"
-dependencies = [
- "chrono",
- "chrono-tz",
- "globwalk",
- "humansize",
- "lazy_static",
- "percent-encoding",
- "pest",
- "pest_derive",
- "rand",
- "regex",
- "serde",
- "serde_json",
- "slug",
- "unic-segment",
-]
-
-[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4260,16 +4012,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
-dependencies = [
- "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -4499,56 +4241,6 @@ name = "ucd-trie"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
-
-[[package]]
-name = "unic-char-property"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8c57a407d9b6fa02b4795eb81c5b6652060a15a7903ea981f3d723e6c0be221"
-dependencies = [
- "unic-char-range",
-]
-
-[[package]]
-name = "unic-char-range"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0398022d5f700414f6b899e10b8348231abf9173fa93144cbc1a43b9793c1fbc"
-
-[[package]]
-name = "unic-common"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d7ff825a6a654ee85a63e80f92f054f904f21e7d12da4e22f9834a4aaa35bc"
-
-[[package]]
-name = "unic-segment"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ed5d26be57f84f176157270c112ef57b86debac9cd21daaabbe56db0f88f23"
-dependencies = [
- "unic-ucd-segment",
-]
-
-[[package]]
-name = "unic-ucd-segment"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2079c122a62205b421f499da10f3ee0f7697f012f55b675e002483c73ea34700"
-dependencies = [
- "unic-char-property",
- "unic-char-range",
- "unic-ucd-version",
-]
-
-[[package]]
-name = "unic-ucd-version"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96bd2f2237fe450fcd0a1d2f5f4e91711124f7857ba2e964247776ebeeb7b0c4"
-dependencies = [
- "unic-common",
-]
 
 [[package]]
 name = "unicase"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,21 +44,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "actix-cors"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b340e9cfa5b08690aae90fb61beb44e9b06f44fe3d0f93781aaa58cfba86245e"
-dependencies = [
- "actix-utils",
- "actix-web",
- "derive_more",
- "futures-util",
- "log",
- "once_cell",
- "smallvec",
-]
-
-[[package]]
 name = "actix-files"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,7 +215,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "cfg-if",
- "cookie 0.16.2",
+ "cookie",
  "derive_more",
  "encoding_rs",
  "futures-core",
@@ -441,55 +426,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "attribute-derive"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c94f43ede6f25dab1dea046bff84d85dea61bd49aba7a9011ad66c0d449077b"
-dependencies = [
- "attribute-derive-macro 0.8.1",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
 name = "attribute-derive"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b48808b337d6b74c15ff9becfc0e139fe2b4e2b224d670a0ecdb46b0b2d3d9b"
 dependencies = [
- "attribute-derive-macro 0.9.1",
+ "attribute-derive-macro",
  "derive-where",
- "manyhow 0.10.4",
+ "manyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "attribute-derive-macro"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b409e2b2d2dc206d2c0ad3575a93f001ae21a1593e2d0c69b69c308e63f3b422"
-dependencies = [
- "collection_literals",
- "interpolator",
- "manyhow 0.8.1",
- "proc-macro-utils",
- "proc-macro2",
- "quote",
- "quote-use 0.7.2",
  "syn 2.0.48",
 ]
 
@@ -501,11 +447,11 @@ checksum = "5b19cbd63850ecff821c413e12846a67ec9f4ce7309c70959b94ecf9b2575ee2"
 dependencies = [
  "collection_literals",
  "interpolator",
- "manyhow 0.10.4",
+ "manyhow",
  "proc-macro-utils",
  "proc-macro2",
  "quote",
- "quote-use 0.8.0",
+ "quote-use",
  "syn 2.0.48",
 ]
 
@@ -541,7 +487,7 @@ dependencies = [
  "base64 0.21.2",
  "bytes",
  "cfg-if",
- "cookie 0.16.2",
+ "cookie",
  "derive_more",
  "futures-core",
  "futures-util",
@@ -727,12 +673,12 @@ dependencies = [
  "bytes",
  "form_urlencoded",
  "hex",
- "hmac 0.12.1",
+ "hmac",
  "http 0.2.9",
  "http 1.1.0",
  "once_cell",
  "percent-encoding",
- "sha2 0.10.6",
+ "sha2",
  "time",
  "tracing",
 ]
@@ -897,12 +843,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
@@ -961,16 +901,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "digest 0.10.6",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
+ "digest",
 ]
 
 [[package]]
@@ -1061,7 +992,6 @@ name = "cac_client"
 version = "0.14.2"
 dependencies = [
  "actix-web",
- "anyhow",
  "cbindgen",
  "chrono",
  "derive_more",
@@ -1071,11 +1001,8 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "service_utils",
  "strum",
  "strum_macros",
- "superposition_macros",
- "superposition_types",
  "tokio",
 ]
 
@@ -1120,7 +1047,7 @@ version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c878c71c2821aa2058722038a59a67583a4240524687c6028571c9b395ded61f"
 dependencies = [
- "darling 0.14.4",
+ "darling",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1247,7 +1174,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_lex 0.2.4",
  "indexmap 1.9.3",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
  "textwrap",
 ]
@@ -1273,7 +1200,7 @@ dependencies = [
  "anstyle",
  "bitflags 1.3.2",
  "clap_lex 0.5.0",
- "strsim 0.10.0",
+ "strsim",
 ]
 
 [[package]]
@@ -1324,20 +1251,6 @@ name = "colorchoice"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "config"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d379af7f68bfc21714c6c7dea883544201741d2ce8274bb12fa54f89507f52a7"
-dependencies = [
- "async-trait",
- "lazy_static",
- "nom",
- "pathdiff",
- "serde",
- "toml 0.5.11",
-]
 
 [[package]]
 name = "config"
@@ -1393,51 +1306,27 @@ checksum = "13418e745008f7349ec7e449155f419a61b92b58a99cc3616942b926825ec76b"
 name = "context_aware_config"
 version = "0.38.0"
 dependencies = [
- "actix",
- "actix-cors",
- "actix-files",
  "actix-http",
  "actix-web",
  "anyhow",
  "base64 0.21.2",
  "blake3",
- "bytes",
  "cac_client",
  "chrono",
  "derive_more",
  "diesel",
- "diesel-derive-enum",
- "dotenv",
- "env_logger",
- "experimentation_platform",
- "frontend",
- "futures",
  "futures-util",
  "itertools 0.10.5",
  "jsonlogic",
  "jsonschema",
- "leptos 0.6.11",
- "leptos_actix 0.5.7",
- "leptos_meta 0.6.11",
- "leptos_router 0.6.11",
  "log",
- "mime",
- "rand",
- "regex",
- "reqwest",
- "rs-snowflake",
- "rusoto_core",
  "serde",
  "serde_json",
  "service_utils",
- "strum",
  "strum_macros",
  "superposition_macros",
  "superposition_types",
- "tracing-log",
- "urlencoding",
  "uuid",
- "valuable",
 ]
 
 [[package]]
@@ -1460,17 +1349,6 @@ name = "cookie"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
  "percent-encoding",
  "time",
@@ -1541,16 +1419,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array",
- "subtle",
-]
-
-[[package]]
 name = "cxx"
 version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1600,18 +1468,8 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core 0.14.4",
- "darling_macro 0.14.4",
-]
-
-[[package]]
-name = "darling"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
-dependencies = [
- "darling_core 0.20.10",
- "darling_macro 0.20.10",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1624,22 +1482,8 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.11.1",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -1648,20 +1492,9 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core 0.14.4",
+ "darling_core",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
-dependencies = [
- "darling_core 0.20.10",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -1675,18 +1508,6 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
-]
-
-[[package]]
-name = "default-struct-builder"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8fa90da96b8fd491f5754d1f7a731f73921e3b7aa0ce333c821a0e43666ac14"
-dependencies = [
- "darling 0.20.10",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
 ]
 
 [[package]]
@@ -1771,43 +1592,13 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "dirs-next"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
-dependencies = [
- "cfg-if",
- "dirs-sys-next",
-]
-
-[[package]]
-name = "dirs-sys-next"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
 ]
 
 [[package]]
@@ -1893,9 +1684,7 @@ dependencies = [
  "cbindgen",
  "chrono",
  "derive_more",
- "dotenv",
  "jsonlogic",
- "log",
  "once_cell",
  "reqwest",
  "serde",
@@ -1918,20 +1707,15 @@ dependencies = [
 name = "experimentation_platform"
 version = "0.18.1"
 dependencies = [
- "actix",
  "actix-http",
  "actix-web",
  "anyhow",
  "chrono",
- "derive_more",
  "diesel",
  "diesel-derive-enum",
- "dotenv",
- "env_logger",
  "jsonlogic",
  "log",
  "reqwest",
- "rs-snowflake",
  "serde",
  "serde_json",
  "service_utils",
@@ -2019,21 +1803,16 @@ dependencies = [
 name = "frontend"
 version = "0.15.1"
 dependencies = [
- "actix-files",
- "actix-web",
  "anyhow",
  "cfg-if",
  "chrono",
  "console_error_panic_hook",
  "derive_more",
- "dotenv",
  "futures",
  "js-sys",
- "leptos 0.6.11",
- "leptos-use",
- "leptos_actix 0.6.11",
- "leptos_meta 0.6.11",
- "leptos_router 0.6.11",
+ "leptos",
+ "leptos_meta",
+ "leptos_router",
  "monaco",
  "once_cell",
  "reqwest",
@@ -2190,26 +1969,6 @@ dependencies = [
 
 [[package]]
 name = "gloo-net"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9902a044653b26b99f7e3693a42f171312d9be8b26b5697bd1e43ad1f8a35e10"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-sink",
- "gloo-utils 0.1.7",
- "js-sys",
- "pin-project",
- "serde",
- "serde_json",
- "thiserror",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-net"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43aaa242d1239a8822c15c645f02166398da4f8b5c4bae795c1f5b44e9eee173"
@@ -2217,7 +1976,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-sink",
- "gloo-utils 0.2.0",
+ "gloo-utils",
  "http 0.2.9",
  "js-sys",
  "pin-project",
@@ -2226,31 +1985,6 @@ dependencies = [
  "thiserror",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "gloo-timers"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
-dependencies = [
- "futures-channel",
- "futures-core",
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "gloo-utils"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037fcb07216cb3a30f7292bd0176b050b7b9a052ba830ef7d5d65f6dc64ba58e"
-dependencies = [
- "js-sys",
- "serde",
- "serde_json",
- "wasm-bindgen",
  "web-sys",
 ]
 
@@ -2352,21 +2086,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.6",
+ "digest",
 ]
 
 [[package]]
@@ -2758,84 +2482,22 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "leptos"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "269ba4ba91ffa73d9559c975e0be17bd4eb34c6b6abd7fdd5704106132d89d2a"
-dependencies = [
- "cfg-if",
- "leptos_config 0.5.7",
- "leptos_dom 0.5.7",
- "leptos_macro 0.5.7",
- "leptos_reactive 0.5.7",
- "leptos_server 0.5.7",
- "server_fn 0.5.7",
- "tracing",
- "typed-builder",
- "typed-builder-macro",
- "web-sys",
-]
-
-[[package]]
-name = "leptos"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20f79fe71c41f5a0506c273f6698a1971bb994ef52a88aeaf4eccb159fcd1e11"
 dependencies = [
  "cfg-if",
- "leptos_config 0.6.11",
- "leptos_dom 0.6.11",
- "leptos_macro 0.6.11",
- "leptos_reactive 0.6.11",
- "leptos_server 0.6.11",
- "server_fn 0.6.11",
+ "leptos_config",
+ "leptos_dom",
+ "leptos_macro",
+ "leptos_reactive",
+ "leptos_server",
+ "server_fn",
  "tracing",
  "typed-builder",
  "typed-builder-macro",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "leptos-use"
-version = "0.10.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142106b99697d98577933e2ed97d1a6fece64a0c58c9314ae56bdf9ad0dcbb2c"
-dependencies = [
- "async-trait",
- "cfg-if",
- "cookie 0.18.1",
- "default-struct-builder",
- "futures-util",
- "gloo-timers",
- "gloo-utils 0.2.0",
- "js-sys",
- "lazy_static",
- "leptos 0.6.11",
- "paste",
- "thiserror",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "leptos_actix"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89db4657bdcd28193e9d8cd640ec5d76b55abdf4b16cd5066f1b03f8aea49758"
-dependencies = [
- "actix-http",
- "actix-web",
- "futures",
- "leptos 0.5.7",
- "leptos_integration_utils 0.5.7",
- "leptos_meta 0.5.7",
- "leptos_router 0.5.7",
- "parking_lot",
- "regex",
- "serde_json",
- "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -2847,30 +2509,17 @@ dependencies = [
  "actix-http",
  "actix-web",
  "futures",
- "leptos 0.6.11",
- "leptos_integration_utils 0.6.11",
- "leptos_macro 0.6.11",
- "leptos_meta 0.6.11",
- "leptos_router 0.6.11",
+ "leptos",
+ "leptos_integration_utils",
+ "leptos_macro",
+ "leptos_meta",
+ "leptos_router",
  "parking_lot",
  "regex",
  "serde_json",
- "server_fn 0.6.11",
+ "server_fn",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "leptos_config"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e72d8689d54737991831e9b279bb4fba36d27a93aa975c75cd4241d9a4a425ec"
-dependencies = [
- "config 0.13.3",
- "regex",
- "serde",
- "thiserror",
- "typed-builder",
 ]
 
 [[package]]
@@ -2879,41 +2528,11 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3caa62f62e8e575051305ed6ac5648dc695f202c7220a98aca21cf4e9a978cf"
 dependencies = [
- "config 0.14.0",
+ "config",
  "regex",
  "serde",
  "thiserror",
  "typed-builder",
-]
-
-[[package]]
-name = "leptos_dom"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad314950d41acb1bfdb8b5924811b2983484a8d6f69a20b834a173a682657ed4"
-dependencies = [
- "async-recursion",
- "cfg-if",
- "drain_filter_polyfill",
- "futures",
- "getrandom",
- "html-escape",
- "indexmap 2.0.2",
- "itertools 0.12.1",
- "js-sys",
- "leptos_reactive 0.5.7",
- "once_cell",
- "pad-adapter",
- "paste",
- "rustc-hash",
- "serde",
- "serde_json",
- "server_fn 0.5.7",
- "smallvec",
- "tracing",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -2931,37 +2550,19 @@ dependencies = [
  "indexmap 2.0.2",
  "itertools 0.12.1",
  "js-sys",
- "leptos_reactive 0.6.11",
+ "leptos_reactive",
  "once_cell",
  "pad-adapter",
  "paste",
  "rustc-hash",
  "serde",
  "serde_json",
- "server_fn 0.6.11",
+ "server_fn",
  "smallvec",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
-]
-
-[[package]]
-name = "leptos_hot_reload"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f62dcab17728877f2d2f16d2c8a6701c4c5fbdfb4964792924acb0b50529659"
-dependencies = [
- "anyhow",
- "camino",
- "indexmap 2.0.2",
- "parking_lot",
- "proc-macro2",
- "quote",
- "rstml",
- "serde",
- "syn 2.0.48",
- "walkdir",
 ]
 
 [[package]]
@@ -2984,53 +2585,16 @@ dependencies = [
 
 [[package]]
 name = "leptos_integration_utils"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fddda3a3b768dad90f80fb56ac6e250bc5c60755f8e3df225913aba4364ed7ee"
-dependencies = [
- "futures",
- "leptos 0.5.7",
- "leptos_config 0.5.7",
- "leptos_hot_reload 0.5.7",
- "leptos_meta 0.5.7",
- "tracing",
-]
-
-[[package]]
-name = "leptos_integration_utils"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1f504afe3e2ac30ca15ba9b74d27243e8919e93d1f78bad32e5e8ec23eaca4b"
 dependencies = [
  "futures",
- "leptos 0.6.11",
- "leptos_config 0.6.11",
- "leptos_hot_reload 0.6.11",
- "leptos_meta 0.6.11",
+ "leptos",
+ "leptos_config",
+ "leptos_hot_reload",
+ "leptos_meta",
  "tracing",
-]
-
-[[package]]
-name = "leptos_macro"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57955d66f624265222444a5c565fea38efa5b0152a1dfc7c060a78e5fb62a852"
-dependencies = [
- "attribute-derive 0.8.1",
- "cfg-if",
- "convert_case 0.6.0",
- "html-escape",
- "itertools 0.12.1",
- "leptos_hot_reload 0.5.7",
- "prettyplease",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "rstml",
- "server_fn_macro 0.5.7",
- "syn 2.0.48",
- "tracing",
- "uuid",
 ]
 
 [[package]]
@@ -3039,35 +2603,21 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31197c2c624c405bec5f1dc8dd5d903a6030d1f0b8e362a01a3a215fcbad5051"
 dependencies = [
- "attribute-derive 0.9.1",
+ "attribute-derive",
  "cfg-if",
  "convert_case 0.6.0",
  "html-escape",
  "itertools 0.12.1",
- "leptos_hot_reload 0.6.11",
+ "leptos_hot_reload",
  "prettyplease",
  "proc-macro-error",
  "proc-macro2",
  "quote",
  "rstml",
- "server_fn_macro 0.6.11",
+ "server_fn_macro",
  "syn 2.0.48",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "leptos_meta"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc25c0f7f14ed5daf42b8d0d273ed790b0449e8ba8cff1c2fa800dc90a75acb"
-dependencies = [
- "cfg-if",
- "indexmap 2.0.2",
- "leptos 0.5.7",
- "tracing",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -3078,34 +2628,10 @@ checksum = "a00900e82a4ca892828db93fce1d4c009480ff3959406e6965aa937c8bab7403"
 dependencies = [
  "cfg-if",
  "indexmap 2.0.2",
- "leptos 0.6.11",
+ "leptos",
  "tracing",
  "wasm-bindgen",
  "web-sys",
-]
-
-[[package]]
-name = "leptos_reactive"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4f54a525a0edfc8c2bf3ee92aae411800b8b10892c9cd819f8e8a6d4f0d62f3"
-dependencies = [
- "base64 0.21.2",
- "cfg-if",
- "futures",
- "indexmap 2.0.2",
- "paste",
- "pin-project",
- "rustc-hash",
- "self_cell",
- "serde",
- "serde-wasm-bindgen 0.5.0",
- "serde_json",
- "slotmap",
- "thiserror",
- "tokio",
- "tracing",
- "wasm-bindgen-futures",
 ]
 
 [[package]]
@@ -3124,43 +2650,12 @@ dependencies = [
  "rustc-hash",
  "self_cell",
  "serde",
- "serde-wasm-bindgen 0.6.5",
+ "serde-wasm-bindgen",
  "serde_json",
  "slotmap",
  "thiserror",
  "tokio",
  "tracing",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "leptos_router"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b31087173c60e25c329a1c6786756dd9ee97750b378622df4d780db160a09040"
-dependencies = [
- "cached",
- "cfg-if",
- "gloo-net 0.2.6",
- "itertools 0.12.1",
- "js-sys",
- "lazy_static",
- "leptos 0.5.7",
- "leptos_integration_utils 0.5.7",
- "leptos_meta 0.5.7",
- "linear-map",
- "lru",
- "once_cell",
- "percent-encoding",
- "regex",
- "serde",
- "serde_json",
- "serde_qs",
- "thiserror",
- "tracing",
- "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3174,13 +2669,13 @@ checksum = "d7fcc2a95a20c8f41adb39770e65c48ffe33cd9503b83669c54edd9b33ba8aa8"
 dependencies = [
  "cached",
  "cfg-if",
- "gloo-net 0.5.0",
+ "gloo-net",
  "itertools 0.12.1",
  "js-sys",
  "lazy_static",
- "leptos 0.6.11",
- "leptos_integration_utils 0.6.11",
- "leptos_meta 0.6.11",
+ "leptos",
+ "leptos_integration_utils",
+ "leptos_meta",
  "linear-map",
  "lru",
  "once_cell",
@@ -3200,32 +2695,16 @@ dependencies = [
 
 [[package]]
 name = "leptos_server"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fd1517c2024bc47d764e96053e55b927f8a2159e735a0cc47232542b493df9d"
-dependencies = [
- "inventory",
- "lazy_static",
- "leptos_macro 0.5.7",
- "leptos_reactive 0.5.7",
- "serde",
- "server_fn 0.5.7",
- "thiserror",
- "tracing",
-]
-
-[[package]]
-name = "leptos_server"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f197d9cbf7db3a09a5d6c561ad0547ad6bf4326bc6bc454171d5f6ee94f745a"
 dependencies = [
  "inventory",
  "lazy_static",
- "leptos_macro 0.6.11",
- "leptos_reactive 0.6.11",
+ "leptos_macro",
+ "leptos_reactive",
  "serde",
- "server_fn 0.6.11",
+ "server_fn",
  "thiserror",
  "tracing",
 ]
@@ -3316,37 +2795,14 @@ dependencies = [
 
 [[package]]
 name = "manyhow"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "516b76546495d933baa165075b95c0a15e8f7ef75e53f56b19b7144d80fd52bd"
-dependencies = [
- "manyhow-macros 0.8.1",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "manyhow"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91ea592d76c0b6471965708ccff7e6a5d277f676b90ab31f4d3f3fc77fade64"
 dependencies = [
- "manyhow-macros 0.10.4",
+ "manyhow-macros",
  "proc-macro2",
  "quote",
  "syn 2.0.48",
-]
-
-[[package]]
-name = "manyhow-macros"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba072c0eadade3160232e70893311f1f8903974488096e2eb8e48caba2f0cf1"
-dependencies = [
- "proc-macro-utils",
- "proc-macro2",
- "quote",
 ]
 
 [[package]]
@@ -3358,17 +2814,6 @@ dependencies = [
  "proc-macro-utils",
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "md-5"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5a279bb9607f9f53c22d496eade00d138d1bdcccd07d74650387cf94942a15"
-dependencies = [
- "block-buffer 0.9.0",
- "digest 0.9.0",
- "opaque-debug",
 ]
 
 [[package]]
@@ -3576,12 +3021,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
 name = "openssl"
 version = "0.10.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3735,7 +3174,7 @@ checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.6",
+ "sha2",
 ]
 
 [[package]]
@@ -3906,35 +3345,12 @@ dependencies = [
 
 [[package]]
 name = "quote-use"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7b5abe3fe82fdeeb93f44d66a7b444dedf2e4827defb0a8e69c437b2de2ef94"
-dependencies = [
- "quote",
- "quote-use-macros 0.7.2",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "quote-use"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b393938dcaab992375d7b3df7887fa98cc91c2f3590598251e7c609e2b788139"
 dependencies = [
  "quote",
- "quote-use-macros 0.8.0",
-]
-
-[[package]]
-name = "quote-use-macros"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ea44c7e20f16017a76a245bb42188517e13d16dcb1aa18044bc406cdc3f4af"
-dependencies = [
- "derive-where",
- "proc-macro2",
- "quote",
- "syn 2.0.48",
+ "quote-use-macros",
 ]
 
 [[package]]
@@ -4010,17 +3426,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_users"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
-dependencies = [
- "getrandom",
- "redox_syscall 0.2.16",
- "thiserror",
-]
-
-[[package]]
 name = "regex"
 version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4070,7 +3475,6 @@ dependencies = [
  "http 0.2.9",
  "http-body 0.4.5",
  "hyper",
- "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -4080,20 +3484,16 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls",
- "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
- "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
  "winreg",
 ]
 
@@ -4145,75 +3545,6 @@ dependencies = [
  "syn 2.0.48",
  "syn_derive",
  "thiserror",
-]
-
-[[package]]
-name = "rusoto_core"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1db30db44ea73551326269adcf7a2169428a054f14faf9e1768f2163494f2fa2"
-dependencies = [
- "async-trait",
- "base64 0.13.1",
- "bytes",
- "crc32fast",
- "futures",
- "http 0.2.9",
- "hyper",
- "hyper-tls",
- "lazy_static",
- "log",
- "rusoto_credential",
- "rusoto_signature",
- "rustc_version",
- "serde",
- "serde_json",
- "tokio",
- "xml-rs",
-]
-
-[[package]]
-name = "rusoto_credential"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee0a6c13db5aad6047b6a44ef023dbbc21a056b6dab5be3b79ce4283d5c02d05"
-dependencies = [
- "async-trait",
- "chrono",
- "dirs-next",
- "futures",
- "hyper",
- "serde",
- "serde_json",
- "shlex",
- "tokio",
- "zeroize",
-]
-
-[[package]]
-name = "rusoto_signature"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ae95491c8b4847931e291b151127eccd6ff8ca13f33603eb3d0035ecb05272"
-dependencies = [
- "base64 0.13.1",
- "bytes",
- "chrono",
- "digest 0.9.0",
- "futures",
- "hex",
- "hmac 0.11.0",
- "http 0.2.9",
- "hyper",
- "log",
- "md-5",
- "percent-encoding",
- "pin-project-lite",
- "rusoto_credential",
- "rustc_version",
- "serde",
- "sha2 0.9.9",
- "tokio",
 ]
 
 [[package]]
@@ -4410,17 +3741,6 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
-dependencies = [
- "js-sys",
- "serde",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "serde-wasm-bindgen"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8302e169f0eddcc139c70f139d19d6467353af16f9fce27e8c30158036a1e16b"
@@ -4504,31 +3824,6 @@ dependencies = [
 
 [[package]]
 name = "server_fn"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c265de965fe48e09ad8899d0ab1ffebdfa1a9914e4de5ff107b07bd94cf7541"
-dependencies = [
- "ciborium",
- "const_format",
- "gloo-net 0.2.6",
- "inventory",
- "js-sys",
- "lazy_static",
- "once_cell",
- "proc-macro2",
- "quote",
- "reqwest",
- "serde",
- "serde_json",
- "serde_qs",
- "server_fn_macro_default 0.5.7",
- "syn 2.0.48",
- "thiserror",
- "xxhash-rust",
-]
-
-[[package]]
-name = "server_fn"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "536a5b959673643ee01e59ae41bf01425482c8070dee95d7061ee2d45296b59c"
@@ -4539,7 +3834,7 @@ dependencies = [
  "const_format",
  "dashmap",
  "futures",
- "gloo-net 0.5.0",
+ "gloo-net",
  "http 1.1.0",
  "inventory",
  "js-sys",
@@ -4548,28 +3843,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_qs",
- "server_fn_macro_default 0.6.11",
+ "server_fn_macro_default",
  "thiserror",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "xxhash-rust",
-]
-
-[[package]]
-name = "server_fn_macro"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77000541a62ceeec01eef3ee0f86c155c33dac5fae750ad04a40852c6d5469a"
-dependencies = [
- "const_format",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.48",
  "xxhash-rust",
 ]
 
@@ -4589,21 +3869,11 @@ dependencies = [
 
 [[package]]
 name = "server_fn_macro_default"
-version = "0.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3353f22e2bcc451074d4feaa37317d9d17dff11d4311928384734ea17ab9ca"
-dependencies = [
- "server_fn_macro 0.5.7",
- "syn 2.0.48",
-]
-
-[[package]]
-name = "server_fn_macro_default"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4ad11700cbccdbd313703916eb8c97301ee423c4a06e5421b77956fdcb36a9f"
 dependencies = [
- "server_fn_macro 0.6.11",
+ "server_fn_macro",
  "syn 2.0.48",
 ]
 
@@ -4611,32 +3881,24 @@ dependencies = [
 name = "service_utils"
 version = "0.21.0"
 dependencies = [
- "actix",
  "actix-web",
  "anyhow",
  "aws-config",
  "aws-sdk-kms",
  "base64 0.21.2",
- "bytes",
  "derive_more",
  "diesel",
- "dotenv",
- "env_logger",
  "futures-util",
  "jsonschema",
  "log",
- "mime",
  "once_cell",
  "regex",
  "reqwest",
  "rs-snowflake",
- "rusoto_core",
  "serde",
  "serde_json",
- "strum",
  "strum_macros",
  "superposition_types",
- "thiserror",
  "urlencoding",
 ]
 
@@ -4648,20 +3910,7 @@ checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
@@ -4672,14 +3921,8 @@ checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.6",
+ "digest",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4770,12 +4013,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
-name = "strsim"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
-
-[[package]]
 name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4804,48 +4041,19 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 name = "superposition"
 version = "0.1.0"
 dependencies = [
- "actix",
- "actix-cors",
  "actix-files",
- "actix-http",
  "actix-web",
- "anyhow",
- "base64 0.21.2",
- "blake3",
- "bytes",
- "cac_client",
- "chrono",
  "context_aware_config",
- "derive_more",
- "diesel",
- "diesel-derive-enum",
  "dotenv",
  "env_logger",
  "experimentation_platform",
  "frontend",
- "futures",
- "futures-util",
- "itertools 0.10.5",
- "jsonschema",
- "leptos 0.6.11",
- "leptos_actix 0.6.11",
- "leptos_meta 0.6.11",
- "leptos_router 0.6.11",
- "log",
- "rand",
- "reqwest",
+ "leptos",
+ "leptos_actix",
  "rs-snowflake",
- "rusoto_core",
- "serde",
  "serde_json",
  "service_utils",
- "strum",
- "strum_macros",
  "superposition_types",
- "tracing-log",
- "urlencoding",
- "uuid",
- "valuable",
 ]
 
 [[package]]
@@ -4863,9 +4071,6 @@ dependencies = [
 [[package]]
 name = "superposition_macros"
 version = "0.1.0"
-dependencies = [
- "superposition_types",
-]
 
 [[package]]
 name = "superposition_types"
@@ -4881,8 +4086,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "strum",
- "strum_macros",
  "thiserror",
 ]
 
@@ -5257,18 +4460,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
 dependencies = [
  "once_cell",
- "valuable",
-]
-
-[[package]]
-name = "tracing-log"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
-dependencies = [
- "lazy_static",
- "log",
- "tracing-core",
 ]
 
 [[package]]
@@ -5459,26 +4650,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "valuable"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
-dependencies = [
- "valuable-derive",
-]
-
-[[package]]
-name = "valuable-derive"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d44690c645190cfce32f91a1582281654b2338c6073fa250b0949fd25c55b32"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "value-bag"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5646,12 +4817,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
 name = "winapi"
@@ -5924,12 +5089,6 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52839dc911083a8ef63efa4d039d1f58b5e409f923e44c80828f206f66e5541c"
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,10 +31,7 @@ assets-dir = "crates/frontend/assets"
 [workspace.dependencies]
 actix-web = "4.5.0"
 anyhow = "1.0.75"
-aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
-aws-sdk-kms = { version = "1.38.0" }
 base64 = "0.21.2"
-blake3 = "1.3.3"
 chrono = { version = "0.4.26", features = ["serde"] }
 derive_more = "^0.99"
 diesel = { version = "2.1.0", features = [
@@ -45,14 +42,9 @@ diesel = { version = "2.1.0", features = [
     "uuid",
     "postgres_backend",
 ] }
-dotenv = "0.15.0"
-env_logger = "0.8"
 jsonlogic = { git = "https://github.com/juspay/jsonlogic_rs.git", version = "0.5.3" }
 jsonschema = "~0.17"
 leptos = { version = "0.6.11" }
-leptos_actix = { version = "0.6.11" }
-leptos_meta = { version = "0.6.11" }
-leptos_router = { version = "0.6.11" }
 log = { version = "0.4.20", features = ["kv_unstable_serde"] }
 once_cell = { version = "1.18.0" }
 regex = "1.9.1"
@@ -62,9 +54,7 @@ serde = { version = "^1", features = ["derive"] }
 serde_json = { version = "1.0" }
 strum = "0.25"
 strum_macros = "0.25"
-thiserror = { version = "1.0.57" }
 toml = { version = "0.8.8", features = ["preserve_order"] }
-urlencoding = "~2.1.2"
 uuid = { version = "1.3.4", features = ["v4", "serde"] }
 
 [workspace.lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ members = [
     "examples/experimentation_client_integration_example",
     "examples/cac_client_integration_example",
     "examples/superposition-demo-app",
-    "crates/superposition_macros"
+    "crates/superposition_macros",
 ]
 
 [[workspace.metadata.leptos]]
@@ -29,9 +29,14 @@ style-file = "crates/frontend/styles/style.css"
 assets-dir = "crates/frontend/assets"
 
 [workspace.dependencies]
-dotenv = "0.15.0"
-actix = "0.13.0"
 actix-web = "4.5.0"
+anyhow = "1.0.75"
+aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
+aws-sdk-kms = { version = "1.38.0" }
+base64 = "0.21.2"
+blake3 = "1.3.3"
+chrono = { version = "0.4.26", features = ["serde"] }
+derive_more = "^0.99"
 diesel = { version = "2.1.0", features = [
     "postgres",
     "r2d2",
@@ -40,37 +45,27 @@ diesel = { version = "2.1.0", features = [
     "uuid",
     "postgres_backend",
 ] }
+dotenv = "0.15.0"
 env_logger = "0.8"
-log = { version = "0.4.20", features = ["kv_unstable_serde"] }
-serde = { version = "^1", features = ["derive"] }
-serde_json = { version = "1.0" }
-derive_more = "^0.99"
-base64 = "0.21.2"
-urlencoding = "~2.1.2"
-regex = "1.9.1"
-chrono = { version = "0.4.26", features = ["serde"] }
-uuid = { version = "1.3.4", features = ["v4", "serde"] }
-reqwest = { version = "0.11.18", features = ["json"] }
-jsonschema = "~0.17"
 jsonlogic = { git = "https://github.com/juspay/jsonlogic_rs.git", version = "0.5.3" }
-rs-snowflake = "0.6.0"
-bytes = "1.4.0"
-rusoto_core = "0.48.0"
-rand = "0.8.5"
-once_cell = { version = "1.18.0" }
-anyhow = "1.0.75"
-strum_macros = "0.25"
-strum = "0.25"
-blake3 = "1.3.3"
+jsonschema = "~0.17"
 leptos = { version = "0.6.11" }
+leptos_actix = { version = "0.6.11" }
 leptos_meta = { version = "0.6.11" }
 leptos_router = { version = "0.6.11" }
-leptos_actix = { version = "0.6.11" }
+log = { version = "0.4.20", features = ["kv_unstable_serde"] }
+once_cell = { version = "1.18.0" }
+regex = "1.9.1"
+reqwest = { version = "0.11.18", features = ["json"] }
+rs-snowflake = "0.6.0"
+serde = { version = "^1", features = ["derive"] }
+serde_json = { version = "1.0" }
+strum = "0.25"
+strum_macros = "0.25"
 thiserror = { version = "1.0.57" }
-leptos-use = "0.10.3"
-mime = "0.3.17"
-aws-sdk-kms = {version = "1.38.0"}
-aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
+toml = { version = "0.8.8", features = ["preserve_order"] }
+urlencoding = "~2.1.2"
+uuid = { version = "1.3.4", features = ["v4", "serde"] }
 
 [workspace.lints.clippy]
 mod_module_files = "warn"

--- a/crates/cac_client/Cargo.toml
+++ b/crates/cac_client/Cargo.toml
@@ -7,22 +7,19 @@ build = "build.rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-once_cell = { workspace = true }
-derive_more = { workspace = true }
 actix-web = { workspace = true }
 chrono = { workspace = true }
+derive_more = { workspace = true }
 jsonlogic = { workspace = true }
+log = { workspace = true }
+once_cell = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-log = { workspace = true }
-strum_macros = { workspace = true }
 strum = { workspace = true }
-tokio = {version = "1.29.1", features = ["full"]}
-service_utils = { path = "../service_utils" }
-superposition_types = {path = "../superposition_types" }
-anyhow = { workspace = true }
-superposition_macros = { path = "../superposition_macros" }
+strum_macros = { workspace = true }
+tokio = { version = "1.29.1", features = ["full"] }
+
 [lib]
 name = "cac_client"
 crate-type = ["cdylib", "lib"]

--- a/crates/cac_toml/src/bin.rs
+++ b/crates/cac_toml/src/bin.rs
@@ -1,7 +1,8 @@
-use cac_toml::ContextAwareConfig;
-use clap::{Arg, Command};
 use std::collections::HashMap;
 use std::process;
+
+use cac_toml::ContextAwareConfig;
+use clap::{Arg, Command};
 use toml::Value;
 
 fn main() {

--- a/crates/cac_toml/src/lib.rs
+++ b/crates/cac_toml/src/lib.rs
@@ -1,12 +1,13 @@
-use pest::iterators::Pair;
-use pest::Parser;
-use pest_derive::Parser;
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap};
 use std::fmt;
 use std::fs;
 use std::path::Path;
 use std::string::String;
+
+use pest::iterators::Pair;
+use pest::Parser;
+use pest_derive::Parser;
 use toml::Value;
 
 // the grammar for context expressions written using PEST

--- a/crates/context_aware_config/Cargo.toml
+++ b/crates/context_aware_config/Cargo.toml
@@ -7,61 +7,27 @@ edition = "2021"
 
 
 [dependencies]
-cac_client = { path = "../cac_client" }
-frontend = { path = "../frontend" }
-
-# env
-dotenv = { workspace = true }
-# Https server framework
-actix = { workspace = true }
+actix-http = "3.3.1"
 actix-web = { workspace = true }
-# To help generate snowflake ids
-rs-snowflake = { workspace = true }
-# To help with generating uuids
-uuid = { workspace = true }
-# To serialize and deserialize objects from json
+anyhow = { workspace = true }
+base64 = { workspace = true }
+blake3 = { workspace = true }
+cac_client = { path = "../cac_client" }
+chrono = { workspace = true }
+derive_more = { workspace = true }
+diesel = { workspace = true }
+futures-util = "0.3.28"
+itertools = "0.10.5"
+jsonlogic = { workspace = true }
+jsonschema = { workspace = true }
+log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-# For logging and debugging
-env_logger = { workspace = true }
-log = { workspace = true }
-# to work with enums
-strum_macros = { workspace = true }
-strum = { workspace = true }
-derive_more = { workspace = true }
-# date and time
-chrono = { workspace = true }
-# ORM
-diesel = { workspace = true }
-blake3 = { workspace = true }
-bytes = { workspace = true }
-rusoto_core = { workspace = true }
-base64 = { workspace = true }
-diesel-derive-enum = { version = "2.0.1", features = ["postgres"] }
-urlencoding = { workspace = true }
-jsonschema = { workspace = true }
-reqwest = { workspace = true, features = ["rustls-tls"] }
-rand = { workspace = true }
 service_utils = { path = "../service_utils" }
-experimentation_platform = { path = "../experimentation_platform" }
-tracing-log = "0.1.3"
-valuable = { version = "0.1.0", features = ["std", "alloc", "derive"] }
-itertools = "0.10.5"
-futures = "0.3.28"
-actix-http = "3.3.1"
-futures-util = "0.3.28"
-actix-cors = "0.6.4"
-leptos_actix = { version = "0.5.2" }
-leptos = { workspace = true }
-leptos_meta = { workspace = true }
-leptos_router = { workspace = true }
-actix-files = { version = "0.6" }
-anyhow = { workspace = true }
-regex = { workspace = true }
-mime = { workspace = true }
-jsonlogic = { workspace = true }
-superposition_types = { path = "../superposition_types" }
+strum_macros = { workspace = true }
 superposition_macros = { path = "../superposition_macros" }
+superposition_types = { path = "../superposition_types", features = ["result"] }
+uuid = { workspace = true }
 
 
 [features]

--- a/crates/context_aware_config/Cargo.toml
+++ b/crates/context_aware_config/Cargo.toml
@@ -11,7 +11,7 @@ actix-http = "3.3.1"
 actix-web = { workspace = true }
 anyhow = { workspace = true }
 base64 = { workspace = true }
-blake3 = { workspace = true }
+blake3 = "1.3.3"
 cac_client = { path = "../cac_client" }
 chrono = { workspace = true }
 derive_more = { workspace = true }

--- a/crates/context_aware_config/src/lib.rs
+++ b/crates/context_aware_config/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unused_crate_dependencies)]
 pub mod api;
 pub mod db;
 pub mod helpers;

--- a/crates/experimentation_client/Cargo.toml
+++ b/crates/experimentation_client/Cargo.toml
@@ -4,16 +4,14 @@ version = "0.8.1"
 edition = "2021"
 
 [dependencies]
-once_cell = { workspace = true }
 chrono = { workspace = true }
+derive_more = { workspace = true }
 jsonlogic = { workspace = true }
-reqwest = { workspace = true , features = ["json"]}
+once_cell = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-tokio = {version = "1.29.1", features = ["full"]}
-dotenv = { workspace = true }
-derive_more = { workspace = true }
-log = { workspace = true }
+tokio = { version = "1.29.1", features = ["full"] }
 
 [lib]
 name = "experimentation_client"

--- a/crates/experimentation_client/Cargo.toml
+++ b/crates/experimentation_client/Cargo.toml
@@ -8,7 +8,7 @@ chrono = { workspace = true }
 derive_more = { workspace = true }
 jsonlogic = { workspace = true }
 once_cell = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { version = "1.29.1", features = ["full"] }

--- a/crates/experimentation_client/src/lib.rs
+++ b/crates/experimentation_client/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unused_crate_dependencies)]
 mod interface;
 mod types;
 mod utils;

--- a/crates/experimentation_platform/Cargo.toml
+++ b/crates/experimentation_platform/Cargo.toml
@@ -6,35 +6,21 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# env
-dotenv = { workspace = true }
-# Https server framework
-actix = { workspace = true }
 actix-web = { workspace = true }
 actix-http = "3.3.1"
-# To help generate snowflake ids
-rs-snowflake = { workspace = true }
-# To help with generating uuids
-uuid = { workspace = true }
-# To serialize and deserialize objects from json
-serde = { workspace = true }
-serde_json = { workspace = true }
-# For logging and debugging
-env_logger = { workspace = true }
-log = { workspace = true }
-# to work with enums
-derive_more = { workspace = true }
-# date and time
+anyhow = { workspace = true }
 chrono = { workspace = true }
-# ORM
 diesel = { workspace = true }
 diesel-derive-enum = { version = "2.0.1", features = ["postgres"] }
-service_utils = { path = "../service_utils" }
-superposition_types = { path = "../superposition_types" }
-reqwest = { workspace = true }
-anyhow = { workspace = true }
-superposition_macros = { path = "../superposition_macros" }
+log = { workspace = true }
 jsonlogic = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+service_utils = { path = "../service_utils" }
+superposition_macros = { path = "../superposition_macros" }
+superposition_types = { path = "../superposition_types", features = ["result"] }
+uuid = { workspace = true }
 
 [features]
 disable_db_data_validation = ["superposition_types/disable_db_data_validation"]

--- a/crates/experimentation_platform/src/lib.rs
+++ b/crates/experimentation_platform/src/lib.rs
@@ -1,2 +1,3 @@
+#![deny(unused_crate_dependencies)]
 pub mod api;
 pub mod db;

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -15,8 +15,8 @@ derive_more = { workspace = true }
 futures = "0.3"
 js-sys = "0.3.65"
 leptos = { workspace = true }
-leptos_meta = { workspace = true }
-leptos_router = { workspace = true }
+leptos_meta = { version = "0.6.11" }
+leptos_router = { version = "0.6.11" }
 monaco = { git = "https://github.com/datron/rust-monaco.git" }
 once_cell = { workspace = true }
 serde = { workspace = true }

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -7,43 +7,42 @@ edition = "2021"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-dotenv = { workspace = true }
-actix-files = { version = "0.6", optional = true }
-actix-web = { version = "4.5.0", optional = true, features = ["macros"] }
-console_error_panic_hook = "0.1"
+anyhow = { workspace = true }
 cfg-if = "1"
+chrono = { workspace = true }
+console_error_panic_hook = { version = "0.1", optional = true }
+derive_more = { workspace = true }
+futures = "0.3"
+js-sys = "0.3.65"
 leptos = { workspace = true }
 leptos_meta = { workspace = true }
-leptos_actix = { workspace = true, optional = true }
 leptos_router = { workspace = true }
-wasm-bindgen = "=0.2.89"
-reqwest = { workspace = true }
+monaco = { git = "https://github.com/datron/rust-monaco.git" }
+once_cell = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-web-sys = { version = "0.3.64", features = ["Event", "Worker", "Blob", "Window"] }
-futures = "0.3"
-derive_more = { workspace = true }
-anyhow = { workspace = true }
-chrono = {workspace = true }
-strum_macros = { workspace = true }
+reqwest = { workspace = true }
 strum = { workspace = true }
-js-sys = "0.3.65"
+strum_macros = { workspace = true }
 url = "2.5.0"
-once_cell = { workspace = true }
-leptos-use = { workspace = true }
-monaco = { git = "https://github.com/datron/rust-monaco.git" }
+wasm-bindgen = "=0.2.89"
+web-sys = { version = "0.3.64", features = [
+  "Event",
+  "Worker",
+  "Blob",
+  "Window",
+  "Storage",
+] }
 
 [features]
 csr = ["leptos/csr", "leptos_meta/csr", "leptos_router/csr"]
-hydrate = ["leptos/hydrate", "leptos_meta/hydrate", "leptos_router/hydrate"]
-ssr = [
-  "dep:actix-files",
-  "dep:actix-web",
-  "dep:leptos_actix",
-  "leptos/ssr",
-  "leptos_meta/ssr",
-  "leptos_router/ssr",
+hydrate = [
+  "leptos/hydrate",
+  "leptos_meta/hydrate",
+  "leptos_router/hydrate",
+  "console_error_panic_hook",
 ]
+ssr = ["leptos/ssr", "leptos_meta/ssr", "leptos_router/ssr"]
 
 [lints]
 workspace = true

--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unknown_lints, clippy::empty_docs)]
+#![deny(unused_crate_dependencies)]
 
 mod api;
 pub mod app;

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 actix-web = { workspace = true }
 anyhow = { workspace = true }
-aws-config = { workspace = true }
-aws-sdk-kms = { workspace = true }
+aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
+aws-sdk-kms = { version = "1.38.0" }
 base64 = { workspace = true }
 derive_more = { workspace = true }
 diesel = { workspace = true }
@@ -24,7 +24,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 strum_macros = { workspace = true }
 superposition_types = { path = "../superposition_types", features = ["result"] }
-urlencoding = { workspace = true }
+urlencoding = "~2.1.2"
 
 [lints]
 workspace = true

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -6,37 +6,25 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# env
-dotenv = { workspace = true }
-# Https server framework
-actix = { workspace = true }
 actix-web = { workspace = true }
-futures-util = "0.3.28"
-# To help generate snowflake ids
-rs-snowflake = { workspace = true }
-#ORM
-env_logger = { workspace = true }
 anyhow = { workspace = true }
-strum_macros = { workspace = true }
-strum = { workspace = true }
-diesel = { workspace = true }
-bytes = { workspace = true }
-rusoto_core = { workspace = true }
+aws-config = { workspace = true }
+aws-sdk-kms = { workspace = true }
 base64 = { workspace = true }
-urlencoding = { workspace = true }
+derive_more = { workspace = true }
+diesel = { workspace = true }
+futures-util = "0.3.28"
 jsonschema = { workspace = true }
 log = { workspace = true }
-serde = { workspace = true }
-serde_json = { workspace = true }
-derive_more = { workspace = true }
-reqwest = { workspace = true }
-thiserror = { workspace = true }
 once_cell = { workspace = true }
 regex = { workspace = true }
-mime = { workspace = true }
-superposition_types = { path="../superposition_types" }
-aws-sdk-kms = {workspace = true}
-aws-config = {workspace = true}
+reqwest = { workspace = true }
+rs-snowflake = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+strum_macros = { workspace = true }
+superposition_types = { path = "../superposition_types", features = ["result"] }
+urlencoding = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/service_utils/src/lib.rs
+++ b/crates/service_utils/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unused_crate_dependencies)]
 pub mod aws;
 pub mod db;
 pub mod helpers;

--- a/crates/superposition/Cargo.toml
+++ b/crates/superposition/Cargo.toml
@@ -9,12 +9,12 @@ edition = "2021"
 actix-files = { version = "0.6" }
 actix-web = { workspace = true }
 context_aware_config = { path = "../context_aware_config" }
-dotenv = { workspace = true }
-env_logger = { workspace = true }
+dotenv = "0.15.0"
+env_logger = "0.8"
 experimentation_platform = { path = "../experimentation_platform" }
 frontend = { path = "../frontend" }
 leptos = { workspace = true }
-leptos_actix = { workspace = true }
+leptos_actix = { version = "0.6.11" }
 rs-snowflake = { workspace = true }
 serde_json = { workspace = true }
 service_utils = { path = "../service_utils" }

--- a/crates/superposition/Cargo.toml
+++ b/crates/superposition/Cargo.toml
@@ -6,57 +6,19 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cac_client = { path = "../cac_client" }
-frontend = { path = "../frontend" }
-service_utils = { path = "../service_utils" }
-experimentation_platform = { path = "../experimentation_platform" }
-context_aware_config = { path = "../context_aware_config" }
-superposition_types = { path = "../superposition_types" }
-# env
-dotenv = { workspace = true }
-# Https server framework
-actix = { workspace = true }
-actix-web = { workspace = true }
-# To help generate snowflake ids
-rs-snowflake = { workspace = true }
-# To help with generating uuids
-uuid = { workspace = true }
-# To serialize and deserialize objects from json
-serde = { workspace = true }
-serde_json = { workspace = true }
-# For logging and debugging
-env_logger = { workspace = true }
-log = { workspace = true }
-# to work with enums
-strum_macros = { workspace = true }
-strum = { workspace = true }
-derive_more = { workspace = true }
-# date and time
-chrono = { workspace = true }
-# ORM
-diesel = { workspace = true }
-blake3 = { workspace = true }
-bytes = { workspace = true }
-rusoto_core = { workspace = true }
-base64 = { workspace = true }
-diesel-derive-enum = { version = "2.0.1", features = ["postgres"] }
-urlencoding = { workspace = true }
-jsonschema = { workspace = true }
-reqwest = { workspace = true, features = ["rustls-tls"] }
-rand = { workspace = true }
-tracing-log = "0.1.3"
-valuable = { version = "0.1.0", features = ["std", "alloc", "derive"] }
-itertools = "0.10.5"
-futures = "0.3.28"
-actix-http = "3.3.1"
-futures-util = "0.3.28"
-actix-cors = "0.6.4"
-leptos_actix = { workspace = true }
-leptos = { workspace = true }
-leptos_meta = { workspace = true }
-leptos_router = { workspace = true }
 actix-files = { version = "0.6" }
-anyhow = { workspace = true }
+actix-web = { workspace = true }
+context_aware_config = { path = "../context_aware_config" }
+dotenv = { workspace = true }
+env_logger = { workspace = true }
+experimentation_platform = { path = "../experimentation_platform" }
+frontend = { path = "../frontend" }
+leptos = { workspace = true }
+leptos_actix = { workspace = true }
+rs-snowflake = { workspace = true }
+serde_json = { workspace = true }
+service_utils = { path = "../service_utils" }
+superposition_types = { path = "../superposition_types" }
 
 [lints]
 workspace = true

--- a/crates/superposition/src/main.rs
+++ b/crates/superposition/src/main.rs
@@ -1,24 +1,27 @@
-use actix_web::dev::Service;
-use actix_web::middleware::Compress;
-use actix_web::web::PathConfig;
-use actix_web::HttpMessage;
-use actix_web::{web, web::get, web::scope, web::Data, App, HttpResponse, HttpServer};
+#![deny(unused_crate_dependencies)]
+
+use std::{
+    collections::HashSet,
+    io::Result,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use actix_files::Files;
+use actix_web::{
+    dev::Service,
+    middleware::Compress,
+    web::{self, get, scope, Data, PathConfig},
+    App, HttpMessage, HttpResponse, HttpServer,
+};
 use context_aware_config::api::*;
 use context_aware_config::helpers::get_meta_schema;
 use experimentation_platform::api::*;
-use serde_json::{Map, Value};
-use std::sync::Arc;
-use std::{collections::HashSet, io::Result};
-use superposition_types::User;
-
-use snowflake::SnowflakeIdGenerator;
-use std::{sync::Mutex, time::Duration};
-
-use actix_files::Files;
 use frontend::app::*;
 use frontend::types::Envs as UIEnvs;
 use leptos::*;
 use leptos_actix::{generate_route_list, LeptosRoutes};
+use serde_json::{Map, Value};
 use service_utils::{
     db::pgschema_manager::PgSchemaManager,
     db::utils::init_pool_manager,
@@ -28,6 +31,8 @@ use service_utils::{
     },
     service::types::{AppEnv, AppScope, AppState, ExperimentationFlags},
 };
+use snowflake::SnowflakeIdGenerator;
+use superposition_types::User;
 
 #[actix_web::get("favicon.ico")]
 async fn favicon(

--- a/crates/superposition_macros/Cargo.toml
+++ b/crates/superposition_macros/Cargo.toml
@@ -5,8 +5,5 @@ edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
-[dependencies]
-superposition_types = { path="../superposition_types" }
-
 [lints]
 workspace = true

--- a/crates/superposition_macros/src/lib.rs
+++ b/crates/superposition_macros/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(unused_crate_dependencies)]
 #[macro_export]
 macro_rules! bad_argument {
     ($msg: literal, $($args: tt)*) => {

--- a/crates/superposition_types/Cargo.toml
+++ b/crates/superposition_types/Cargo.toml
@@ -9,22 +9,19 @@ edition = "2021"
 # env
 actix = { workspace = true }
 actix-web = { workspace = true }
-strum_macros = { workspace = true }
-strum = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 derive_more = { workspace = true }
-thiserror = { workspace = true }
-diesel = { workspace = true }
-anyhow = { workspace = true }
+thiserror = { workspace = true, optional = true }
+diesel = { workspace = true, optional = true }
+anyhow = { workspace = true, optional = true }
 jsonlogic = { workspace = true }
 regex = { workspace = true }
 
 [features]
 disable_db_data_validation = []
+result = ["diesel", "anyhow", "thiserror"]
 
 [lints]
 workspace = true
-
-

--- a/crates/superposition_types/Cargo.toml
+++ b/crates/superposition_types/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 
 [dependencies]
 # env
-actix = { workspace = true }
 actix-web = { workspace = true }
 log = { workspace = true }
 serde = { workspace = true }

--- a/crates/superposition_types/Cargo.toml
+++ b/crates/superposition_types/Cargo.toml
@@ -12,7 +12,7 @@ log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 derive_more = { workspace = true }
-thiserror = { workspace = true, optional = true }
+thiserror = { version = "1.0.57", optional = true }
 diesel = { workspace = true, optional = true }
 anyhow = { workspace = true, optional = true }
 jsonlogic = { workspace = true }
@@ -20,7 +20,7 @@ regex = { workspace = true }
 
 [features]
 disable_db_data_validation = []
-result = ["diesel", "anyhow", "thiserror"]
+result = ["dep:diesel", "dep:anyhow", "dep:thiserror"]
 
 [lints]
 workspace = true

--- a/crates/superposition_types/src/lib.rs
+++ b/crates/superposition_types/src/lib.rs
@@ -1,4 +1,7 @@
+#![deny(unused_crate_dependencies)]
+#[cfg(feature = "result")]
 pub mod result;
+
 use std::fmt::Display;
 
 use actix::fut::{ready, Ready};
@@ -260,12 +263,10 @@ impl Display for RegexEnum {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use anyhow::anyhow;
-    use result as superposition;
     use serde_json::json;
 
     #[test]
-    fn ok_test_deserialize_condition() -> superposition::Result<()> {
+    fn ok_test_deserialize_condition() {
         let db_request_condition_map: Map<String, Value> = Map::from_iter(vec![(
             "and".to_string(),
             json!([
@@ -314,9 +315,8 @@ mod tests {
         .unwrap();
         let db_expected_condition =
             Cac::<Condition>::try_from_db(db_request_condition_map)
-                .map_err(|err| superposition::AppError::UnexpectedError(anyhow!(err)))?
-                .into_inner();
-        assert_eq!(db_condition, db_expected_condition);
+                .map(|a| a.into_inner());
+        assert_eq!(Ok(db_condition), db_expected_condition);
 
         let default_condition = serde_json::from_str::<Condition>(
             &json!(default_request_condition_map).to_string(),
@@ -324,25 +324,20 @@ mod tests {
         .unwrap();
         let default_expected_condition =
             Cac::<Condition>::try_from(default_request_condition_map)
-                .map_err(superposition::AppError::BadArgument)?
-                .into_inner();
-        assert_eq!(default_condition, default_expected_condition);
+                .map(|a| a.into_inner());
+        assert_eq!(Ok(default_condition), default_expected_condition);
 
         let exp_condition = serde_json::from_str::<Condition>(
             &json!(exp_request_condition_map).to_string(),
         )
         .unwrap();
         let exp_expected_condition =
-            Exp::<Condition>::try_from(exp_request_condition_map)
-                .map_err(superposition::AppError::BadArgument)?
-                .into_inner();
-        assert_eq!(exp_condition, exp_expected_condition);
-
-        Ok(())
+            Exp::<Condition>::try_from(exp_request_condition_map).map(|a| a.into_inner());
+        assert_eq!(Ok(exp_condition), exp_expected_condition);
     }
 
     #[test]
-    fn fail_test_deserialize_condition() -> superposition::Result<()> {
+    fn fail_test_deserialize_condition() {
         let request_condition_map: Map<String, Value> = Map::from_iter(vec![(
             "and".to_string(),
             json!([
@@ -404,12 +399,10 @@ mod tests {
                 .contains("variantIds should not be present"),
             true
         );
-
-        Ok(())
     }
 
     #[test]
-    fn test_deserialize_override() -> superposition::Result<()> {
+    fn test_deserialize_override() {
         let override_map = Map::from_iter(vec![
             ("key1".to_string(), json!("val1")),
             ("key2".to_string(), json!(5)),
@@ -419,20 +412,17 @@ mod tests {
 
         let deserialize_overrides =
             serde_json::from_str::<Overrides>(&json!(override_map).to_string()).unwrap();
-        let db_expected_overrides = Cac::<Overrides>::try_from_db(override_map.clone())
-            .map_err(|err| superposition::AppError::UnexpectedError(anyhow!(err)))?
-            .into_inner();
-        assert_eq!(deserialize_overrides, db_expected_overrides);
+        let db_expected_overrides =
+            Cac::<Overrides>::try_from_db(override_map.clone()).map(|a| a.into_inner());
+        assert_eq!(Ok(deserialize_overrides.clone()), db_expected_overrides);
 
-        let exp_expected_overrides = Exp::<Overrides>::try_from(override_map.clone())
-            .map_err(superposition::AppError::BadArgument)?
-            .into_inner();
-        assert_eq!(deserialize_overrides, exp_expected_overrides);
+        let exp_expected_overrides =
+            Exp::<Overrides>::try_from(override_map.clone()).map(|a| a.into_inner());
+        assert_eq!(Ok(deserialize_overrides.clone()), exp_expected_overrides);
 
-        let default_expected_overrides = Cac::<Overrides>::try_from(override_map.clone())
-            .map_err(superposition::AppError::BadArgument)?
-            .into_inner();
-        assert_eq!(deserialize_overrides, default_expected_overrides);
+        let default_expected_overrides =
+            Cac::<Overrides>::try_from(override_map.clone()).map(|a| a.into_inner());
+        assert_eq!(Ok(deserialize_overrides), default_expected_overrides);
 
         let empty_overrides = serde_json::from_str::<Cac<Overrides>>(
             &json!(empty_override_map.clone()).to_string(),
@@ -445,7 +435,5 @@ mod tests {
                 .contains("override should not be empty"),
             true
         );
-
-        Ok(())
     }
 }

--- a/crates/superposition_types/src/lib.rs
+++ b/crates/superposition_types/src/lib.rs
@@ -3,8 +3,8 @@
 pub mod result;
 
 use std::fmt::Display;
+use std::future::{ready, Ready};
 
-use actix::fut::{ready, Ready};
 use actix_web::{dev::Payload, error, FromRequest, HttpMessage, HttpRequest};
 use derive_more::{AsRef, Deref, DerefMut, Into};
 use log::error;

--- a/examples/cac_client_integration_example/Cargo.toml
+++ b/examples/cac_client_integration_example/Cargo.toml
@@ -6,12 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-cac_client = { path = "../../crates/cac_client" }
-chrono = { workspace = true }
-
-# Https server framework
-actix = { workspace = true }
 actix-web = { workspace = true }
+cac_client = { path = "../../crates/cac_client" }
 serde_json = { workspace = true }
 
 

--- a/examples/cac_client_integration_example/src/main.rs
+++ b/examples/cac_client_integration_example/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(unused_crate_dependencies)]
 use actix_web::{
     get, rt,
     web::{get, Query},

--- a/examples/cac_toml_app_example/src/main.rs
+++ b/examples/cac_toml_app_example/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(unused_crate_dependencies)]
 use cac_toml::ContextAwareConfig;
 use clap::{Arg, Command};
 use std::collections::HashMap;

--- a/examples/experimentation_client_integration_example/Cargo.toml
+++ b/examples/experimentation_client_integration_example/Cargo.toml
@@ -6,12 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-experimentation_client = { path = "../../crates/experimentation_client" }
-chrono = { workspace = true }
-
-# Https server framework
-actix = { workspace = true }
 actix-web = { workspace = true }
+experimentation_client = { path = "../../crates/experimentation_client" }
 serde_json = { workspace = true }
 
 [lints]

--- a/examples/experimentation_client_integration_example/src/main.rs
+++ b/examples/experimentation_client_integration_example/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(unused_crate_dependencies)]
 use actix_web::{
     get, rt,
     web::{get, Data, Path},

--- a/examples/superposition-demo-app/Cargo.toml
+++ b/examples/superposition-demo-app/Cargo.toml
@@ -6,9 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "4"
 actix-files = "0.6"
+actix-web = "4"
 awc = "3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
-tera = "1.11"

--- a/examples/superposition-demo-app/src/main.rs
+++ b/examples/superposition-demo-app/src/main.rs
@@ -1,3 +1,4 @@
+#![deny(unused_crate_dependencies)]
 use actix_files as fs;
 use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
 use awc::Client;

--- a/makefile
+++ b/makefile
@@ -122,7 +122,7 @@ backend:
 
 build: frontend backend
 
-run: kill build
+run: kill frontend
 	while ! make validate-psql-connection validate-aws-connection; \
 		do echo "waiting for postgres, localstack bootup"; \
 		sleep 0.5; \


### PR DESCRIPTION
## Problem

1. `make run` compiles code twice
2. Redundant dependencies across all crates
3. Single use dependency specified at workspace `Cargo.toml`
4. `superposition_types` uses `diesel` as dependency, which causes dependency issues in 3rd party repos using this crate
5. dependencies in random order
6. `cac_client` returning data of types `superposition_types::result::Result<T>` in cases where the return should neither be a `Result` type or can simply be a `Result<T, String>`

## Solution

1. Remove redundant compile step
2. Remove unused dependencies, mandate `#![deny(unused_crate_dependencies)]` for all crates
3. Localise single use dependency to the crates instead of workspace `Cargo.toml`
4. make `result` type as a feature for `superposition_types` (make `diesel` optional)
5. sorted dependencies in alphabetical order
6. Update return type of `cac_client` functions to direct `T` or `Result<T, String>`