### PR TITLE
feat: Use Common db model types in frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4111,6 +4111,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "strum_macros",
  "superposition_derives",
  "thiserror",
  "uuid",

--- a/crates/context_aware_config/Cargo.toml
+++ b/crates/context_aware_config/Cargo.toml
@@ -33,7 +33,6 @@ superposition_macros = { path = "../superposition_macros" }
 superposition_types = { path = "../superposition_types", features = [
     "result",
     "diesel_derives",
-    "server",
 ] }
 uuid = { workspace = true }
 

--- a/crates/context_aware_config/src/api/dimension/handlers.rs
+++ b/crates/context_aware_config/src/api/dimension/handlers.rs
@@ -14,7 +14,8 @@ use superposition_macros::{bad_argument, db_error, not_found, unexpected_error};
 use superposition_types::{
     cac::{
         models::Dimension,
-        schema::{dimensions, dimensions::dsl::*},
+        schema::dimensions::{self, dsl::*},
+        types::DimensionWithMandatory,
     },
     custom_query::PaginationParams,
     result as superposition, PaginatedResponse, TenantConfig, User,
@@ -28,7 +29,7 @@ use crate::{
     helpers::validate_jsonschema,
 };
 
-use super::types::{DeleteReq, DimensionName, DimensionWithMandatory, UpdateReq};
+use super::types::{DeleteReq, DimensionName, UpdateReq};
 
 pub fn endpoints() -> Scope {
     Scope::new("")

--- a/crates/context_aware_config/src/api/dimension/types.rs
+++ b/crates/context_aware_config/src/api/dimension/types.rs
@@ -1,8 +1,7 @@
-use chrono::{DateTime, NaiveDateTime, Utc};
 use derive_more::{AsRef, Deref, DerefMut, Into};
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer};
 use serde_json::Value;
-use superposition_types::{cac::models::Dimension, RegexEnum};
+use superposition_types::RegexEnum;
 
 #[derive(Debug, Deserialize)]
 pub struct CreateReq {
@@ -85,35 +84,6 @@ impl TryFrom<String> for DimensionName {
     type Error = String;
     fn try_from(value: String) -> Result<Self, Self::Error> {
         Ok(Self::validate_data(value)?)
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct DimensionWithMandatory {
-    pub dimension: String,
-    pub position: i32,
-    pub created_at: DateTime<Utc>,
-    pub created_by: String,
-    pub schema: Value,
-    pub function_name: Option<String>,
-    pub last_modified_at: NaiveDateTime,
-    pub last_modified_by: String,
-    pub mandatory: bool,
-}
-
-impl DimensionWithMandatory {
-    pub fn new(value: Dimension, mandatory: bool) -> Self {
-        DimensionWithMandatory {
-            dimension: value.dimension,
-            position: value.position,
-            created_at: value.created_at,
-            created_by: value.created_by,
-            schema: value.schema,
-            function_name: value.function_name,
-            last_modified_at: value.last_modified_at,
-            last_modified_by: value.last_modified_by,
-            mandatory,
-        }
     }
 }
 

--- a/crates/experimentation_client/Cargo.toml
+++ b/crates/experimentation_client/Cargo.toml
@@ -11,7 +11,9 @@ once_cell = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
-superposition_types = { path = "../superposition_types" }
+superposition_types = { path = "../superposition_types", features = [
+    "experimentation",
+] }
 tokio = { version = "1.29.1", features = ["full"] }
 
 [lib]

--- a/crates/experimentation_client/src/types.rs
+++ b/crates/experimentation_client/src/types.rs
@@ -2,28 +2,16 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use superposition_types::{Exp, Overridden, Overrides};
+use superposition_types::{
+    experimentation::models::{ExperimentStatusType, VariantType},
+    Exp, Overridden, Overrides,
+};
 
 #[derive(Clone, Debug)]
 pub struct Config {
     pub tenant: String,
     pub hostname: String,
     pub poll_frequency: u64,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
-#[serde(rename_all = "UPPERCASE")]
-pub(crate) enum ExperimentStatusType {
-    Created,
-    InProgress,
-    Concluded,
-}
-
-#[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]
-#[serde(rename_all = "UPPERCASE")]
-pub(crate) enum VariantType {
-    Control,
-    Experimental,
 }
 
 #[repr(C)]
@@ -56,10 +44,3 @@ pub struct Experiment {
 pub type Experiments = Vec<Experiment>;
 
 pub(crate) type ExperimentStore = HashMap<String, Experiment>;
-
-#[derive(Serialize, Deserialize, Default)]
-pub(crate) struct ListExperimentsResponse {
-    pub(crate) total_items: i64,
-    pub(crate) total_pages: i64,
-    pub(crate) data: Experiments,
-}

--- a/crates/experimentation_platform/src/api/experiments/types.rs
+++ b/crates/experimentation_platform/src/api/experiments/types.rs
@@ -72,13 +72,6 @@ impl From<Experiment> for ExperimentResponse {
     }
 }
 
-#[derive(Serialize)]
-pub struct ExperimentsResponse {
-    pub total_items: i64,
-    pub total_pages: i64,
-    pub data: Vec<ExperimentResponse>,
-}
-
 /********** Experiment Conclude Req Types **********/
 
 #[derive(Deserialize, Debug)]

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 anyhow = { workspace = true }
-cfg-if = {workspace = true }
+cfg-if = { workspace = true }
 chrono = { workspace = true }
 console_error_panic_hook = { version = "0.1", optional = true }
 derive_more = { workspace = true }
@@ -24,7 +24,9 @@ serde_json = { workspace = true }
 reqwest = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-superposition_types = { path = "../superposition_types", default-features = false }
+superposition_types = { path = "../superposition_types", features = [
+  "experimentation",
+], default-features = false }
 url = "2.5.0"
 wasm-bindgen = "=0.2.89"
 web-sys = { version = "0.3.64", features = [

--- a/crates/frontend/src/api.rs
+++ b/crates/frontend/src/api.rs
@@ -1,12 +1,15 @@
 use leptos::ServerFnError;
-use superposition_types::Config;
+use superposition_types::{
+    cac::{
+        models::{ConfigVersion, DefaultConfig, Function, TypeTemplate},
+        types::DimensionWithMandatory,
+    },
+    custom_query::PaginationParams,
+    Config, PaginatedResponse,
+};
 
 use crate::{
-    types::{
-        ConfigVersionListResponse, DefaultConfig, Dimension, ExperimentListFilters,
-        ExperimentResponse, FetchTypeTemplateResponse, FunctionResponse, ListFilters,
-        PaginatedResponse,
-    },
+    types::{ExperimentListFilters, ExperimentResponse},
     utils::{
         construct_request_headers, get_host, parse_json_response, request,
         use_host_server,
@@ -15,14 +18,14 @@ use crate::{
 
 // #[server(GetDimensions, "/fxn", "GetJson")]
 pub async fn fetch_dimensions(
-    filters: &ListFilters,
+    filters: &PaginationParams,
     tenant: String,
-) -> Result<PaginatedResponse<Dimension>, ServerFnError> {
+) -> Result<PaginatedResponse<DimensionWithMandatory>, ServerFnError> {
     let client = reqwest::Client::new();
     let host = use_host_server();
 
     let url = format!("{}/dimension?{}", host, filters.to_string());
-    let response: PaginatedResponse<Dimension> = client
+    let response: PaginatedResponse<DimensionWithMandatory> = client
         .get(url)
         .header("x-tenant", &tenant)
         .send()
@@ -37,7 +40,7 @@ pub async fn fetch_dimensions(
 
 // #[server(GetDefaultConfig, "/fxn", "GetJson")]
 pub async fn fetch_default_config(
-    filters: &ListFilters,
+    filters: &PaginationParams,
     tenant: String,
 ) -> Result<PaginatedResponse<DefaultConfig>, ServerFnError> {
     let client = reqwest::Client::new();
@@ -58,16 +61,14 @@ pub async fn fetch_default_config(
 }
 
 pub async fn fetch_snapshots(
+    filters: &PaginationParams,
     tenant: String,
-    page: i64,
-    count: i64,
-    all: bool,
-) -> Result<ConfigVersionListResponse, ServerFnError> {
+) -> Result<PaginatedResponse<ConfigVersion>, ServerFnError> {
     let client = reqwest::Client::new();
     let host = use_host_server();
 
-    let url = format!("{host}/config/versions?page={page}&count={count}&all={all}");
-    let response: ConfigVersionListResponse = client
+    let url = format!("{host}/config/versions?{}", filters.to_string());
+    let response: PaginatedResponse<ConfigVersion> = client
         .get(url)
         .header("x-tenant", tenant)
         .send()
@@ -109,7 +110,7 @@ pub async fn delete_context(
 
 pub async fn fetch_experiments(
     filters: &ExperimentListFilters,
-    pagination: &ListFilters,
+    pagination: &PaginationParams,
     tenant: String,
 ) -> Result<PaginatedResponse<ExperimentResponse>, ServerFnError> {
     let client = reqwest::Client::new();
@@ -140,14 +141,14 @@ pub async fn fetch_experiments(
 }
 
 pub async fn fetch_functions(
-    filters: ListFilters,
+    filters: &PaginationParams,
     tenant: String,
-) -> Result<PaginatedResponse<FunctionResponse>, ServerFnError> {
+) -> Result<PaginatedResponse<Function>, ServerFnError> {
     let client = reqwest::Client::new();
     let host = use_host_server();
 
     let url = format!("{}/function?{}", host, filters.to_string());
-    let response: PaginatedResponse<FunctionResponse> = client
+    let response: PaginatedResponse<Function> = client
         .get(url)
         .header("x-tenant", tenant)
         .send()
@@ -163,12 +164,12 @@ pub async fn fetch_functions(
 pub async fn fetch_function(
     function_name: String,
     tenant: String,
-) -> Result<FunctionResponse, ServerFnError> {
+) -> Result<Function, ServerFnError> {
     let client = reqwest::Client::new();
     let host = use_host_server();
 
     let url = format!("{}/function/{}", host, function_name);
-    let response: FunctionResponse = client
+    let response: Function = client
         .get(url)
         .header("x-tenant", tenant)
         .send()
@@ -257,13 +258,11 @@ pub async fn delete_dimension(name: String, tenant: String) -> Result<(), String
 }
 
 pub async fn fetch_types(
+    filters: &PaginationParams,
     tenant: String,
-    page: i64,
-    count: i64,
-    all: bool,
-) -> Result<FetchTypeTemplateResponse, ServerFnError> {
+) -> Result<PaginatedResponse<TypeTemplate>, ServerFnError> {
     let host = use_host_server();
-    let url = format!("{host}/types?page={page}&count={count}&all={all}");
+    let url = format!("{host}/types?{}", filters.to_string());
     let err_handler = |e: String| ServerFnError::new(e.to_string());
     let response = request::<()>(
         url,
@@ -273,7 +272,7 @@ pub async fn fetch_types(
     )
     .await
     .map_err(err_handler)?;
-    parse_json_response::<FetchTypeTemplateResponse>(response)
+    parse_json_response::<PaginatedResponse<TypeTemplate>>(response)
         .await
         .map_err(err_handler)
 }

--- a/crates/frontend/src/components/context_form.rs
+++ b/crates/frontend/src/components/context_form.rs
@@ -1,23 +1,25 @@
 pub mod utils;
+
 use std::collections::{HashMap, HashSet};
+
+use leptos::*;
+use serde_json::{Map, Value};
+use superposition_types::cac::types::DimensionWithMandatory;
+use web_sys::MouseEvent;
 
 use crate::components::{
     condition_pills::types::ConditionOperator,
     dropdown::{Dropdown, DropdownDirection},
     input_components::{BooleanToggle, EnumDropdown},
 };
-use crate::types::Dimension;
 use crate::utils::get_key_type;
-use leptos::*;
-use serde_json::{Map, Value};
-use web_sys::MouseEvent;
 
 use super::condition_pills::types::Condition;
 
 #[component]
 pub fn context_form<NF>(
     handle_change: NF,
-    dimensions: Vec<Dimension>,
+    dimensions: Vec<DimensionWithMandatory>,
     #[prop(default = false)] is_standalone: bool,
     context: Vec<Condition>,
     #[prop(default = String::new())] heading_sub_text: String,
@@ -68,7 +70,7 @@ where
     });
 
     let handle_select_dropdown_option =
-        Callback::new(move |selected_dimension: Dimension| {
+        Callback::new(move |selected_dimension: DimensionWithMandatory| {
             let dimension_name = selected_dimension.dimension;
             set_used_dimensions.update(|value: &mut HashSet<String>| {
                 value.insert(dimension_name.clone());
@@ -111,7 +113,7 @@ where
                                     .get_value()
                                     .into_iter()
                                     .map(|ele| (ele.dimension.clone(), ele))
-                                    .collect::<HashMap<String, Dimension>>();
+                                    .collect::<HashMap<String, DimensionWithMandatory>>();
                                 view! {
                                     <For
                                         each=move || {
@@ -438,7 +440,7 @@ where
                                             .filter(|dimension| {
                                                 !used_dimensions.get().contains(&dimension.dimension)
                                             })
-                                            .collect::<Vec<Dimension>>();
+                                            .collect::<Vec<DimensionWithMandatory>>();
                                         view! {
                                             <Dropdown
                                                 dropdown_icon="ri-add-line".to_string()

--- a/crates/frontend/src/components/context_form/utils.rs
+++ b/crates/frontend/src/components/context_form/utils.rs
@@ -1,18 +1,19 @@
+use anyhow::Result;
+use leptos::logging;
+use serde_json::{json, Map, Value};
+use superposition_types::cac::types::DimensionWithMandatory;
+
 use crate::{
     components::condition_pills::types::{Condition, ConditionOperator},
-    types::Dimension,
     utils::{
         construct_request_headers, get_config_value, get_host, parse_json_response,
         request, ConfigType,
     },
 };
-use anyhow::Result;
-use leptos::logging;
-use serde_json::{json, Map, Value};
 
 pub fn get_condition_schema(
     condition: &Condition,
-    dimensions: Vec<Dimension>,
+    dimensions: Vec<DimensionWithMandatory>,
 ) -> Result<Value, String> {
     let var = &condition.left_operand; // Dimension name
     let op = &condition.operator; // Operator type
@@ -180,7 +181,7 @@ pub fn get_condition_schema(
 
 pub fn construct_context(
     conditions: Vec<Condition>,
-    dimensions: Vec<Dimension>,
+    dimensions: Vec<DimensionWithMandatory>,
 ) -> Value {
     if conditions.is_empty() {
         json!({})
@@ -209,7 +210,7 @@ pub fn construct_context(
 pub fn construct_request_payload(
     overrides: Map<String, Value>,
     conditions: Vec<Condition>,
-    dimensions: Vec<Dimension>,
+    dimensions: Vec<DimensionWithMandatory>,
 ) -> Value {
     // Construct the override section
     let override_section: Map<String, Value> = overrides;
@@ -230,7 +231,7 @@ pub async fn create_context(
     tenant: String,
     overrides: Map<String, Value>,
     conditions: Vec<Condition>,
-    dimensions: Vec<Dimension>,
+    dimensions: Vec<DimensionWithMandatory>,
 ) -> Result<serde_json::Value, String> {
     let host = get_host();
     let url = format!("{host}/context");
@@ -250,7 +251,7 @@ pub async fn update_context(
     tenant: String,
     overrides: Map<String, Value>,
     conditions: Vec<Condition>,
-    dimensions: Vec<Dimension>,
+    dimensions: Vec<DimensionWithMandatory>,
 ) -> Result<serde_json::Value, String> {
     let host = get_host();
     let url = format!("{host}/context/overrides");

--- a/crates/frontend/src/components/dimension_form/utils.rs
+++ b/crates/frontend/src/components/dimension_form/utils.rs
@@ -1,8 +1,8 @@
+use superposition_types::cac::models::Dimension;
+
+use crate::utils::{construct_request_headers, get_host, parse_json_response, request};
+
 use super::types::{DimensionCreateReq, DimensionUpdateReq};
-use crate::{
-    types::Dimension,
-    utils::{construct_request_headers, get_host, parse_json_response, request},
-};
 
 pub async fn create_dimension(
     tenant: String,

--- a/crates/frontend/src/components/experiment_conclude_form.rs
+++ b/crates/frontend/src/components/experiment_conclude_form.rs
@@ -2,9 +2,11 @@ pub mod utils;
 
 use std::rc::Rc;
 
-use self::utils::conclude_experiment;
-use crate::types::{Experiment, Variant, VariantType};
 use leptos::*;
+use superposition_types::experimentation::models::{Variant, VariantType};
+use utils::conclude_experiment;
+
+use crate::types::Experiment;
 
 #[component]
 pub fn experiment_conclude_form<HS>(

--- a/crates/frontend/src/components/experiment_form.rs
+++ b/crates/frontend/src/components/experiment_form.rs
@@ -1,13 +1,18 @@
 pub mod types;
 pub mod utils;
 
-use self::utils::{create_experiment, update_experiment};
+use leptos::*;
+use superposition_types::{
+    cac::{models::DefaultConfig, types::DimensionWithMandatory},
+    experimentation::models::VariantType,
+};
+use utils::{create_experiment, update_experiment};
+use web_sys::MouseEvent;
+
 use crate::components::button::Button;
 use crate::components::context_form::ContextForm;
 use crate::components::variant_form::VariantForm;
-use crate::types::{DefaultConfig, Dimension, VariantFormT, VariantType};
-use leptos::*;
-use web_sys::MouseEvent;
+use crate::types::{VariantFormT, VariantFormTs};
 
 use super::condition_pills::types::Condition;
 
@@ -32,7 +37,7 @@ fn default_variants_for_form() -> Vec<(String, VariantFormT)> {
     ]
 }
 
-fn get_init_state(variants: &[VariantFormT]) -> Vec<(String, VariantFormT)> {
+fn get_init_state(variants: &VariantFormTs) -> Vec<(String, VariantFormT)> {
     let init_variants = if variants.is_empty() {
         default_variants_for_form()
     } else {
@@ -51,10 +56,10 @@ pub fn experiment_form<NF>(
     #[prop(default = String::new())] id: String,
     name: String,
     context: Vec<Condition>,
-    variants: Vec<VariantFormT>,
+    variants: VariantFormTs,
     handle_submit: NF,
     default_config: Vec<DefaultConfig>,
-    dimensions: Vec<Dimension>,
+    dimensions: Vec<DimensionWithMandatory>,
 ) -> impl IntoView
 where
     NF: Fn() + 'static + Clone,

--- a/crates/frontend/src/components/experiment_form/types.rs
+++ b/crates/frontend/src/components/experiment_form/types.rs
@@ -1,6 +1,8 @@
-use crate::types::{Variant, VariantFormT};
 use serde::Serialize;
 use serde_json::{Map, Value};
+use superposition_types::experimentation::models::Variant;
+
+use crate::types::VariantFormT;
 
 #[derive(Serialize)]
 pub struct ExperimentCreateRequest {
@@ -18,7 +20,7 @@ pub struct VariantUpdateRequest {
 
 impl From<VariantFormT> for VariantUpdateRequest {
     fn from(value: VariantFormT) -> Self {
-        VariantUpdateRequest {
+        Self {
             id: value.id,
             overrides: Map::from_iter(value.overrides),
         }

--- a/crates/frontend/src/components/experiment_form/utils.rs
+++ b/crates/frontend/src/components/experiment_form/utils.rs
@@ -1,9 +1,12 @@
-use super::types::{ExperimentCreateRequest, ExperimentUpdateRequest};
+use serde_json::Value;
+use superposition_types::cac::types::DimensionWithMandatory;
+
 use crate::components::condition_pills::types::Condition;
 use crate::components::context_form::utils::construct_context;
-use crate::types::{Dimension, VariantFormT};
+use crate::types::VariantFormT;
 use crate::utils::{construct_request_headers, get_host, parse_json_response, request};
-use serde_json::Value;
+
+use super::types::{ExperimentCreateRequest, ExperimentUpdateRequest};
 
 pub fn validate_experiment(experiment: &ExperimentCreateRequest) -> Result<bool, String> {
     if experiment.name.is_empty() {
@@ -17,7 +20,7 @@ pub async fn create_experiment(
     variants: Vec<VariantFormT>,
     name: String,
     tenant: String,
-    dimensions: Vec<Dimension>,
+    dimensions: Vec<DimensionWithMandatory>,
 ) -> Result<Value, String> {
     let payload = ExperimentCreateRequest {
         name,

--- a/crates/frontend/src/components/function_form/utils.rs
+++ b/crates/frontend/src/components/function_form/utils.rs
@@ -1,9 +1,12 @@
-use super::types::{FunctionCreateRequest, FunctionUpdateRequest};
+use serde_json::Value;
+use superposition_types::cac::models::Function;
+
 use crate::{
-    types::{FunctionResponse, FunctionTestResponse},
+    types::FunctionTestResponse,
     utils::{construct_request_headers, get_host, parse_json_response, request},
 };
-use serde_json::Value;
+
+use super::types::{FunctionCreateRequest, FunctionUpdateRequest};
 
 pub async fn create_function(
     function_name: String,
@@ -11,7 +14,7 @@ pub async fn create_function(
     runtime_version: String,
     description: String,
     tenant: String,
-) -> Result<FunctionResponse, String> {
+) -> Result<Function, String> {
     let payload = FunctionCreateRequest {
         function_name,
         function,
@@ -38,7 +41,7 @@ pub async fn update_function(
     runtime_version: String,
     description: String,
     tenant: String,
-) -> Result<FunctionResponse, String> {
+) -> Result<Function, String> {
     let payload = FunctionUpdateRequest {
         function,
         runtime_version,

--- a/crates/frontend/src/components/override_form.rs
+++ b/crates/frontend/src/components/override_form.rs
@@ -1,16 +1,17 @@
 use std::collections::{HashMap, HashSet};
 
+use leptos::*;
+use serde_json::Value;
+use superposition_types::cac::models::DefaultConfig;
+use web_sys::MouseEvent;
+
 use crate::{
     components::{
         dropdown::{Dropdown, DropdownDirection},
         input::{Input, InputType},
     },
     schema::{EnumVariants, SchemaType},
-    types::DefaultConfig,
 };
-use leptos::*;
-use serde_json::Value;
-use web_sys::MouseEvent;
 
 #[component]
 fn type_badge(r#type: Option<SchemaType>) -> impl IntoView {

--- a/crates/frontend/src/components/variant_form.rs
+++ b/crates/frontend/src/components/variant_form.rs
@@ -3,6 +3,9 @@ use std::collections::{HashMap, HashSet};
 use chrono::Local;
 use leptos::*;
 use serde_json::Value;
+use superposition_types::{
+    cac::models::DefaultConfig, experimentation::models::VariantType,
+};
 
 use crate::{
     components::{
@@ -10,7 +13,7 @@ use crate::{
         override_form::OverrideForm,
     },
     schema::SchemaType,
-    types::{DefaultConfig, VariantFormT, VariantType},
+    types::VariantFormT,
 };
 
 fn get_override_keys_from_variants(

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -1,35 +1,31 @@
 pub mod utils;
 
+use chrono::{prelude::Utc, TimeZone};
 use futures::join;
 use leptos::*;
-
-use chrono::{prelude::Utc, TimeZone};
 use serde::{Deserialize, Serialize};
-use superposition_types::SortBy;
+use serde_json::{json, Map, Value};
+use superposition_types::{
+    cac::{models::DefaultConfig, types::DimensionWithMandatory},
+    custom_query::PaginationParams,
+    PaginatedResponse, SortBy,
+};
+use utils::experiment_table_columns;
 
+use crate::api::{fetch_default_config, fetch_dimensions, fetch_experiments};
 use crate::components::drawer::{close_drawer, Drawer, DrawerBtn};
 use crate::components::skeleton::Skeleton;
 use crate::components::table::types::TablePaginationProps;
 use crate::components::{experiment_form::ExperimentForm, stat::Stat, table::Table};
-
 use crate::providers::condition_collapse_provider::ConditionCollapseProvider;
 use crate::providers::editor_provider::EditorProvider;
-use crate::types::{
-    ExperimentListFilters, ExperimentResponse, ListFilters, PaginatedResponse,
-};
+use crate::types::{ExperimentListFilters, ExperimentResponse, VariantFormTs};
 use crate::utils::update_page_direction;
 
-use self::utils::experiment_table_columns;
-use crate::{
-    api::{fetch_default_config, fetch_dimensions, fetch_experiments},
-    types::{DefaultConfig, Dimension},
-};
-use serde_json::{json, Map, Value};
-
-#[derive(Serialize, Deserialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
 struct CombinedResource {
     experiments: PaginatedResponse<ExperimentResponse>,
-    dimensions: Vec<Dimension>,
+    dimensions: Vec<DimensionWithMandatory>,
     default_config: Vec<DefaultConfig>,
 }
 
@@ -49,16 +45,13 @@ pub fn experiment_list() -> impl IntoView {
         sort_by: Some(SortBy::Desc),
     });
 
-    let (pagination_filters_rs, pagination_filters_ws) = create_signal(ListFilters {
-        page: Some(1),
-        count: Some(10),
-        all: None,
-    });
+    let (pagination_filters_rs, pagination_filters_ws) =
+        create_signal(PaginationParams::default_request());
 
     let (reset_exp_form, set_exp_form) = create_signal(0);
 
     let combined_resource: Resource<
-        (String, ExperimentListFilters, ListFilters),
+        (String, ExperimentListFilters, PaginationParams),
         CombinedResource,
     > = create_blocking_resource(
         move || {
@@ -84,16 +77,14 @@ pub fn experiment_list() -> impl IntoView {
                 join!(experiments_future, dimensions_future, config_future);
             // Construct the combined result, handling errors as needed
             CombinedResource {
-                experiments: experiments_result.unwrap_or(PaginatedResponse::default()),
+                experiments: experiments_result.unwrap_or_default(),
                 dimensions: dimensions_result
-                    .unwrap_or(PaginatedResponse::default())
+                    .unwrap_or_default()
                     .data
                     .into_iter()
                     .filter(|d| d.dimension != "variantIds")
                     .collect(),
-                default_config: config_result
-                    .unwrap_or(PaginatedResponse::default())
-                    .data,
+                default_config: config_result.unwrap_or_default().data,
             }
         },
     );
@@ -208,22 +199,9 @@ pub fn experiment_list() -> impl IntoView {
                 </div>
 
                 {move || {
-                    let dim = combined_resource
+                    let CombinedResource {dimensions : dim, default_config : def_conf, experiments: _ } = combined_resource
                         .get()
-                        .unwrap_or(CombinedResource {
-                            experiments: PaginatedResponse::default(),
-                            dimensions: vec![],
-                            default_config: vec![],
-                        })
-                        .dimensions;
-                    let def_conf = combined_resource
-                        .get()
-                        .unwrap_or(CombinedResource {
-                            experiments: PaginatedResponse::default(),
-                            dimensions: vec![],
-                            default_config: vec![],
-                        })
-                        .default_config;
+                        .unwrap_or_default();
                     let _ = reset_exp_form.get();
                     view! {
                         <Drawer
@@ -239,7 +217,7 @@ pub fn experiment_list() -> impl IntoView {
                                 <ExperimentForm
                                     name="".to_string()
                                     context=vec![]
-                                    variants=vec![]
+                                    variants=VariantFormTs::default()
                                     dimensions=dim.clone()
                                     default_config=def_conf.clone()
                                     handle_submit=handle_submit_experiment_form

--- a/crates/frontend/src/pages/function.rs
+++ b/crates/frontend/src/pages/function.rs
@@ -2,31 +2,24 @@ pub mod function_create;
 pub mod function_list;
 pub mod utils;
 
+use std::time::Duration;
+
 use leptos::*;
 use leptos_router::use_params_map;
-
-use crate::{
-    components::skeleton::{Skeleton, SkeletonVariant},
-    types::FunctionResponse,
-};
-
-use self::utils::publish_function;
-
-use crate::api::fetch_function;
-use std::time::Duration;
+use serde::{Deserialize, Serialize};
 use strum::EnumProperty;
 use strum_macros::Display;
-use web_sys::MouseEvent;
+use superposition_types::cac::models::Function;
+use utils::publish_function;
+use web_sys::{HtmlButtonElement, MouseEvent};
 
-use crate::utils::get_element_by_id;
-use web_sys::HtmlButtonElement;
-
+use crate::api::fetch_function;
 use crate::components::{
     function_form::{FunctionEditor, TestForm},
     monaco_editor::MonacoEditor,
+    skeleton::{Skeleton, SkeletonVariant},
 };
-
-use serde::{Deserialize, Serialize};
+use crate::utils::get_element_by_id;
 
 #[derive(Clone, Debug, Copy, Display, strum_macros::EnumProperty, PartialEq)]
 enum CodeTab {
@@ -38,7 +31,7 @@ enum CodeTab {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 struct CombinedResource {
-    function: Option<FunctionResponse>,
+    function: Option<Function>,
 }
 
 // TODO: Just rewrite this file and everything related to functions

--- a/crates/frontend/src/pages/function/function_create.rs
+++ b/crates/frontend/src/pages/function/function_create.rs
@@ -1,12 +1,13 @@
-use crate::components::function_form::FunctionEditor;
-use crate::types::FunctionResponse;
 use leptos::*;
 use leptos_router::use_navigate;
 use serde::{Deserialize, Serialize};
+use superposition_types::cac::models::Function;
+
+use crate::components::function_form::FunctionEditor;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 struct CombinedResource {
-    function: Option<FunctionResponse>,
+    function: Option<Function>,
 }
 
 #[component]

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -5,27 +5,23 @@ use leptos::*;
 use serde_json::{Map, Value};
 use strum::EnumProperty;
 use strum_macros::Display;
-use superposition_types::Config;
+use superposition_types::{custom_query::PaginationParams, Config};
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlButtonElement, HtmlSpanElement, MouseEvent};
 
 use crate::components::condition_pills::types::Conditions;
+use crate::components::condition_pills::{
+    types::{Condition, ConditionOperator},
+    Condition as ConditionComponent,
+};
 use crate::components::skeleton::{Skeleton, SkeletonVariant};
 use crate::providers::condition_collapse_provider::ConditionCollapseProvider;
-use crate::types::ListFilters;
 use crate::{
     api::{fetch_config, fetch_dimensions},
     components::{
         button::Button, context_form::ContextForm, dropdown::DropdownDirection,
     },
     utils::{check_url_and_return_val, get_element_by_id, get_host},
-};
-use crate::{
-    components::condition_pills::{
-        types::{Condition, ConditionOperator},
-        Condition as ConditionComponent,
-    },
-    types::PaginatedResponse,
 };
 
 #[derive(Clone, Debug, Copy, Display, strum_macros::EnumProperty, PartialEq)]
@@ -185,19 +181,9 @@ pub fn home() -> impl IntoView {
     let dimension_resource = create_resource(
         move || tenant_rs.get(),
         |tenant| async {
-            match fetch_dimensions(
-                &ListFilters {
-                    page: None,
-                    count: None,
-                    all: Some(true),
-                },
-                tenant,
-            )
-            .await
-            {
-                Ok(data) => data,
-                Err(_) => PaginatedResponse::default(),
-            }
+            fetch_dimensions(&PaginationParams::all_entries(), tenant)
+                .await
+                .unwrap_or_default()
         },
     );
 
@@ -401,7 +387,7 @@ pub fn home() -> impl IntoView {
                                                 <ContextForm
                                                     dimensions=dimension
                                                         .to_owned()
-                                                        .unwrap_or(PaginatedResponse::default())
+                                                        .unwrap_or_default()
                                                         .data
                                                     context=vec![]
                                                     heading_sub_text="Query your configs".to_string()

--- a/crates/frontend/src/utils.rs
+++ b/crates/frontend/src/utils.rs
@@ -1,18 +1,19 @@
-use std::env;
+use std::{env, str::FromStr};
 
-use crate::{
-    components::alert::AlertType,
-    providers::alert_provider::enqueue_alert,
-    types::{DefaultConfig, Dimension, Envs, ErrorResponse},
-};
 use cfg_if::cfg_if;
 use leptos::*;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use serde::de::DeserializeOwned;
 use serde_json::{Map, Value};
-use std::str::FromStr;
+use superposition_types::cac::{models::DefaultConfig, types::DimensionWithMandatory};
 use url::Url;
 use wasm_bindgen::JsCast;
+
+use crate::{
+    components::alert::AlertType,
+    providers::alert_provider::enqueue_alert,
+    types::{Envs, ErrorResponse},
+};
 
 #[allow(dead_code)]
 pub fn modal_action(name: &str, action: &str) {
@@ -200,7 +201,7 @@ pub enum ConfigType {
     // this gets rid of the warning
     #[allow(dead_code)]
     DefaultConfig(DefaultConfig),
-    Dimension(Dimension),
+    Dimension(DimensionWithMandatory),
 }
 
 #[derive(Clone, Debug)]

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -11,8 +11,10 @@ anyhow = { workspace = true }
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 aws-sdk-kms = { version = "1.38.0" }
 base64 = { workspace = true }
+chrono = { workspace = true }
 derive_more = { workspace = true }
 diesel = { workspace = true }
+fred = { workspace = true, optional = true }
 futures-util = "0.3.28"
 jsonschema = { workspace = true }
 log = { workspace = true }
@@ -25,8 +27,6 @@ serde_json = { workspace = true }
 strum_macros = { workspace = true }
 superposition_types = { path = "../superposition_types", features = ["result"] }
 urlencoding = "~2.1.2"
-fred = { workspace = true, optional = true }
-chrono = { workspace = true }
 
 [features]
 high-performance-mode = ["dep:fred"]

--- a/crates/superposition_types/Cargo.toml
+++ b/crates/superposition_types/Cargo.toml
@@ -21,6 +21,7 @@ log = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+strum_macros = { workspace = true, optional = true }
 superposition_derives = { path = "../superposition_derives", optional = true }
 thiserror = { version = "1.0.57", optional = true }
 uuid = { workspace = true }
@@ -35,7 +36,7 @@ diesel_derives = [
 disable_db_data_validation = []
 result = ["dep:diesel", "dep:anyhow", "dep:thiserror", "dep:actix-web"]
 server = ["dep:actix-web"]
-experimentation = []
+experimentation = ["dep:strum_macros"]
 
 [lints]
 workspace = true

--- a/crates/superposition_types/src/cac.rs
+++ b/crates/superposition_types/src/cac.rs
@@ -1,3 +1,4 @@
 pub mod models;
 #[cfg(feature = "diesel_derives")]
 pub mod schema;
+pub mod types;

--- a/crates/superposition_types/src/cac/models.rs
+++ b/crates/superposition_types/src/cac/models.rs
@@ -2,7 +2,7 @@ use bigdecimal::BigDecimal;
 use chrono::{offset::Utc, DateTime, NaiveDateTime};
 #[cfg(feature = "diesel_derives")]
 use diesel::{AsChangeset, Insertable, Queryable, Selectable};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
 use crate::{Cac, Condition, Contextual, Overridden, Overrides};
@@ -45,7 +45,7 @@ impl Overridden<Cac<Overrides>> for Context {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "diesel_derives",
     derive(Queryable, Selectable, Insertable, AsChangeset)
@@ -64,7 +64,7 @@ pub struct Dimension {
     pub position: i32,
 }
 
-#[derive(Serialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(
     feature = "diesel_derives",
     derive(Queryable, Selectable, Insertable, AsChangeset)
@@ -83,7 +83,7 @@ pub struct DefaultConfig {
     pub last_modified_by: String,
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(
     feature = "diesel_derives",
     derive(Queryable, Selectable, Insertable, AsChangeset)
@@ -121,7 +121,7 @@ pub struct EventLog {
     pub query: String,
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(feature = "diesel_derives", derive(Queryable, Selectable, Insertable))]
 #[cfg_attr(feature = "diesel_derives", diesel(check_for_backend(diesel::pg::Pg)))]
 #[cfg_attr(feature = "diesel_derives", diesel(primary_key(id)))]
@@ -133,15 +133,14 @@ pub struct ConfigVersion {
     pub created_at: NaiveDateTime,
 }
 
-#[derive(Serialize, Clone, Debug)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 #[cfg_attr(
     feature = "diesel_derives",
     derive(Queryable, Selectable, Insertable, AsChangeset)
 )]
 #[cfg_attr(feature = "diesel_derives", diesel(check_for_backend(diesel::pg::Pg)))]
-#[cfg_attr(feature = "diesel_derives", diesel(table_name = type_templates))]
 #[cfg_attr(feature = "diesel_derives", diesel(primary_key(type_name)))]
-pub struct TypeTemplates {
+pub struct TypeTemplate {
     pub type_name: String,
     pub type_schema: Value,
     pub created_by: String,

--- a/crates/superposition_types/src/cac/types.rs
+++ b/crates/superposition_types/src/cac/types.rs
@@ -1,0 +1,34 @@
+use chrono::{offset::Utc, DateTime, NaiveDateTime};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use super::models::Dimension;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DimensionWithMandatory {
+    pub dimension: String,
+    pub position: i32,
+    pub created_at: DateTime<Utc>,
+    pub created_by: String,
+    pub schema: Value,
+    pub function_name: Option<String>,
+    pub last_modified_at: NaiveDateTime,
+    pub last_modified_by: String,
+    pub mandatory: bool,
+}
+
+impl DimensionWithMandatory {
+    pub fn new(value: Dimension, mandatory: bool) -> Self {
+        Self {
+            dimension: value.dimension,
+            position: value.position,
+            created_at: value.created_at,
+            created_by: value.created_by,
+            schema: value.schema,
+            function_name: value.function_name,
+            last_modified_at: value.last_modified_at,
+            last_modified_by: value.last_modified_by,
+            mandatory,
+        }
+    }
+}

--- a/crates/superposition_types/src/experimentation/models.rs
+++ b/crates/superposition_types/src/experimentation/models.rs
@@ -14,7 +14,11 @@ use crate::{Condition, Exp, Overrides};
 #[cfg(feature = "diesel_derives")]
 use super::schema::*;
 
-#[derive(Debug, Clone, Copy, PartialEq, Deserialize, Serialize)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Deserialize, Serialize, strum_macros::Display,
+)]
+#[serde(rename_all = "UPPERCASE")]
+#[strum(serialize_all = "UPPERCASE")]
 #[cfg_attr(
     feature = "diesel_derives",
     derive(diesel_derive_enum::DbEnum, QueryId)
@@ -30,7 +34,8 @@ pub enum ExperimentStatusType {
     INPROGRESS,
 }
 
-#[derive(Deserialize, Serialize, Clone, PartialEq, Debug)]
+#[derive(Deserialize, Serialize, Clone, PartialEq, Debug, strum_macros::Display)]
+#[strum(serialize_all = "UPPERCASE")]
 pub enum VariantType {
     CONTROL,
     EXPERIMENTAL,

--- a/crates/superposition_types/src/lib.rs
+++ b/crates/superposition_types/src/lib.rs
@@ -2,7 +2,6 @@
 pub mod cac;
 mod config;
 mod contextual;
-#[cfg(feature = "server")]
 pub mod custom_query;
 #[cfg(feature = "experimentation")]
 pub mod experimentation;
@@ -190,6 +189,16 @@ pub struct PaginatedResponse<T> {
     pub total_pages: i64,
     pub total_items: i64,
     pub data: Vec<T>,
+}
+
+impl<T> Default for PaginatedResponse<T> {
+    fn default() -> Self {
+        Self {
+            total_pages: 0,
+            total_items: 0,
+            data: Vec::new(),
+        }
+    }
 }
 
 #[derive(


### PR DESCRIPTION
## Problem
Types redefined in `frontend` crate

## Solution
Remove the repeated definitions from `frontend` crate and re-use types defined in `superposition_types`

### Continuation for this [PR](https://github.com/juspay/superposition/pull/286)