### PR TITLE
feat: Webhook trigger for experiments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4046,6 +4046,7 @@ dependencies = [
  "frontend",
  "leptos",
  "leptos_actix",
+ "reqwest",
  "rs-snowflake",
  "serde_json",
  "service_utils",

--- a/crates/service_utils/src/service/types.rs
+++ b/crates/service_utils/src/service/types.rs
@@ -53,6 +53,7 @@ pub struct AppState {
     pub superposition_token: String,
     #[cfg(feature = "high-performance-mode")]
     pub redis: fred::clients::RedisPool,
+    pub http_client: reqwest::Client,
 }
 
 impl FromStr for AppEnv {

--- a/crates/superposition/Cargo.toml
+++ b/crates/superposition/Cargo.toml
@@ -23,6 +23,7 @@ superposition_types = { path = "../superposition_types" }
 toml = { workspace = true }
 fred = { workspace = true, optional = true }
 cfg-if = { workspace = true }
+reqwest = { workspace = true }
 
 [features]
 high-performance-mode = ["context_aware_config/high-performance-mode", "service_utils/high-performance-mode", "dep:fred"]

--- a/crates/superposition/Superposition.cac.toml
+++ b/crates/superposition/Superposition.cac.toml
@@ -1,9 +1,28 @@
 [default-config]
 mandatory_dimensions = { "value" = [
 ], "schema" = { "type" = "array", "items" = { "type" = "number" } } }
+experiments_webhook_config = { "value" = { "enabled" = false }, "schema" = { "type" = "object", "properties" = { "enabled" = { "type" = "boolean" }, "configuration" = { "type" = "object", "properties" = { "url" = { "type" = "string" }, "method" = { "enum" = [
+    "Post",
+    "Get",
+], "type" = "string" }, "headers" = { "type" = "array", "items" = { "type" = "string", "enum" = [
+    "ConfigVersion",
+] } }, "authorization" = { "type" = "object", "properties" = { "key" = { "type" = "string" }, "value" = { "type" = "string" } }, "required" = [
+    "key",
+    "value",
+] }, "required" = [
+    "url",
+    "method",
+    "headers",
+    "authorization",
+], "additionalProperties" = false } } }, "required" = [
+    "enabled",
+] } }
 
 [dimensions]
 tenant = { schema = { "type" = "string", "enum" = ["test", "dev"] } }
 
 [context."$tenant == 'dev'"]
 mandatory_dimensions = []
+experiments_webhook_config = { "enabled" = false, "configuration" = { "url" = "http://localhost:8080/config/test", "method" = "Get", "headers" = [
+    "ConfigVersion",
+], "authorization" = { key = "Authorization", value = "TOKEN_FOR_WEBHOOK" } } }

--- a/crates/superposition/src/app_state.rs
+++ b/crates/superposition/src/app_state.rs
@@ -140,5 +140,6 @@ pub async fn get(
         superposition_token: get_superposition_token(&kms_client, &app_env).await,
         #[cfg(feature = "high-performance-mode")]
         redis: redis_pool,
+        http_client: reqwest::Client::new(),
     }
 }

--- a/crates/superposition_macros/src/lib.rs
+++ b/crates/superposition_macros/src/lib.rs
@@ -57,3 +57,13 @@ macro_rules! response_error {
         )
     };
 }
+
+#[macro_export]
+macro_rules! webhook_error {
+    ($msg: literal, $($args: tt)*) => {
+        superposition_types::result::AppError::WebhookError(anyhow::anyhow!(format!($msg, $($args)*)))
+    };
+    ($err: tt) => {
+        superposition_types::result::AppError::WebhookError(anyhow::anyhow!($err.to_string()))
+    };
+}

--- a/crates/superposition_types/src/lib.rs
+++ b/crates/superposition_types/src/lib.rs
@@ -6,6 +6,7 @@ pub mod custom_query;
 mod overridden;
 #[cfg(feature = "result")]
 pub mod result;
+pub mod webhook;
 
 use std::fmt::Display;
 use std::future::{ready, Ready};
@@ -16,6 +17,7 @@ use log::error;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use webhook::WebhookConfig;
 
 pub use crate::config::{Condition, Config, Context, Overrides};
 pub use crate::contextual::Contextual;
@@ -154,6 +156,7 @@ impl Display for RegexEnum {
 #[derive(Clone, Deserialize)]
 pub struct TenantConfig {
     pub mandatory_dimensions: Vec<String>,
+    pub experiments_webhook_config: WebhookConfig,
 }
 
 #[cfg(feature = "server")]

--- a/crates/superposition_types/src/result.rs
+++ b/crates/superposition_types/src/result.rs
@@ -21,6 +21,8 @@ pub enum AppError {
     ResponseError(#[from] ResponseError),
     #[error(transparent)]
     UnexpectedError(anyhow::Error),
+    #[error("webhook error ( `{0}` )")]
+    WebhookError(String),
 }
 
 #[derive(Debug, this_error, Display, Clone)]
@@ -70,6 +72,7 @@ impl AppError {
                 error,
             )) => error.message().to_owned(),
             AppError::DbError(_) => String::from("Something went wrong"),
+            AppError::WebhookError(error) => error.to_string(),
         }
     }
 }
@@ -118,6 +121,11 @@ impl error::ResponseError for AppError {
             AppError::DbError(_) => Self::generate_err_response(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Something went wrong",
+            ),
+
+            AppError::WebhookError(error) => Self::generate_err_response(
+                StatusCode::from_u16(512).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR),
+                &error,
             ),
         }
     }

--- a/crates/superposition_types/src/webhook.rs
+++ b/crates/superposition_types/src/webhook.rs
@@ -1,0 +1,78 @@
+use serde::{Deserialize, Deserializer, Serialize};
+use std::fmt::{self};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum HeadersEnum {
+    ConfigVersion,
+}
+
+impl fmt::Display for HeadersEnum {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ConfigVersion => write!(f, "x-config-version"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum HttpMethod {
+    Get,
+    Post,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Authorization {
+    pub key: String,
+    pub value: String,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Webhook {
+    pub url: String,
+    pub method: HttpMethod,
+    pub headers: Vec<HeadersEnum>,
+    pub authorization: Authorization,
+}
+
+#[derive(Serialize, Deserialize)]
+pub enum WebhookEvent {
+    ExperimentCreated,
+    ExperimentStarted,
+    ExperimentInprogress,
+    ExperimentUpdated,
+    ExperimentConcluded,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct WebhookResponse<T> {
+    pub event: WebhookEvent,
+    pub payload: T,
+}
+
+#[derive(Clone, Serialize)]
+pub enum WebhookConfig {
+    Disbled,
+    Enabled(Webhook),
+}
+
+impl<'de> Deserialize<'de> for WebhookConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct WebhookConfigHelper {
+            enabled: bool,
+            configuration: Option<Webhook>,
+        }
+
+        let helper = WebhookConfigHelper::deserialize(deserializer)?;
+        match (helper.enabled, helper.configuration) {
+            (true, None) => Err(serde::de::Error::custom(
+                "Configuration must be provided when enabled is true",
+            )),
+            (true, Some(webhook)) => Ok(Self::Enabled(webhook)),
+            (false, _) => Ok(Self::Disbled),
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Webhook trigger for experiments

## Solution
 Webhook trigger for experiments (Create, Conclude, ramp, update_overrides)

## Tenant Config changes

`experiments_webhook_config = { "value" = {}, "schema" = { "type" = "object", properties = {"url" = { "type" = "string" }, "method" = { "enum" = ["Post","Put","Get"], "type" = "string" },"headers" = { "type" = "array", "items" = { "type" = "string", "enum" = ["ConfigVersion"] }}, authorization = {"type" = "object", properties = { "key" = { "type" = "string" }, "value" = { "type" = "string" }}}, "required"= ["url", "method", "headers", "authorization"], "additionalProperties" = false}}}
`

## Post-deployment activity

Tenant Config Changes
