### PR TITLE
feat: Use dimension[] for dimension params in context/list

### DIFF
--- a/crates/context_aware_config/src/api/context/handlers.rs
+++ b/crates/context_aware_config/src/api/context/handlers.rs
@@ -38,7 +38,7 @@ use superposition_types::{
             default_configs::dsl,
         },
     },
-    custom_query::{self as superposition_query, CustomQuery, PlatformQuery, QueryMap},
+    custom_query::{self as superposition_query, CustomQuery, DimensionQuery, QueryMap},
     result as superposition, Cac, Contextual, Overridden, Overrides, PaginatedResponse,
     TenantConfig, User,
 };
@@ -615,8 +615,8 @@ async fn get_context(
 
 #[get("/list")]
 async fn list_contexts(
-    filter_params: PlatformQuery<ContextFilters>,
-    dimension_params: superposition_query::Query<QueryMap>,
+    filter_params: superposition_query::Query<ContextFilters>,
+    dimension_params: DimensionQuery<QueryMap>,
     db_conn: DbConnection,
 ) -> superposition::Result<Json<PaginatedResponse<Context>>> {
     use superposition_types::cac::schema::contexts::dsl::*;

--- a/crates/context_aware_config/src/api/context/handlers.rs
+++ b/crates/context_aware_config/src/api/context/handlers.rs
@@ -40,7 +40,7 @@ use superposition_types::{
     },
     custom_query::{self as superposition_query, CustomQuery, DimensionQuery, QueryMap},
     result as superposition, Cac, Contextual, Overridden, Overrides, PaginatedResponse,
-    TenantConfig, User,
+    SortBy, TenantConfig, User,
 };
 
 #[cfg(feature = "high-performance-mode")]
@@ -48,7 +48,7 @@ use crate::helpers::put_config_in_redis;
 use crate::{
     api::{
         context::types::{
-            ContextAction, ContextBulkResponse, ContextFilterSortBy, ContextFilters,
+            ContextAction, ContextBulkResponse, ContextFilterSortOn, ContextFilters,
             DimensionCondition, MoveReq, PriorityRecomputeResponse, PutReq, PutResp,
             WeightRecomputeResponse,
         },
@@ -633,15 +633,15 @@ async fn list_contexts(
     }
 
     let dimension_params = dimension_params.into_inner();
+    let builder = contexts.into_boxed();
 
-    let mut builder = contexts.into_boxed();
-    match filter_params.sort_by.unwrap_or_default() {
-        ContextFilterSortBy::PriorityAsc => builder = builder.order(priority.asc()),
-        ContextFilterSortBy::PriorityDesc => builder = builder.order(priority.desc()),
-        ContextFilterSortBy::CreatedAtAsc => builder = builder.order(created_at.asc()),
-        ContextFilterSortBy::CreatedAtDesc => builder = builder.order(created_at.desc()),
-    }
-
+    #[rustfmt::skip]
+    let mut builder = match (filter_params.sort_on.unwrap_or_default(), filter_params.sort_by.unwrap_or(SortBy::Asc)) {
+        (ContextFilterSortOn::Priority,  SortBy::Asc)  => builder.order(priority.asc()),
+        (ContextFilterSortOn::Priority,  SortBy::Desc) => builder.order(priority.desc()),
+        (ContextFilterSortOn::CreatedAt, SortBy::Asc)  => builder.order(created_at.asc()),
+        (ContextFilterSortOn::CreatedAt, SortBy::Desc) => builder.order(created_at.desc()),
+    };
     if let Some(created_by_filter) = filter_params.created_by.clone() {
         builder = builder.filter(created_by.eq_any(created_by_filter.0))
     }

--- a/crates/context_aware_config/src/api/context/types.rs
+++ b/crates/context_aware_config/src/api/context/types.rs
@@ -1,7 +1,7 @@
 use bigdecimal::BigDecimal;
 use serde::{Deserialize, Serialize};
 use superposition_types::{
-    custom_query::CommaSeparatedStringQParams, Cac, Condition, Overrides,
+    custom_query::CommaSeparatedStringQParams, Cac, Condition, Overrides, SortBy,
 };
 
 #[cfg_attr(test, derive(Debug, PartialEq))] // Derive traits only when running tests
@@ -32,16 +32,14 @@ pub struct PutResp {
 
 #[derive(Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub enum ContextFilterSortBy {
-    CreatedAtAsc,
-    CreatedAtDesc,
-    PriorityAsc,
-    PriorityDesc,
+pub enum ContextFilterSortOn {
+    CreatedAt,
+    Priority,
 }
 
-impl Default for ContextFilterSortBy {
+impl Default for ContextFilterSortOn {
     fn default() -> Self {
-        Self::PriorityAsc
+        Self::Priority
     }
 }
 
@@ -50,7 +48,8 @@ pub struct ContextFilters {
     pub page: Option<u32>,
     pub size: Option<u32>,
     pub prefix: Option<CommaSeparatedStringQParams>,
-    pub sort_by: Option<ContextFilterSortBy>,
+    pub sort_on: Option<ContextFilterSortOn>,
+    pub sort_by: Option<SortBy>,
     pub created_by: Option<CommaSeparatedStringQParams>,
 }
 

--- a/crates/superposition_types/src/custom_query.rs
+++ b/crates/superposition_types/src/custom_query.rs
@@ -52,18 +52,18 @@ pub trait CustomQuery: Sized {
     fn into_inner(self) -> Self::Inner;
 }
 
-/// Provides struct to extract those query params from the request which are `wrapped` in `platform[param_name]`
+/// Provides struct to extract those query params from the request which are `wrapped` in `dimension[param_name]`
 #[derive(Debug, Clone)]
-pub struct PlatformQuery<T: DeserializeOwned>(pub T);
+pub struct DimensionQuery<T: DeserializeOwned>(pub T);
 
-impl<T> CustomQuery for PlatformQuery<T>
+impl<T> CustomQuery for DimensionQuery<T>
 where
     T: DeserializeOwned,
 {
     type Inner = T;
 
     fn regex_pattern() -> &'static str {
-        r"platform\[(?<query_name>.*)\]"
+        r"dimension\[(?<query_name>.*)\]"
     }
 
     fn capture_group() -> &'static str {
@@ -79,7 +79,7 @@ where
     }
 }
 
-impl<T> actix_web::FromRequest for PlatformQuery<T>
+impl<T> actix_web::FromRequest for DimensionQuery<T>
 where
     T: DeserializeOwned,
 {


### PR DESCRIPTION
## Problem
`platform[key_name]` format for passing params forces to change all endpoints to create a consistency across all the endpoints


## Solution
1. `dimension[dimension_name]` rather to get the dynamic dimension params from the query request and keep the other params outside of any prefix notation
2. split current `sort_by` filter into `sort_by` and `sort_on` filters, following the new convention