### PR TITLE
feat: add key filter for default config

### DIFF
--- a/crates/frontend/src/api.rs
+++ b/crates/frontend/src/api.rs
@@ -1,5 +1,6 @@
 use leptos::ServerFnError;
 use superposition_types::{
+    api::default_config::DefaultConfigFilters,
     custom_query::PaginationParams,
     database::{
         models::{
@@ -45,14 +46,15 @@ pub async fn fetch_dimensions(
 
 // #[server(GetDefaultConfig, "/fxn", "GetJson")]
 pub async fn fetch_default_config(
-    filters: &PaginationParams,
+    pagination: &PaginationParams,
+    filters: &DefaultConfigFilters,
     tenant: String,
     org_id: String,
 ) -> Result<PaginatedResponse<DefaultConfig>, ServerFnError> {
     let client = reqwest::Client::new();
     let host = use_host_server();
 
-    let url = format!("{}/default-config?{}", host, filters);
+    let url = format!("{}/default-config?{}&{}", host, pagination, filters);
     let response: PaginatedResponse<DefaultConfig> = client
         .get(url)
         .header("x-tenant", tenant)

--- a/crates/frontend/src/pages/context_override.rs
+++ b/crates/frontend/src/pages/context_override.rs
@@ -3,6 +3,7 @@ use leptos::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use superposition_types::{
+    api::default_config::DefaultConfigFilters,
     custom_query::PaginationParams,
     database::{models::cac::DefaultConfig, types::DimensionWithMandatory},
     Config, Context,
@@ -202,6 +203,7 @@ pub fn context_override() -> impl IntoView {
             move || (tenant_rws.get().0, org_rws.get().0),
             |(current_tenant, org_id)| async move {
                 let empty_list_filters = PaginationParams::all_entries();
+                let default_config_filters = DefaultConfigFilters::default();
                 let (config_result, dimensions_result, default_config_result) = join!(
                     fetch_config(current_tenant.to_string(), None, org_id.clone()),
                     fetch_dimensions(
@@ -211,6 +213,7 @@ pub fn context_override() -> impl IntoView {
                     ),
                     fetch_default_config(
                         &empty_list_filters,
+                        &default_config_filters,
                         current_tenant.to_string(),
                         org_id.clone()
                     )

--- a/crates/frontend/src/pages/experiment.rs
+++ b/crates/frontend/src/pages/experiment.rs
@@ -3,6 +3,7 @@ use leptos::*;
 use leptos_router::use_params_map;
 use serde::{Deserialize, Serialize};
 use superposition_types::{
+    api::default_config::DefaultConfigFilters,
     custom_query::PaginationParams,
     database::{models::cac::DefaultConfig, types::DimensionWithMandatory},
 };
@@ -48,6 +49,7 @@ pub fn experiment_page() -> impl IntoView {
     let combined_resource: Resource<(String, String, String), CombinedResource> =
         create_blocking_resource(source, |(exp_id, tenant, org_id)| async move {
             // Perform all fetch operations concurrently
+            let default_config_filters = DefaultConfigFilters::default();
             let experiments_future =
                 fetch_experiment(exp_id.to_string(), tenant.to_string(), org_id.clone());
             let empty_list_filters = PaginationParams::all_entries();
@@ -55,6 +57,7 @@ pub fn experiment_page() -> impl IntoView {
                 fetch_dimensions(&empty_list_filters, tenant.to_string(), org_id.clone());
             let config_future = fetch_default_config(
                 &empty_list_filters,
+                &default_config_filters,
                 tenant.to_string(),
                 org_id.clone(),
             );

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -6,6 +6,7 @@ use leptos::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use superposition_types::{
+    api::default_config::DefaultConfigFilters,
     custom_query::PaginationParams,
     database::{models::cac::DefaultConfig, types::DimensionWithMandatory},
     PaginatedResponse, SortBy,
@@ -71,6 +72,7 @@ pub fn experiment_list() -> impl IntoView {
         |(current_tenant, filters, pagination_filters, org_id)| async move {
             // Perform all fetch operations concurrently
             let fetch_all_filters = PaginationParams::all_entries();
+            let default_config_filters = DefaultConfigFilters::default();
             let experiments_future = fetch_experiments(
                 &filters,
                 &pagination_filters,
@@ -84,6 +86,7 @@ pub fn experiment_list() -> impl IntoView {
             );
             let config_future = fetch_default_config(
                 &fetch_all_filters,
+                &default_config_filters,
                 current_tenant.to_string(),
                 org_id.clone(),
             );

--- a/crates/superposition_types/src/api.rs
+++ b/crates/superposition_types/src/api.rs
@@ -1,1 +1,2 @@
+pub mod default_config;
 pub mod workspace;

--- a/crates/superposition_types/src/api/default_config.rs
+++ b/crates/superposition_types/src/api/default_config.rs
@@ -1,0 +1,19 @@
+use core::fmt;
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+pub struct DefaultConfigFilters {
+    pub name: Option<String>,
+}
+
+impl Display for DefaultConfigFilters {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut query_params = vec![];
+        if let Some(key_name) = &self.name {
+            query_params.push(format!("name={}", key_name));
+        }
+        write!(f, "{}", query_params.join("&"))
+    }
+}


### PR DESCRIPTION
## Problem
Default config screen is paginated, but provides no way to search for a key

## Solution
Provide a filter to find config keys


https://github.com/user-attachments/assets/d52d23dd-b7de-4954-bb38-3e1801365508

