### PR TITLE
refactor: make default config page's code cleaner

### DIFF
--- a/crates/frontend/src/components/input.rs
+++ b/crates/frontend/src/components/input.rs
@@ -431,7 +431,7 @@ pub fn input(
             Some(ref v) => {
                 view! { <Toggle value=v.clone() on_change class name/> }.into_view()
             }
-            None => view! { <span>An error occured</span> }.into_view(),
+            None => view! { <Toggle value=false on_change class name/> }.into_view(),
         },
         InputType::Select(ref options) => view! { <Select id name class value on_change disabled options=options.0.clone()/> }
         .into_view(),

--- a/crates/frontend/src/utils.rs
+++ b/crates/frontend/src/utils.rs
@@ -195,6 +195,10 @@ pub fn check_url_and_return_val(s: String) -> String {
 }
 
 pub enum ConfigType {
+    // Default config is not actually dead code, it's used
+    // but for some reason the compiler thinks it's dead code
+    // this gets rid of the warning
+    #[allow(dead_code)]
     DefaultConfig(DefaultConfig),
     Dimension(Dimension),
 }


### PR DESCRIPTION

## Problem
The default config input selection was doing the same thing as Input component

## Solution
Replace input with the new component to unify changes across frontend

P.S I used leptosfmt on default_config_form.rs only, so the diff may look large but most of them are formatting changes