### PR TITLE
feat: sort_by and created_by filter params for context/list

### DIFF
--- a/crates/context_aware_config/src/api/context/types.rs
+++ b/crates/context_aware_config/src/api/context/types.rs
@@ -27,10 +27,27 @@ pub struct PutResp {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ContextFilterSortBy {
+    CreatedAtAsc,
+    CreatedAtDesc,
+    PriorityAsc,
+    PriorityDesc,
+}
+
+impl Default for ContextFilterSortBy {
+    fn default() -> Self {
+        Self::PriorityAsc
+    }
+}
+
+#[derive(Deserialize)]
 pub struct ContextFilters {
     pub page: Option<u32>,
     pub size: Option<u32>,
     pub prefix: Option<String>,
+    pub sort_by: Option<ContextFilterSortBy>,
+    pub created_by: Option<String>,
 }
 
 #[cfg_attr(test, derive(Debug, PartialEq))] // Derive traits only when running tests


### PR DESCRIPTION
## Problem
No option to filter and search on `created_by` and no option to change the sorting logic

## Solution

1. Add option to sort contexts by passing `platform[sort_by]`, 
    accepted values: `priority_asc`, `priority_desc`, `created_at_asc`, `created_at_desc` (default : `priority_asc`)
2. Add option to search context created by a user by passing `platform[created_by]`,
    accepted values: comma separated user email ids (does an exact match)