### PR TITLE
fix: webhook ui failure handling

### DIFF
--- a/crates/frontend/src/utils.rs
+++ b/crates/frontend/src/utils.rs
@@ -429,7 +429,7 @@ where
         enqueue_alert(error_msg.clone(), AlertType::Error, 5000);
         return Err(error_msg);
     }
-    if status.is_server_error() {
+    if status.is_server_error() && status != 512 {
         let error_msg = response
             .json::<ErrorResponse>()
             .await


### PR DESCRIPTION
## Problem
Webhook failures in frontend not handled properly

## Solution
added a condition to ignore the 512 status code