### PR TITLE
fix: Filter config by prefix

### DIFF
--- a/crates/context_aware_config/src/api/config/helpers.rs
+++ b/crates/context_aware_config/src/api/config/helpers.rs
@@ -1,5 +1,4 @@
 use serde_json::{Map, Value};
-use superposition_macros::unexpected_error;
 use superposition_types::{result as superposition, Config};
 
 pub fn apply_prefix_filter_to_config(
@@ -10,12 +9,7 @@ pub fn apply_prefix_filter_to_config(
         .get("prefix")
         .and_then(|prefix| prefix.as_str())
     {
-        config = config
-            .try_filter_by_prefix(&prefix.split(',').map(String::from).collect())
-            .map_err(|err| {
-                log::error!("config.try_filter_by_prefix error : {err}");
-                unexpected_error!(err)
-            })?;
+        config = config.filter_by_prefix(&prefix.split(',').map(String::from).collect());
     }
 
     query_params_map.remove("prefix");

--- a/crates/superposition_types/src/config.rs
+++ b/crates/superposition_types/src/config.rs
@@ -121,6 +121,7 @@ impl_try_from_map!(Cac, Condition, Condition::validate_data_for_cac);
 impl_try_from_map!(Exp, Condition, Condition::validate_data_for_exp);
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Context {
     pub id: String,
     pub condition: Condition,
@@ -136,6 +137,7 @@ impl Contextual for Context {
 
 #[repr(C)]
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[cfg_attr(test, derive(PartialEq))]
 pub struct Config {
     pub contexts: Vec<Context>,
     pub overrides: HashMap<String, Overrides>,
@@ -202,5 +204,389 @@ impl Config {
             overrides: filtered_overrides,
             default_configs: filtered_default_config,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::{HashMap, HashSet};
+
+    use serde_json::{from_value, json, Map, Number, Value};
+
+    use super::Config;
+
+    fn get_config() -> Config {
+        let config_json = json!({
+            "contexts": [
+                {
+                    "id": "40c2564c114e1a2036bc6ce0e730289d05e117b051f2d286d6e7c68960f3bc7d",
+                    "condition": {
+                        "==": [
+                            {
+                                "var": "test3"
+                            },
+                            true
+                        ]
+                    },
+                    "priority": 1,
+                    "override_with_keys": [
+                        "0e72cf409a9eba53446dc858191751accf9f8ad3e6195413933145a497feb0ef"
+                    ]
+                },
+                {
+                    "id": "691ed369369ac3facdd07e5dd388e07ed682a7e212a04b7bcd0186e6f2d0d097",
+                    "condition": {
+                        "==": [
+                            {
+                                "var": "test2"
+                            },
+                            123
+                        ]
+                    },
+                    "priority": 2,
+                    "override_with_keys": [
+                        "2b96b6e8c6475d40d0dc92a05360828a304b9c2ed58abbe03958b178b431a5f9"
+                    ]
+                },
+                {
+                    "id": "9fbf3b9fa10caaaf31f6003cbd20ed36d40efe73b5c6b238288c0a96e6933500",
+                    "condition": {
+                        "and": [
+                            {
+                                "==": [
+                                    {
+                                        "var": "test3"
+                                    },
+                                    false
+                                ]
+                            },
+                            {
+                                "==": [
+                                    {
+                                        "var": "test"
+                                    },
+                                    "test"
+                                ]
+                            }
+                        ]
+                    },
+                    "priority": 3,
+                    "override_with_keys": [
+                        "e2fa5b38c3a1448cf0e27f9d555fdb8964a686d8ae41b70b55e6ee30359b87c8"
+                    ]
+                }
+            ],
+            "overrides": {
+                "0e72cf409a9eba53446dc858191751accf9f8ad3e6195413933145a497feb0ef": {
+                    "test.test1": 5,
+                    "test2.test": "testval"
+                },
+                "2b96b6e8c6475d40d0dc92a05360828a304b9c2ed58abbe03958b178b431a5f9": {
+                    "test2.key": true,
+                    "test2.test": "value"
+                },
+                "e2fa5b38c3a1448cf0e27f9d555fdb8964a686d8ae41b70b55e6ee30359b87c8": {
+                    "key1": true
+                }
+            },
+            "default_configs": {
+                "key1": false,
+                "test.test.test1": 1,
+                "test.test1": 12,
+                "test2.key": false,
+                "test2.test": "def_val"
+            }
+        });
+
+        from_value(config_json).unwrap()
+    }
+
+    fn get_dimension_filtered_config1() -> Config {
+        let config_json = json!({
+            "contexts": [
+                {
+                    "id": "40c2564c114e1a2036bc6ce0e730289d05e117b051f2d286d6e7c68960f3bc7d",
+                    "condition": {
+                        "==": [
+                            {
+                                "var": "test3"
+                            },
+                            true
+                        ]
+                    },
+                    "priority": 1,
+                    "override_with_keys": [
+                        "0e72cf409a9eba53446dc858191751accf9f8ad3e6195413933145a497feb0ef"
+                    ]
+                },
+                {
+                    "id": "691ed369369ac3facdd07e5dd388e07ed682a7e212a04b7bcd0186e6f2d0d097",
+                    "condition": {
+                        "==": [
+                            {
+                                "var": "test2"
+                            },
+                            123
+                        ]
+                    },
+                    "priority": 2,
+                    "override_with_keys": [
+                        "2b96b6e8c6475d40d0dc92a05360828a304b9c2ed58abbe03958b178b431a5f9"
+                    ]
+                }
+            ],
+            "overrides": {
+                "2b96b6e8c6475d40d0dc92a05360828a304b9c2ed58abbe03958b178b431a5f9": {
+                    "test2.key": true,
+                    "test2.test": "value"
+                },
+                "0e72cf409a9eba53446dc858191751accf9f8ad3e6195413933145a497feb0ef": {
+                    "test.test1": 5,
+                    "test2.test": "testval"
+                }
+            },
+            "default_configs": {
+                "key1": false,
+                "test.test.test1": 1,
+                "test.test1": 12,
+                "test2.key": false,
+                "test2.test": "def_val"
+            }
+        });
+
+        from_value(config_json).unwrap()
+    }
+
+    fn get_dimension_filtered_config2() -> Config {
+        let config_json = json!({
+            "contexts": [
+                {
+                    "id": "691ed369369ac3facdd07e5dd388e07ed682a7e212a04b7bcd0186e6f2d0d097",
+                    "condition": {
+                        "==": [
+                            {
+                                "var": "test2"
+                            },
+                            123
+                        ]
+                    },
+                    "priority": 2,
+                    "override_with_keys": [
+                        "2b96b6e8c6475d40d0dc92a05360828a304b9c2ed58abbe03958b178b431a5f9"
+                    ]
+                }
+            ],
+            "overrides": {
+                "2b96b6e8c6475d40d0dc92a05360828a304b9c2ed58abbe03958b178b431a5f9": {
+                    "test2.key": true,
+                    "test2.test": "value"
+                }
+            },
+            "default_configs": {
+                "key1": false,
+                "test.test.test1": 1,
+                "test.test1": 12,
+                "test2.key": false,
+                "test2.test": "def_val"
+            }
+        });
+
+        from_value(config_json).unwrap()
+    }
+
+    fn get_dimension_filtered_config3() -> Config {
+        let config_json = json!(  {
+            "contexts": [],
+            "overrides": {},
+            "default_configs": {
+                "key1": false,
+                "test.test.test1": 1,
+                "test.test1": 12,
+                "test2.key": false,
+                "test2.test": "def_val"
+            }
+        });
+
+        from_value(config_json).unwrap()
+    }
+
+    fn get_prefix_filtered_config1() -> Config {
+        let config_json = json!({
+            "contexts": [
+                {
+                    "id": "40c2564c114e1a2036bc6ce0e730289d05e117b051f2d286d6e7c68960f3bc7d",
+                    "condition": {
+                        "==": [
+                            {
+                                "var": "test3"
+                            },
+                            true
+                        ]
+                    },
+                    "priority": 1,
+                    "override_with_keys": [
+                        "0e72cf409a9eba53446dc858191751accf9f8ad3e6195413933145a497feb0ef"
+                    ]
+                }
+            ],
+            "overrides": {
+                "0e72cf409a9eba53446dc858191751accf9f8ad3e6195413933145a497feb0ef": {
+                    "test.test1": 5
+                }
+            },
+            "default_configs": {
+                "test.test.test1": 1,
+                "test.test1": 12
+            }
+        });
+        from_value(config_json).unwrap()
+    }
+
+    fn get_prefix_filtered_config2() -> Config {
+        let config_json = json!({
+            "contexts": [
+                {
+                    "id": "40c2564c114e1a2036bc6ce0e730289d05e117b051f2d286d6e7c68960f3bc7d",
+                    "condition": {
+                        "==": [
+                            {
+                                "var": "test3"
+                            },
+                            true
+                        ]
+                    },
+                    "priority": 1,
+                    "override_with_keys": [
+                        "0e72cf409a9eba53446dc858191751accf9f8ad3e6195413933145a497feb0ef"
+                    ]
+                },
+                {
+                    "id": "691ed369369ac3facdd07e5dd388e07ed682a7e212a04b7bcd0186e6f2d0d097",
+                    "condition": {
+                        "==": [
+                            {
+                                "var": "test2"
+                            },
+                            123
+                        ]
+                    },
+                    "priority": 2,
+                    "override_with_keys": [
+                        "2b96b6e8c6475d40d0dc92a05360828a304b9c2ed58abbe03958b178b431a5f9"
+                    ]
+                }
+            ],
+            "overrides": {
+                "2b96b6e8c6475d40d0dc92a05360828a304b9c2ed58abbe03958b178b431a5f9": {
+                    "test2.key": true,
+                    "test2.test": "value"
+                },
+                "0e72cf409a9eba53446dc858191751accf9f8ad3e6195413933145a497feb0ef": {
+                    "test.test1": 5,
+                    "test2.test": "testval"
+                }
+            },
+            "default_configs": {
+                "test.test.test1": 1,
+                "test.test1": 12,
+                "test2.key": false,
+                "test2.test": "def_val"
+            }
+        });
+        from_value(config_json).unwrap()
+    }
+
+    #[test]
+    fn filter_by_dimensions() {
+        let config = get_config();
+
+        let dimension_data =
+            Map::from_iter(vec![(String::from("test3"), Value::Bool(true))].into_iter());
+
+        assert_eq!(
+            config.filter_by_dimensions(&dimension_data),
+            get_dimension_filtered_config1()
+        );
+
+        let dimension_data = Map::from_iter(
+            vec![
+                (String::from("test3"), Value::Bool(false)),
+                (String::from("test"), Value::String(String::from("key"))),
+            ]
+            .into_iter(),
+        );
+
+        assert_eq!(
+            config.filter_by_dimensions(&dimension_data),
+            get_dimension_filtered_config2()
+        );
+
+        let dimension_data = Map::from_iter(
+            vec![
+                (String::from("test3"), Value::Bool(false)),
+                (String::from("test"), Value::String(String::from("key"))),
+                (String::from("test2"), Value::Number(Number::from(12))),
+            ]
+            .into_iter(),
+        );
+
+        assert_eq!(
+            config.filter_by_dimensions(&dimension_data),
+            get_dimension_filtered_config3()
+        );
+    }
+
+    #[test]
+    fn filter_default_by_prefix() {
+        let config = get_config();
+
+        let prefix_list = HashSet::from_iter(vec![String::from("test.")].into_iter());
+
+        assert_eq!(
+            config.filter_default_by_prefix(&prefix_list),
+            json!({
+                "test.test.test1": 1,
+                "test.test1": 12,
+            })
+            .as_object()
+            .unwrap()
+            .clone()
+        );
+
+        let prefix_list = HashSet::from_iter(vec![String::from("test3")].into_iter());
+
+        assert_eq!(config.filter_default_by_prefix(&prefix_list), Map::new());
+    }
+
+    #[test]
+    fn filter_by_prefix() {
+        let config = get_config();
+
+        let prefix_list = HashSet::from_iter(vec![String::from("test.")].into_iter());
+
+        assert_eq!(
+            config.filter_by_prefix(&prefix_list),
+            get_prefix_filtered_config1()
+        );
+
+        let prefix_list = HashSet::from_iter(
+            vec![String::from("test."), String::from("test2.")].into_iter(),
+        );
+
+        assert_eq!(
+            config.filter_by_prefix(&prefix_list),
+            get_prefix_filtered_config2()
+        );
+
+        let prefix_list = HashSet::from_iter(vec![String::from("abcd")].into_iter());
+
+        assert_eq!(
+            config.filter_by_prefix(&prefix_list),
+            Config {
+                contexts: Vec::new(),
+                overrides: HashMap::new(),
+                default_configs: Map::new(),
+            }
+        );
     }
 }

--- a/crates/superposition_types/src/config.rs
+++ b/crates/superposition_types/src/config.rs
@@ -208,14 +208,14 @@ impl Config {
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use std::collections::{HashMap, HashSet};
 
     use serde_json::{from_value, json, Map, Number, Value};
 
     use super::Config;
 
-    fn get_config() -> Config {
+    pub(crate) fn get_config() -> Config {
         let config_json = json!({
             "contexts": [
                 {
@@ -301,7 +301,32 @@ mod tests {
         from_value(config_json).unwrap()
     }
 
-    fn get_dimension_filtered_config1() -> Config {
+    pub(crate) fn get_dimension_data1() -> Map<String, Value> {
+        Map::from_iter(vec![(String::from("test3"), Value::Bool(true))].into_iter())
+    }
+
+    pub(crate) fn get_dimension_data2() -> Map<String, Value> {
+        Map::from_iter(
+            vec![
+                (String::from("test3"), Value::Bool(false)),
+                (String::from("test"), Value::String(String::from("key"))),
+            ]
+            .into_iter(),
+        )
+    }
+
+    pub(crate) fn get_dimension_data3() -> Map<String, Value> {
+        Map::from_iter(
+            vec![
+                (String::from("test3"), Value::Bool(false)),
+                (String::from("test"), Value::String(String::from("key"))),
+                (String::from("test2"), Value::Number(Number::from(12))),
+            ]
+            .into_iter(),
+        )
+    }
+
+    pub(crate) fn get_dimension_filtered_config1() -> Config {
         let config_json = json!({
             "contexts": [
                 {
@@ -357,7 +382,7 @@ mod tests {
         from_value(config_json).unwrap()
     }
 
-    fn get_dimension_filtered_config2() -> Config {
+    pub(crate) fn get_dimension_filtered_config2() -> Config {
         let config_json = json!({
             "contexts": [
                 {
@@ -394,7 +419,7 @@ mod tests {
         from_value(config_json).unwrap()
     }
 
-    fn get_dimension_filtered_config3() -> Config {
+    pub(crate) fn get_dimension_filtered_config3() -> Config {
         let config_json = json!(  {
             "contexts": [],
             "overrides": {},
@@ -410,7 +435,7 @@ mod tests {
         from_value(config_json).unwrap()
     }
 
-    fn get_prefix_filtered_config1() -> Config {
+    pub(crate) fn get_prefix_filtered_config1() -> Config {
         let config_json = json!({
             "contexts": [
                 {
@@ -442,7 +467,7 @@ mod tests {
         from_value(config_json).unwrap()
     }
 
-    fn get_prefix_filtered_config2() -> Config {
+    pub(crate) fn get_prefix_filtered_config2() -> Config {
         let config_json = json!({
             "contexts": [
                 {
@@ -500,38 +525,18 @@ mod tests {
     fn filter_by_dimensions() {
         let config = get_config();
 
-        let dimension_data =
-            Map::from_iter(vec![(String::from("test3"), Value::Bool(true))].into_iter());
-
         assert_eq!(
-            config.filter_by_dimensions(&dimension_data),
+            config.filter_by_dimensions(&get_dimension_data1()),
             get_dimension_filtered_config1()
         );
 
-        let dimension_data = Map::from_iter(
-            vec![
-                (String::from("test3"), Value::Bool(false)),
-                (String::from("test"), Value::String(String::from("key"))),
-            ]
-            .into_iter(),
-        );
-
         assert_eq!(
-            config.filter_by_dimensions(&dimension_data),
+            config.filter_by_dimensions(&get_dimension_data2()),
             get_dimension_filtered_config2()
         );
 
-        let dimension_data = Map::from_iter(
-            vec![
-                (String::from("test3"), Value::Bool(false)),
-                (String::from("test"), Value::String(String::from("key"))),
-                (String::from("test2"), Value::Number(Number::from(12))),
-            ]
-            .into_iter(),
-        );
-
         assert_eq!(
-            config.filter_by_dimensions(&dimension_data),
+            config.filter_by_dimensions(&get_dimension_data3()),
             get_dimension_filtered_config3()
         );
     }

--- a/crates/superposition_types/src/config.rs
+++ b/crates/superposition_types/src/config.rs
@@ -181,11 +181,8 @@ impl Config {
         let filtered_default_config = self.filter_default_by_prefix(prefix_list);
 
         for (key, overrides) in &self.overrides {
-            let filtered_overrides_map: Map<String, Value> = overrides
-                .clone()
-                .into_iter()
-                .filter(|(key, _)| prefix_list.contains(key))
-                .collect();
+            let filtered_overrides_map =
+                filter_config_keys_by_prefix(overrides.clone().into(), prefix_list);
 
             if break_on_validate {
                 let filtered_override_map = Cac::<Overrides>::validate_db_data(

--- a/crates/superposition_types/src/contextual.rs
+++ b/crates/superposition_types/src/contextual.rs
@@ -42,3 +42,149 @@ pub trait Contextual: Clone {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use serde_json::{from_value, json};
+
+    use crate::{
+        config::tests::{
+            get_config, get_dimension_data1, get_dimension_data2, get_dimension_data3,
+            get_dimension_filtered_config1, get_dimension_filtered_config2,
+            get_dimension_filtered_config3,
+        },
+        Context,
+    };
+
+    use super::Contextual;
+
+    fn get_dimension_filtered_contexts1() -> Vec<Context> {
+        let contexts = json!([
+            {
+                "id": "40c2564c114e1a2036bc6ce0e730289d05e117b051f2d286d6e7c68960f3bc7d",
+                "condition": {
+                    "==": [
+                        {
+                            "var": "test3"
+                        },
+                        true
+                    ]
+                },
+                "priority": 1,
+                "override_with_keys": [
+                    "0e72cf409a9eba53446dc858191751accf9f8ad3e6195413933145a497feb0ef"
+                ]
+            },
+            {
+                "id": "9fbf3b9fa10caaaf31f6003cbd20ed36d40efe73b5c6b238288c0a96e6933500",
+                "condition": {
+                    "and": [
+                        {
+                            "==": [
+                                {
+                                    "var": "test3"
+                                },
+                                false
+                            ]
+                        },
+                        {
+                            "==": [
+                                {
+                                    "var": "test"
+                                },
+                                "test"
+                            ]
+                        }
+                    ]
+                },
+                "priority": 3,
+                "override_with_keys": [
+                    "e2fa5b38c3a1448cf0e27f9d555fdb8964a686d8ae41b70b55e6ee30359b87c8"
+                ]
+            }
+        ]);
+
+        from_value(contexts).unwrap()
+    }
+
+    fn get_dimension_filtered_contexts2() -> Vec<Context> {
+        let contexts = json!([{
+            "id": "9fbf3b9fa10caaaf31f6003cbd20ed36d40efe73b5c6b238288c0a96e6933500",
+            "condition": {
+                "and": [
+                    {
+                        "==": [
+                            {
+                                "var": "test3"
+                            },
+                            false
+                        ]
+                    },
+                    {
+                        "==": [
+                            {
+                                "var": "test"
+                            },
+                            "test"
+                        ]
+                    }
+                ]
+            },
+            "priority": 3,
+            "override_with_keys": [
+                "e2fa5b38c3a1448cf0e27f9d555fdb8964a686d8ae41b70b55e6ee30359b87c8"
+            ]
+        }]);
+
+        from_value(contexts).unwrap()
+    }
+
+    #[test]
+    fn filter_by_eval() {
+        let config = get_config();
+
+        assert_eq!(
+            Contextual::filter_by_eval(config.contexts.clone(), &get_dimension_data1()),
+            get_dimension_filtered_config1().contexts
+        );
+
+        assert_eq!(
+            Contextual::filter_by_eval(config.contexts.clone(), &get_dimension_data2()),
+            get_dimension_filtered_config2().contexts
+        );
+
+        assert_eq!(
+            Contextual::filter_by_eval(config.contexts, &get_dimension_data3()),
+            get_dimension_filtered_config3().contexts
+        );
+    }
+
+    #[test]
+    fn filter_by_dimension() {
+        let config = get_config();
+
+        assert_eq!(
+            Contextual::filter_by_dimension(
+                config.contexts.clone(),
+                &get_dimension_data1().keys().cloned().collect::<Vec<_>>()
+            ),
+            get_dimension_filtered_contexts1()
+        );
+
+        assert_eq!(
+            Contextual::filter_by_dimension(
+                config.contexts.clone(),
+                &get_dimension_data2().keys().cloned().collect::<Vec<_>>()
+            ),
+            get_dimension_filtered_contexts2()
+        );
+
+        assert_eq!(
+            Contextual::filter_by_dimension(
+                config.contexts,
+                &get_dimension_data3().keys().cloned().collect::<Vec<_>>()
+            ),
+            Vec::new()
+        );
+    }
+}

--- a/crates/superposition_types/src/custom_query.rs
+++ b/crates/superposition_types/src/custom_query.rs
@@ -139,6 +139,7 @@ where
 
 /// Provides struct to `Deserialize` `HashMap<String, String>` as `serde_json::Map<String, serde_json::Value>`
 #[derive(Deserialize, Deref, DerefMut)]
+#[cfg_attr(test, derive(Debug, PartialEq))]
 #[serde(from = "HashMap<String,String>")]
 pub struct QueryMap(Map<String, Value>);
 
@@ -195,5 +196,43 @@ impl<'de> Deserialize<'de> for PaginationParams {
             page: helper.page,
             all: helper.all,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use serde_json::{from_value, json};
+
+    use crate::custom_query::QueryMap;
+
+    #[test]
+    fn querymap_from_hashmap() {
+        let hashmap: HashMap<String, String> = from_value(json!({
+            "key1": "123",
+            "key2": "\"123\"",
+            "key3": "test",
+            "key4": "true",
+            "key5": "\"true\"",
+            "key6": "null",
+            "key7": "\"null\""
+        }))
+        .unwrap();
+
+        let map = json!({
+            "key1": 123,
+            "key2": "123",
+            "key3": "test",
+            "key4": true,
+            "key5": "true",
+            "key6": null,
+            "key7": "null"
+        })
+        .as_object()
+        .unwrap()
+        .clone();
+
+        assert_eq!(QueryMap::from(hashmap), QueryMap(map));
     }
 }

--- a/crates/superposition_types/src/overridden.rs
+++ b/crates/superposition_types/src/overridden.rs
@@ -36,34 +36,23 @@ pub trait Overridden<T: TryFrom<Map<String, Value>>>: Clone {
 mod tests {
     use std::collections::HashSet;
 
-    use serde_json::{json, Map};
+    use serde_json::Map;
+
+    use crate::config::tests::{
+        get_config, get_prefix_filtered_config1, get_prefix_filtered_config2,
+    };
 
     use super::filter_config_keys_by_prefix;
 
     #[test]
     fn test_filter_config_keys_by_prefix() {
-        let config = json!({
-            "key1": false,
-            "test.test.test1": 1,
-            "test.test1": 12,
-            "test2.key": false,
-            "test2.test": "def_val"
-        })
-        .as_object()
-        .unwrap()
-        .clone();
+        let config = get_config();
 
         let prefix_list = HashSet::from_iter(vec![String::from("test.")].into_iter());
 
         assert_eq!(
-            filter_config_keys_by_prefix(config.clone(), &prefix_list),
-            json!({
-                "test.test.test1": 1,
-                "test.test1": 12
-            })
-            .as_object()
-            .unwrap()
-            .clone()
+            filter_config_keys_by_prefix(config.default_configs.clone(), &prefix_list),
+            get_prefix_filtered_config1().default_configs
         );
 
         let prefix_list = HashSet::from_iter(
@@ -71,22 +60,14 @@ mod tests {
         );
 
         assert_eq!(
-            filter_config_keys_by_prefix(config.clone(), &prefix_list),
-            json!({
-                "test.test.test1": 1,
-                "test.test1": 12,
-                "test2.key": false,
-                "test2.test": "def_val"
-            })
-            .as_object()
-            .unwrap()
-            .clone()
+            filter_config_keys_by_prefix(config.default_configs.clone(), &prefix_list),
+            get_prefix_filtered_config2().default_configs
         );
 
         let prefix_list = HashSet::from_iter(vec![String::from("abcd")].into_iter());
 
         assert_eq!(
-            filter_config_keys_by_prefix(config, &prefix_list),
+            filter_config_keys_by_prefix(config.default_configs, &prefix_list),
             Map::new()
         );
     }


### PR DESCRIPTION
## Problem
`Config.filter_by_prefix` gives wrong config on filtering

## Solution
1. Fix the logic for `filter_by_prefix`
2. `try_filter_by_prefix` function was not needed, both server and client should use `filter_by_prefix`, using `try_filter_by_prefix` in server gives wrong output
3. Added tests for `Config`, `QueryMap`, `Contextual`, `Overridden` functions
