### PR TITLE
invalidate client cache on config change

### DIFF
--- a/crates/cac_client/src/lib.rs
+++ b/crates/cac_client/src/lib.rs
@@ -161,6 +161,7 @@ impl Client {
         let mut last_modified = self.last_modified.write().await;
         let last_modified_at = get_last_modified(&fetched_config);
         *config = fetched_config.json::<Config>().await.map_err_to_string()?;
+        self.config_cache.invalidate_all();
         if let Some(val) = last_modified_at {
             *last_modified = val;
         }


### PR DESCRIPTION
## Problem
After config change , client resolve fn gives wrong result , this is due to cache which is not getting invalidated 
when config changes

## Solution
call invalidate function

## Environment variable changes

What ENVs need to be added or changed

## Pre-deployment activity
Things needed to be done before deploying this change (if any)

## Post-deployment activity
Things needed to be done after deploying this change (if any)

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
Describe any possible issues that could occur because of this change