### PR TITLE
feat: use new input type for json schema inputs as well

### DIFF
--- a/crates/frontend/src/components/default_config_form.rs
+++ b/crates/frontend/src/components/default_config_form.rs
@@ -28,7 +28,7 @@ pub fn default_config_form<NF>(
     #[prop(default = String::new())] config_key: String,
     #[prop(default = String::new())] config_type: String,
     #[prop(default = Value::Null)] type_schema: Value,
-    #[prop(default = String::new())] config_value: String,
+    #[prop(default = Value::Null)] config_value: Value,
     #[prop(default = None)] function_name: Option<Value>,
     #[prop(default = None)] prefix: Option<String>,
     handle_submit: NF,
@@ -38,20 +38,12 @@ where
 {
     let tenant_rs = use_context::<ReadSignal<String>>().unwrap();
 
-    let (config_key, set_config_key) = create_signal(config_key);
+    let (config_key_rs, config_key_ws) = create_signal(config_key);
     let (config_type_rs, config_type_ws) = create_signal(config_type);
     let (config_schema_rs, config_schema_ws) = create_signal(type_schema);
-    let (config_value, set_config_value) = create_signal(config_value);
-    let (function_name, set_function_name) = create_signal(function_name);
+    let (config_value_rs, config_value_ws) = create_signal(config_value);
+    let (function_name_rs, function_name_ws) = create_signal(function_name);
     let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
-    let string_to_value_closure = |val: String| {
-        Value::from_str(&val).unwrap_or_else(|_| {
-            // do this for Value::String, since for some reason from_str
-            // cannot convert unquoted rust strings to Value::String
-            Value::from_str(format!("\"{}\"", val).as_str())
-                .expect("Invalid default config value")
-        })
-    };
 
     let functions_resource: Resource<String, Vec<crate::types::FunctionResponse>> =
         create_blocking_resource(
@@ -76,7 +68,7 @@ where
 
     let handle_select_dropdown_option =
         Callback::new(move |selected_function: FunctionsName| {
-            set_function_name.update(|value| {
+            function_name_ws.update(|value| {
                 let function_name = selected_function.clone();
                 leptos::logging::log!("function selected: {:?}", function_name);
                 let fun_name = match function_name.as_str() {
@@ -92,14 +84,14 @@ where
     let on_submit = move |ev: MouseEvent| {
         req_inprogress_ws.set(true);
         ev.prevent_default();
-        let f_name = prefix
-            .clone()
-            .map_or_else(|| config_key.get(), |prefix| prefix + &config_key.get());
+        let f_name = prefix.clone().map_or_else(
+            || config_key_rs.get(),
+            |prefix| prefix + &config_key_rs.get(),
+        );
         let f_schema = config_schema_rs.get();
-        let f_value = config_value.get();
+        let f_value = config_value_rs.get();
 
-        let fun_name = function_name.get();
-        let f_value = string_to_value_closure(f_value);
+        let fun_name = function_name_rs.get();
 
         let payload = DefaultConfigCreateReq {
             schema: f_schema,
@@ -133,6 +125,7 @@ where
         });
     };
     view! {
+        <EditorProvider>
         <form class="form-control w-full space-y-4 bg-white text-gray-700 font-mono">
 
             <div class="form-control">
@@ -144,10 +137,10 @@ where
                     type="text"
                     placeholder="Key"
                     class="input input-bordered w-full max-w-md"
-                    value=config_key.get_untracked()
+                    value=config_key_rs.get_untracked()
                     on:change=move |ev| {
                         let value = event_target_value(&ev);
-                        set_config_key.set(value);
+                        config_key_ws.set(value);
                     }
                 />
 
@@ -183,16 +176,16 @@ where
                                     config_schema_ws.set(selected_item.type_schema);
                                 })
                             />
-                            <EditorProvider>
-                                <Input
-                                    id="type-schema"
-                                    class="mt-5 rounded-md resize-y w-full max-w-md pt-3"
-                                    schema_type=config_type_schema
-                                    value=config_schema_rs.get()
-                                    on_change=Callback::new(move |new_config_schema| config_schema_ws.set(new_config_schema))
-                                    r#type=InputType::Monaco
-                                />
-                            </EditorProvider>
+
+                            <Input
+                                id="type-schema"
+                                class="mt-5 rounded-md resize-y w-full max-w-md pt-3"
+                                schema_type=config_type_schema
+                                value=config_schema_rs.get()
+                                on_change=Callback::new(move |new_config_schema| config_schema_ws.set(new_config_schema))
+                                r#type=InputType::Monaco
+                            />
+
                         </div>
                     }
                 }}
@@ -209,9 +202,9 @@ where
                         view! {
                             <EnumDropdown
                                 schema
-                                config_value=config_value.get()
+                                config_value=config_value_rs.get().as_str().map(String::from).unwrap_or_default()
                                 handle_change=Callback::new(move |selected_enum: String| {
-                                    set_config_value.set(selected_enum);
+                                    config_value_ws.set(Value::String(selected_enum));
                                 })
 
                                 class=String::from("mt-2")
@@ -220,49 +213,84 @@ where
                             .into_view()
                     }
                     "BOOLEAN" => {
-                        let value = config_value.get();
-                        if value.is_empty() {
-                            set_config_value
-                                .set(value.parse::<bool>().unwrap_or(false).to_string());
+                        let value = config_value_rs.get();
+                        if value.is_null() {
+                            config_value_ws.set(Value::Bool(false));
                         }
                         view! {
                             <BooleanToggle
-                                value={value.parse::<bool>().unwrap_or(false)}
-                                on_change=Callback::new(move |flag: bool| {
-                                    set_config_value.set(flag.to_string());
-                                })
+                                value=value.as_bool().unwrap_or(false)
+                                on_change=Callback::new(move |flag: bool| config_value_ws.set(Value::Bool(flag)))
                             />
                         }
                             .into_view()
                     }
-                    "NUMBER" | "INTEGER" => {
+                    "INTEGER" => {
                         view! {
                             <input
                                 type="number"
                                 placeholder="Value"
                                 class="input input-bordered w-full max-w-md"
-                                value=config_value.get()
+                                value=config_value_rs.get().as_i64()
                                 on:change=move |ev| {
-                                    logging::log!("{:?}", event_target_value(& ev));
-                                    set_config_value.set(event_target_value(&ev));
+                                    logging::log!("{:?}", event_target_value(&ev));
+                                    let entered_integer = i64::from_str(&event_target_value(&ev)).unwrap_or(0);
+                                    config_value_ws.set(json!(entered_integer));
                                 }
                             />
                         }
                             .into_view()
                     }
+                    "NUMBER" => {
+                        view! {
+                            <input
+                                type="number"
+                                placeholder="Value"
+                                class="input input-bordered w-full max-w-md"
+                                value=config_value_rs.get().as_f64()
+                                on:change=move |ev| {
+                                    logging::log!("{:?}", event_target_value(&ev));
+                                    let entered_decimal = f64::from_str(&event_target_value(&ev)).unwrap_or_default();
+                                    config_value_ws.set(json!(entered_decimal));
+                                }
+                            />
+                        }
+                            .into_view()
+                    }
+                    "OBJECT" => {
+                        let config_type_schema = SchemaType::Single(JsonSchemaType::from(&config_schema_rs.get()));
+                        view! {
+                            <Input
+                                id="default-config-value"
+                                class="mt-5 rounded-md resize-y w-full max-w-md pt-3"
+                                schema_type=config_type_schema
+                                value=config_value_rs.get()
+                                on_change=Callback::new(move |new_default_config: Value| {
+                                    logging::log!("{:?}", new_default_config);
+                                    config_value_ws.set(new_default_config);
+                                })
+                                r#type=InputType::Monaco
+                            />
+
+                        }.into_view()
+                    },
                     _ => {
+                        let config_value = match config_value_rs.get() {
+                            Value::String(s) => s,
+                            _ => String::new()
+                        };
                         view! {
                             <textarea
                                 type="text"
                                 placeholder="Value"
                                 class="input input-bordered w-full max-w-md pt-3"
                                 on:change=move |ev| {
-                                    logging::log!("{:?}", event_target_value(& ev));
-                                    set_config_value.set(event_target_value(&ev));
+                                    logging::log!("{:?}", event_target_value(&ev));
+                                    config_value_ws.set(Value::String(event_target_value(&ev)));
                                 }
                             >
 
-                                {config_value.get()}
+                                {config_value}
                             </textarea>
                         }
                             .into_view()
@@ -305,7 +333,7 @@ where
                                 <Dropdown
                                     dropdown_width="w-100"
                                     dropdown_icon="".to_string()
-                                    dropdown_text=function_name
+                                    dropdown_text=function_name_rs
                                         .get()
                                         .and_then(|v| match v {
                                             Value::String(s) => Some(s),
@@ -347,5 +375,6 @@ where
             }
 
         </form>
+        </EditorProvider>
     }
 }

--- a/crates/frontend/src/components/default_config_form.rs
+++ b/crates/frontend/src/components/default_config_form.rs
@@ -6,13 +6,16 @@ use serde_json::{json, Map, Value};
 use std::str::FromStr;
 use web_sys::MouseEvent;
 
+use crate::providers::editor_provider::EditorProvider;
 use crate::{
     api::{fetch_functions, fetch_types},
     components::{
         button::Button,
         dropdown::{Dropdown, DropdownBtnType, DropdownDirection},
+        input::{Input, InputType},
         input_components::{BooleanToggle, EnumDropdown},
     },
+    schema::{JsonSchemaType, SchemaType},
     types::{FunctionsName, TypeTemplate},
     utils::get_key_type,
 };
@@ -161,11 +164,7 @@ where
                     } else {
                         config_type_rs.get()
                     };
-                    let config_textarea = if config_schema_rs.get().is_null() {
-                        String::from("")
-                    } else {
-                        format!("{}", config_schema_rs.get())
-                    };
+                    let config_type_schema = SchemaType::Single(JsonSchemaType::from(&config_schema_rs.get()));
                     view! {
                         <div class="form-control">
                             <label class="label">
@@ -184,21 +183,16 @@ where
                                     config_schema_ws.set(selected_item.type_schema);
                                 })
                             />
-
-                            <textarea
-                                type="text"
-                                placeholder="JSON schema"
-                                class="input input-bordered mt-5 rounded-md resize-y w-full max-w-md pt-3"
-                                rows=8
-                                on:change=move |ev| {
-                                    config_schema_ws
-                                        .set(string_to_value_closure(event_target_value(&ev)))
-                                }
-                            >
-
-                                {config_textarea}
-                            </textarea>
-
+                            <EditorProvider>
+                                <Input
+                                    id="type-schema"
+                                    class="mt-5 rounded-md resize-y w-full max-w-md pt-3"
+                                    schema_type=config_type_schema
+                                    value=config_schema_rs.get()
+                                    on_change=Callback::new(move |new_config_schema| config_schema_ws.set(new_config_schema))
+                                    r#type=InputType::Monaco
+                                />
+                            </EditorProvider>
                         </div>
                     }
                 }}

--- a/crates/frontend/src/components/input.rs
+++ b/crates/frontend/src/components/input.rs
@@ -17,11 +17,9 @@ pub enum InputType {
     Text,
     Number,
     Integer,
-
     Toggle,
     Monaco,
     Select(EnumVariants),
-
     Disabled,
 }
 

--- a/crates/frontend/src/components/override_form.rs
+++ b/crates/frontend/src/components/override_form.rs
@@ -95,7 +95,7 @@ fn override_input(
                             }
                         >
 
-                            <i class="ri-delete-bin-2-line text-xl text-2xl font-bold"></i>
+                            <i class="ri-delete-bin-2-line text-2xl font-bold"></i>
                         </button>
 
                     </div>

--- a/crates/frontend/src/components/type_template_form.rs
+++ b/crates/frontend/src/components/type_template_form.rs
@@ -1,9 +1,15 @@
 pub mod utils;
 
 use crate::components::type_template_form::utils::create_type;
-use crate::components::{button::Button, type_template_form::utils::update_type};
+use crate::components::{
+    button::Button,
+    input::{Input, InputType},
+    type_template_form::utils::update_type,
+};
+use crate::providers::editor_provider::EditorProvider;
+use crate::schema::{JsonSchemaType, SchemaType};
 use leptos::*;
-use serde_json::{from_str, json, Value};
+use serde_json::{json, Value};
 use web_sys::MouseEvent;
 
 #[component]
@@ -83,30 +89,18 @@ where
                 </label>
                 {move || {
                     let schem = type_schema_rs.get();
+                    let schema_type = SchemaType::Single(JsonSchemaType::from(&schem));
                     view! {
-                        <textarea
-                            type="text"
-                            class="input input-bordered shadow-md"
-                            name="type_schema"
-                            id="type_schema"
-                            style="min-height: 150px"
-                            placeholder="type schema"
-                            on:change=move |ev| {
-                                let value = event_target_value(&ev);
-                                match from_str::<Value>(&value) {
-                                    Ok(test_val) => {
-                                        type_schema_ws.set(test_val);
-                                        set_error_message.set("".to_string());
-                                    }
-                                    Err(err) => {
-                                        set_error_message.set(err.to_string());
-                                    }
-                                };
-                            }
-                        >
-
-                            {format!("{}", schem)}
-                        </textarea>
+                        <EditorProvider>
+                            <Input
+                                id="type-schema"
+                                class="mt-5 rounded-md resize-y w-full max-w-md pt-3"
+                                schema_type
+                                value=schem
+                                on_change=Callback::new(move |new_type_schema| type_schema_ws.set(new_type_schema))
+                                r#type=InputType::Monaco
+                            />
+                        </EditorProvider>
                     }
                 }}
 

--- a/crates/frontend/src/pages/default_config.rs
+++ b/crates/frontend/src/pages/default_config.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 #[derive(Clone, Debug, Default)]
 pub struct RowData {
     pub key: String,
-    pub value: String,
+    pub value: Value,
     pub schema: Value,
     pub function_name: Option<Value>,
 }
@@ -75,7 +75,7 @@ pub fn default_config() -> impl IntoView {
         let actions_col_formatter = move |_: &str, row: &Map<String, Value>| {
             let row_key = row["key"].to_string().replace('"', "");
             let is_folder = row_key.contains('.');
-            let row_value = row["value"].to_string().replace('"', "");
+            let row_value = row["value"].clone();
 
             let schema = row["schema"].clone().to_string();
             let schema_object =

--- a/crates/superposition_types/src/lib.rs
+++ b/crates/superposition_types/src/lib.rs
@@ -9,13 +9,16 @@ pub mod result;
 pub mod webhook;
 
 use std::fmt::Display;
+#[cfg(feature = "server")]
 use std::future::{ready, Ready};
 
 #[cfg(feature = "server")]
 use actix_web::{dev::Payload, error, FromRequest, HttpMessage, HttpRequest};
+#[cfg(feature = "server")]
 use log::error;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
+#[cfg(feature = "server")]
 use serde_json::json;
 use webhook::WebhookConfig;
 

--- a/makefile
+++ b/makefile
@@ -102,7 +102,7 @@ superposition_legacy:
 
 superposition_dev:
 	# export DB_PASSWORD=`./docker-compose/localstack/get_db_password.sh`
-	cargo watch -x 'run --color always --bin superposition --no-default-features --features=ssr'
+	cargo watch -x 'run --color always --bin superposition --no-default-features --features=$(FEATURES)'
 
 
 frontend:


### PR DESCRIPTION
## Problem
The input field to enter a type schema for a config was set to textarea

## Solution
Use the smarter input component that we already use for overrides

https://github.com/user-attachments/assets/e187f0b2-7073-4e07-8932-5a60edfea1c2

