### PR TITLE
chore: Delete SuperpositionUser trait

### DIFF
--- a/crates/context_aware_config/src/api/context/handlers.rs
+++ b/crates/context_aware_config/src/api/context/handlers.rs
@@ -42,7 +42,7 @@ use serde_json::{from_value, json, Map, Value};
 use service_utils::helpers::{parse_config_tags, validation_err_to_str};
 use service_utils::service::types::DbConnection;
 use std::collections::HashMap;
-use superposition_types::{SuperpositionUser, User};
+use superposition_types::User;
 
 use super::helpers::{
     validate_condition_with_functions, validate_condition_with_mandatory_dimensions,

--- a/crates/context_aware_config/src/api/default_config/handlers.rs
+++ b/crates/context_aware_config/src/api/default_config/handlers.rs
@@ -8,7 +8,7 @@ use service_utils::{
 use superposition_macros::{
     bad_argument, db_error, not_found, unexpected_error, validation_error,
 };
-use superposition_types::{result as superposition, SuperpositionUser, User};
+use superposition_types::{result as superposition, User};
 
 use crate::{
     api::{

--- a/crates/context_aware_config/src/api/dimension/handlers.rs
+++ b/crates/context_aware_config/src/api/dimension/handlers.rs
@@ -18,7 +18,7 @@ use diesel::{
 use jsonschema::{Draft, JSONSchema};
 use serde_json::Value;
 use superposition_macros::{bad_argument, not_found, unexpected_error};
-use superposition_types::{result as superposition, SuperpositionUser, User};
+use superposition_types::{result as superposition, User};
 
 use service_utils::service::types::{AppState, DbConnection, Tenant};
 

--- a/crates/context_aware_config/src/api/functions/handlers.rs
+++ b/crates/context_aware_config/src/api/functions/handlers.rs
@@ -23,7 +23,7 @@ use serde_json::json;
 use service_utils::service::types::DbConnection;
 
 use superposition_macros::{bad_argument, not_found, unexpected_error};
-use superposition_types::{result as superposition, SuperpositionUser, User};
+use superposition_types::{result as superposition, User};
 
 use validation_functions::{compile_fn, execute_fn};
 

--- a/crates/experimentation_platform/src/api/experiments/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiments/handlers.rs
@@ -20,9 +20,7 @@ use service_utils::service::types::{
     AppHeader, AppState, CustomHeaders, DbConnection, Tenant,
 };
 use superposition_macros::{bad_argument, response_error, unexpected_error};
-use superposition_types::{
-    result as superposition, Condition, Exp, Overrides, SuperpositionUser, User,
-};
+use superposition_types::{result as superposition, Condition, Exp, Overrides, User};
 
 use super::{
     helpers::{

--- a/crates/superposition_types/src/lib.rs
+++ b/crates/superposition_types/src/lib.rs
@@ -12,13 +12,6 @@ use regex::Regex;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{json, Map, Value};
 
-pub trait SuperpositionUser {
-    fn get_email(&self) -> String;
-    fn get_username(&self) -> String;
-    fn get_auth_token(&self) -> String;
-    fn get_auth_type(&self) -> String;
-}
-
 #[derive(Debug, Clone)]
 pub struct User {
     pub email: String,
@@ -27,20 +20,20 @@ pub struct User {
     pub auth_type: String,
 }
 
-impl SuperpositionUser for User {
-    fn get_email(&self) -> String {
+impl User {
+    pub fn get_email(&self) -> String {
         self.email.clone()
     }
 
-    fn get_username(&self) -> String {
+    pub fn get_username(&self) -> String {
         self.username.clone()
     }
 
-    fn get_auth_token(&self) -> String {
+    pub fn get_auth_token(&self) -> String {
         self.auth_token.clone()
     }
 
-    fn get_auth_type(&self) -> String {
+    pub fn get_auth_type(&self) -> String {
         self.auth_type.clone()
     }
 }
@@ -52,17 +45,6 @@ impl Default for User {
             username: "superposition".into(),
             auth_token: "1234abcd".into(),
             auth_type: "Bearer".into(),
-        }
-    }
-}
-
-impl From<Box<dyn SuperpositionUser>> for User {
-    fn from(value: Box<dyn SuperpositionUser>) -> Self {
-        User {
-            email: value.get_email(),
-            username: value.get_username(),
-            auth_token: value.get_auth_token(),
-            auth_type: value.get_auth_type(),
         }
     }
 }


### PR DESCRIPTION
## Problem
`SuperpositionUser` trait was introduced as a means to provide a way to convert any other user type to `superposition_types::User` type, which is not needed as the correct way around this is implement `superposition_types::User: From<Self>` for the other User type

## Solution
Deleted `SuperpositionUser` trait and its usages