### PR TITLE
fix: workspace dropdown and UI misalignment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5270,19 +5270,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b56f625e64f3a1084ded111c4d5f477df9f8c92df113852fa5a374dbda78826"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -5307,9 +5308,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0162dbf37223cd2afce98f3d0785506dcb8d266223983e4b5b525859e6e182b2"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5317,9 +5318,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0eb82fcb7930ae6219a7ecfd55b217f5f0893484b7a13022ebb2b2bf20b5283"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5330,9 +5331,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.89"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ab9b36309365056cd639da3134bf87fa8f3d86008abf99e612384a6eecd459f"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-streams"

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -29,7 +29,7 @@ superposition_types = { path = "../superposition_types", features = [
   "api"
 ], default-features = false }
 url = { workspace = true }
-wasm-bindgen = "=0.2.89"
+wasm-bindgen = "=0.2.93"
 web-sys = { version = "0.3.64", features = [
   "Event",
   "Worker",

--- a/crates/frontend/src/components/side_nav.rs
+++ b/crates/frontend/src/components/side_nav.rs
@@ -79,7 +79,7 @@ pub fn side_nav(
     let workspace_resource = create_blocking_resource(
         move || org_rws.get().0,
         |org_id| async move {
-            let filters = PaginationParams::default();
+            let filters = PaginationParams::all_entries();
             fetch_workspaces(&filters, &org_id)
                 .await
                 .unwrap_or_default()


### PR DESCRIPTION
## Problem
- Workspace dropdown shows only 10 entries
- The UI breaks due to https://github.com/rustwasm/wasm-pack/issues/1389

## Solution
- Ask the API for all entries
- Update wasm-bindgen

## Possible Issues in the future
Updating wasm-bindgen doesn't solve anything and the UI issue returns