### PR TITLE
feat: JsonLogic algebraic representation

### DIFF
--- a/crates/frontend/src/lib.rs
+++ b/crates/frontend/src/lib.rs
@@ -5,6 +5,7 @@ mod api;
 pub mod app;
 pub mod components;
 pub mod hoc;
+pub mod logic;
 pub mod pages;
 pub mod providers;
 pub mod schema;

--- a/crates/frontend/src/logic.rs
+++ b/crates/frontend/src/logic.rs
@@ -1,0 +1,357 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Map};
+
+use crate::schema::{HtmlDisplay, SchemaType};
+use superposition_types::Context;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Expression {
+    Is(serde_json::Value),
+    In(serde_json::Value),
+    Has(serde_json::Value),
+    Between(serde_json::Value, serde_json::Value),
+    Other(String, Vec<serde_json::Value>),
+}
+
+pub fn is_variable(v: &serde_json::Value) -> bool {
+    v.is_object() && v.as_object().unwrap().contains_key("var")
+}
+
+pub fn is_constant(v: &serde_json::Value) -> bool {
+    !is_variable(v)
+}
+
+impl Expression {
+    fn try_from_expression_map(
+        source: &Map<String, serde_json::Value>,
+    ) -> Result<Self, &'static str> {
+        if let Some(operator) = source.keys().next() {
+            let operands = source[operator]
+                .as_array()
+                .cloned()
+                .ok_or("Invalid operands list for context")?;
+
+            let operand_0 = operands.first();
+            let operand_1 = operands.get(1);
+            let operand_2 = operands.get(2);
+
+            match (operator.as_str(), operand_0, operand_1, operand_2) {
+                ("==", Some(o1), Some(o2), None)
+                    if is_variable(o1) && is_constant(o2) =>
+                {
+                    return Ok(Expression::Is(o2.clone()));
+                }
+                ("<=", Some(o1), Some(o2), Some(o3))
+                    if is_variable(o2) && is_constant(o1) && is_constant(o3) =>
+                {
+                    return Ok(Expression::Between(o1.clone(), o3.clone()));
+                }
+                ("in", Some(o1), Some(o2), None)
+                    if is_variable(o1) && is_constant(o2) =>
+                {
+                    return Ok(Expression::In(o2.clone()));
+                }
+                ("in", Some(o1), Some(o2), None)
+                    if is_variable(o2) && is_constant(o1) =>
+                {
+                    return Ok(Expression::Has(o1.clone()));
+                }
+                _ => {
+                    return Ok(Expression::Other(operator.clone(), operands.clone()));
+                }
+            }
+        }
+
+        Err("not a valid expression map")
+    }
+    fn to_expression_json(&self, var: &str) -> serde_json::Value {
+        match self {
+            Expression::Is(c) => {
+                json!({
+                    "==": [
+                        {"var": var},
+                        c
+                    ]
+                })
+            }
+            Expression::In(c) => {
+                json!({
+                    "in": [
+                        {"var": var},
+                        c
+                    ]
+                })
+            }
+            Expression::Has(c) => {
+                json!({
+                    "in": [
+                        c,
+                        {"var": var}
+                    ]
+                })
+            }
+            Expression::Between(c1, c2) => {
+                json!({
+                    "<=": [
+                        c1,
+                        {"var": var},
+                        c2
+                    ]
+                })
+            }
+            Expression::Other(operator, operands) => {
+                json!({
+                    operator: operands.clone()
+                })
+            }
+        }
+    }
+    fn to_expression_query_str(&self, var: &str) -> String {
+        match self {
+            Expression::Is(c) => {
+                format!("{}{}{}", var, "==", c.html_display())
+            }
+            Expression::In(c) => {
+                format!("{}{}{}", var, "in", c.html_display())
+            }
+            Expression::Has(c) => {
+                format!("{}{}{}", var, "in", c.html_display())
+            }
+            Expression::Between(c1, c2) => {
+                let c_str = format!("{},{}", c1.html_display(), c2.html_display());
+                format!("{}{}{}", var, "<=", c_str)
+            }
+            Expression::Other(operator, operands) => {
+                let c_str = operands
+                    .iter()
+                    .filter_map(|operand| {
+                        if is_variable(operand) {
+                            return None;
+                        }
+                        Some(operand.html_display())
+                    })
+                    .collect::<Vec<String>>()
+                    .join(",");
+                format!("{}{}{}", var, operator, c_str)
+            }
+        }
+    }
+    pub fn to_constants_vec(&self) -> Vec<serde_json::Value> {
+        match self {
+            Expression::Is(c) | Expression::In(c) | Expression::Has(c) => {
+                vec![c.clone()]
+            }
+            Expression::Between(c1, c2) => {
+                vec![c1.clone(), c2.clone()]
+            }
+            Expression::Other(_, operands) => operands
+                .iter()
+                .filter_map(|operand| {
+                    if is_variable(operand) {
+                        return None;
+                    }
+                    Some(operand.clone())
+                })
+                .collect::<Vec<serde_json::Value>>(),
+        }
+    }
+    pub fn to_operator(&self) -> Operator {
+        Operator::from(self)
+    }
+}
+
+impl From<(SchemaType, Operator)> for Expression {
+    fn from((r#type, operator): (SchemaType, Operator)) -> Self {
+        match operator {
+            Operator::Is => Expression::Is(r#type.default_value()),
+            Operator::In => Expression::In(r#type.default_value()),
+            Operator::Has => Expression::Has(r#type.default_value()),
+            Operator::Between => {
+                Expression::Between(r#type.default_value(), r#type.default_value())
+            }
+            Operator::Other(o) => Expression::Other(o, vec![]),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Operator {
+    Is,
+    In,
+    Has,
+    Between,
+    Other(String),
+}
+
+impl From<&Expression> for Operator {
+    fn from(value: &Expression) -> Self {
+        match value {
+            Expression::Is(_) => Operator::Is,
+            Expression::In(_) => Operator::In,
+            Expression::Has(_) => Operator::Has,
+            Expression::Between(_, _) => Operator::Between,
+            Expression::Other(o, _) => Operator::Other(o.clone()),
+        }
+    }
+}
+
+impl From<&Condition> for Operator {
+    fn from(value: &Condition) -> Self {
+        (&value.expression).into()
+    }
+}
+
+impl Operator {
+    pub fn from_operator_input(source: String) -> Self {
+        match source.as_str() {
+            "==" => Operator::Is,
+            "<=" => Operator::Between,
+            "in" => Operator::In,
+            "has" => Operator::Has,
+            other => Operator::Other(other.to_string()),
+        }
+    }
+
+    pub fn to_condition_json_operator(self) -> String {
+        match self {
+            Self::Has => "in".to_owned(),
+            Self::Is => "==".to_owned(),
+            Self::In => "in".to_owned(),
+            Self::Between => "<=".to_owned(),
+            Self::Other(o) => o,
+        }
+    }
+}
+
+impl Display for Operator {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Has => f.write_str("has"),
+            Self::Is => f.write_str("is"),
+            Self::In => f.write_str("in"),
+            Self::Between => f.write_str("between"),
+            Self::Other(o) => f.write_str(o),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Condition {
+    pub variable: String,
+    pub expression: Expression,
+}
+
+impl Condition {
+    pub fn new_with_default_expression(var: String, r#type: SchemaType) -> Self {
+        Condition {
+            variable: var,
+            expression: Expression::Is(r#type.default_value()),
+        }
+    }
+
+    fn try_var_from_condition_map(
+        source: &Map<String, serde_json::Value>,
+    ) -> Result<String, &'static str> {
+        if let Some(operator) = source.keys().next() {
+            return source[operator]
+                .as_array()
+                .ok_or("Invalid operands list for context")?
+                .iter()
+                .find_map(|o| {
+                    o.as_object()
+                        .map(|v| {
+                            v.get("var")
+                                .map(|s| s.as_str().map(|s| s.to_owned()))
+                                .flatten()
+                        })
+                        .flatten()
+                })
+                .ok_or("variable doesn't exist in operands");
+        }
+        Err("not a valid condition map")
+    }
+
+    pub fn try_from_condition_map(
+        source: &Map<String, serde_json::Value>,
+    ) -> Result<Self, &'static str> {
+        let variable = Self::try_var_from_condition_map(source)?;
+        let expression = Expression::try_from_expression_map(source)?;
+
+        Ok(Condition {
+            variable,
+            expression,
+        })
+    }
+
+    pub fn try_from_condition_json(
+        source: &serde_json::Value,
+    ) -> Result<Self, &'static str> {
+        let obj = source
+            .as_object()
+            .ok_or("not a valid condition value, should be an object")?;
+        Self::try_from_condition_map(obj)
+    }
+
+    pub fn to_condition_json(&self) -> serde_json::Value {
+        self.expression.to_expression_json(&self.variable)
+    }
+
+    pub fn to_condition_query_str(&self) -> String {
+        self.expression.to_expression_query_str(&self.variable)
+    }
+}
+
+#[derive(
+    Clone,
+    Debug,
+    derive_more::Deref,
+    derive_more::DerefMut,
+    Serialize,
+    Deserialize,
+    Default,
+)]
+pub struct Conditions(pub Vec<Condition>);
+
+impl Conditions {
+    pub fn from_context_json(
+        context: &Map<String, serde_json::Value>,
+    ) -> Result<Self, &'static str> {
+        Ok(Conditions(match context.get("and") {
+            Some(v) => v
+                .as_array()
+                .ok_or("failed to parse value of and as array")
+                .and_then(|arr| {
+                    arr.iter()
+                        .map(Condition::try_from_condition_json)
+                        .collect::<Result<Vec<Condition>, &'static str>>()
+                })?,
+            None => Condition::try_from_condition_map(&context).map(|v| vec![v])?,
+        }))
+    }
+    pub fn to_context_json(self) -> serde_json::Value {
+        json!({
+            "and": self.iter().map(|v| v.to_condition_json()).collect::<Vec<serde_json::Value>>()
+        })
+    }
+    pub fn to_query_string(self) -> String {
+        self.iter()
+            .map(|v| v.to_condition_query_str())
+            .collect::<Vec<String>>()
+            .join("&")
+    }
+}
+
+impl FromIterator<Condition> for Conditions {
+    fn from_iter<T: IntoIterator<Item = Condition>>(iter: T) -> Self {
+        Conditions(iter.into_iter().collect::<Vec<Condition>>())
+    }
+}
+
+impl TryFrom<&Context> for Conditions {
+    type Error = &'static str;
+    fn try_from(context: &Context) -> Result<Self, Self::Error> {
+        Self::from_context_json(&context.condition.as_ref())
+    }
+}

--- a/crates/frontend/src/schema.rs
+++ b/crates/frontend/src/schema.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use derive_more::{Deref, DerefMut};
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 
 pub trait HtmlDisplay: ToString {
     fn html_display(&self) -> String;
@@ -81,14 +81,18 @@ pub enum SchemaType {
 impl SchemaType {
     pub fn default_value(&self) -> Value {
         match self {
-            SchemaType::Multiple(_) => json!(""),
-            SchemaType::Single(JsonSchemaType::String) => json!(""),
+            SchemaType::Multiple(_) => Value::String(String::default()),
+            SchemaType::Single(JsonSchemaType::String) => {
+                Value::String(String::default())
+            }
             SchemaType::Single(JsonSchemaType::Number) => json!(0),
             SchemaType::Single(JsonSchemaType::Integer) => json!(0),
-            SchemaType::Single(JsonSchemaType::Boolean) => json!(false),
-            SchemaType::Single(JsonSchemaType::Object) => json!({}),
-            SchemaType::Single(JsonSchemaType::Array) => json!([]),
-            SchemaType::Single(JsonSchemaType::Null) => json!("null"),
+            SchemaType::Single(JsonSchemaType::Boolean) => Value::Bool(bool::default()),
+            SchemaType::Single(JsonSchemaType::Object) => Value::Object(Map::new()),
+            SchemaType::Single(JsonSchemaType::Array) => Value::Array(Vec::new()),
+            SchemaType::Single(JsonSchemaType::Null) => {
+                Value::String(String::from("null"))
+            }
         }
     }
     fn parse_from_array(arr: &[Value]) -> Result<Self, String> {

--- a/crates/superposition_types/src/config.rs
+++ b/crates/superposition_types/src/config.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use derive_more::{Deref, DerefMut, Into};
+use derive_more::{AsRef, Deref, DerefMut, Into};
 #[cfg(feature = "diesel_derives")]
 use diesel::{deserialize::FromSqlRow, expression::AsExpression, sql_types::Json};
 use serde::{Deserialize, Deserializer, Serialize};
@@ -71,7 +71,7 @@ impl IntoIterator for Overrides {
 impl_try_from_map!(Cac, Overrides, Overrides::validate_data);
 impl_try_from_map!(Exp, Overrides, Overrides::validate_data);
 
-#[derive(Deserialize, Serialize, Clone, Deref, Debug, PartialEq, Into)]
+#[derive(Deserialize, Serialize, Clone, Deref, Debug, PartialEq, Into, AsRef)]
 #[cfg_attr(
     feature = "diesel_derives",
     derive(AsExpression, FromSqlRow, JsonFromSql, JsonToSql)

--- a/crates/superposition_types/src/lib.rs
+++ b/crates/superposition_types/src/lib.rs
@@ -16,15 +16,11 @@ use std::fmt::Display;
 use std::future::{ready, Ready};
 
 #[cfg(feature = "server")]
-use actix_web::{dev::Payload, error, FromRequest, HttpMessage, HttpRequest};
+use actix_web::{dev::Payload, FromRequest, HttpMessage, HttpRequest};
 #[cfg(feature = "diesel_derives")]
 use diesel_derive_enum as _;
-#[cfg(feature = "server")]
-use log::error;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "server")]
-use serde_json::json;
 use webhook::WebhookConfig;
 
 pub use crate::config::{Condition, Config, Context, Overrides};
@@ -77,9 +73,9 @@ impl FromRequest for User {
         if let Some(user) = req.extensions().get::<Self>() {
             ready(Ok(user.to_owned()))
         } else {
-            error!("No user was found while validating token");
-            ready(Err(error::ErrorUnauthorized(
-                json!({"message":"invalid token provided"}),
+            log::error!("No user was found while validating token");
+            ready(Err(actix_web::error::ErrorUnauthorized(
+                serde_json::json!({"message":"invalid token provided"}),
             )))
         }
     }
@@ -178,7 +174,7 @@ impl FromRequest for TenantConfig {
     ) -> Self::Future {
         let result = req.extensions().get::<Self>().cloned().ok_or_else(|| {
             log::error!("Tenant config not found");
-            error::ErrorInternalServerError("Tenant config not found")
+            actix_web::error::ErrorInternalServerError("Tenant config not found")
         });
 
         ready(result)


### PR DESCRIPTION
## Problem
No concrete type representation for JsonLogic in Rust, leading to clumsy parsing and custom logic to generate context conditions.

## Solution
This PR introduces types such as:
- Operands
- Operator
- Condition

which aims towards representing JsonLogic correctly in an algebraic fashion.
Along with the type, behaviors such as generating context JsonLogic, conversion from JsonLogic to these types are also added in this PR.

Alongside, generating forms from JsonLogic is handled in this PR, additionally logic to parse based on operators all defined at one place, for ease of use.