### PR TITLE
fix: show delete prompt for delete actions

### DIFF
--- a/crates/frontend/src/components/type_template_form.rs
+++ b/crates/frontend/src/components/type_template_form.rs
@@ -119,36 +119,6 @@ where
                 <textarea
                     placeholder="Enter description"
                     class="textarea textarea-bordered w-full max-w-md"
-                    value=description_rs.get_untracked()
-                    on:change=move |ev| {
-                        let value = event_target_value(&ev);
-                        description_ws.set(value);
-                    }
-                />
-            </div>
-
-            <div class="form-control">
-                <label class="label">
-                    <span class="label-text">change_reason</span>
-                </label>
-                <textarea
-                    placeholder="Enter change_reason"
-                    class="textarea textarea-bordered w-full max-w-md"
-                    value=change_reason_rs.get_untracked()
-                    on:change=move |ev| {
-                        let value = event_target_value(&ev);
-                        change_reason_ws.set(value);
-                    }
-                />
-            </div>
-
-            <div class="form-control">
-                <label class="label">
-                    <span class="label-text">Description</span>
-                </label>
-                <textarea
-                    placeholder="Enter description"
-                    class="textarea textarea-bordered w-full max-w-md"
                     value=description_rs.get()
                     on:change=move |ev| {
                         let value = event_target_value(&ev);

--- a/crates/frontend/src/pages/custom_types.rs
+++ b/crates/frontend/src/pages/custom_types.rs
@@ -6,12 +6,15 @@ use superposition_types::custom_query::PaginationParams;
 use crate::components::table::types::ColumnSortable;
 use crate::components::type_template_form::utils::delete_type;
 use crate::components::{
+    alert::AlertType,
+    delete_modal::DeleteModal,
     drawer::{close_drawer, open_drawer, Drawer, DrawerBtn},
     skeleton::Skeleton,
     stat::Stat,
     table::Table,
     type_template_form::TypeTemplateForm,
 };
+use crate::providers::alert_provider::enqueue_alert;
 use crate::types::{OrganisationId, Tenant};
 use crate::utils::unwrap_option_or_default_with_error;
 use crate::{api::fetch_types, components::table::types::Column};
@@ -42,6 +45,34 @@ pub fn types_page() -> impl IntoView {
                 )
         },
     );
+
+    let (delete_modal_visible_rs, delete_modal_visible_ws) = create_signal(false);
+    let (delete_row_rs, delete_row_ws) = create_signal::<Option<TypeTemplateRow>>(None);
+
+    let confirm_delete = Callback::new(move |_| {
+        if let Some(row_data) = delete_row_rs.get().clone() {
+            spawn_local(async move {
+                let tenant = tenant_rws.get().0;
+                let org = org_rws.get().0;
+                let api_response =
+                    delete_type(tenant, row_data.clone().type_name, org).await;
+                match api_response {
+                    Ok(_) => {
+                        enqueue_alert(
+                            format!("type template deleted successfully"),
+                            AlertType::Success,
+                            5000,
+                        );
+                        types_resource.refetch();
+                    }
+                    Err(err) => enqueue_alert(String::from(err), AlertType::Error, 5000),
+                }
+                types_resource.refetch();
+            });
+        }
+        delete_row_ws.set(None);
+        delete_modal_visible_ws.set(false);
+    });
     let selected_type = create_rw_signal::<Option<TypeTemplateRow>>(None);
     let table_columns = create_memo(move |_| {
         vec![
@@ -69,16 +100,8 @@ pub fn types_page() -> impl IntoView {
                             delete_row_json.clone(),
                         )
                         .unwrap();
-                        spawn_local({
-                            async move {
-                                let tenant = tenant_rws.get().0;
-                                let org = org_rws.get().0;
-                                let _ =
-                                    delete_type(tenant, row_data.clone().type_name, org)
-                                        .await;
-                                types_resource.refetch();
-                            }
-                        });
+                        delete_row_ws.set(Some(row_data));
+                        delete_modal_visible_ws.set(true);
                     };
                     view! {
                         <div class="join">
@@ -195,6 +218,13 @@ pub fn types_page() -> impl IntoView {
                                     />
                                 </div>
                             </div>
+                            <DeleteModal
+                                modal_visible=delete_modal_visible_rs
+                                confirm_delete=confirm_delete
+                                set_modal_visible=delete_modal_visible_ws
+                                header_text="Are you sure you want to delete this type template? Action is irreversible."
+                                    .to_string()
+                            />
                         }
                     }}
 


### PR DESCRIPTION
## Problem
Delete modal is not displayed in default config and type templates pages. Also, the type template form shows the description and change reason twice

## Solution
Show a delete prompt and remove duplicate fields


https://github.com/user-attachments/assets/d29819bf-97e1-4248-aa6c-09c13247ee8c


closes #399 