### PR TITLE
feat: experiment filters in UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4681,6 +4681,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "strum",
  "strum_macros",
  "superposition_derives",
  "thiserror",

--- a/crates/experimentation_platform/src/api/experiments/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiments/handlers.rs
@@ -766,10 +766,12 @@ async fn list_experiments(
                 builder.filter(experiments::name.like(format!("%{}%", experiment_name)));
         }
         if let Some(ref context_search) = filters.context {
-            builder = builder.filter(
-                sql::<Bool>("context::text LIKE ")
-                    .bind::<Text, _>(format!("%{}%", context_search)),
-            );
+            for c in context_search.iter() {
+                builder = builder.filter(
+                    sql::<Bool>("context::text LIKE ")
+                        .bind::<Text, _>(format!("%{}%", c)),
+                );
+            }
         }
         if let Some(ref created_by) = filters.created_by {
             builder =

--- a/crates/experimentation_platform/src/api/experiments/types.rs
+++ b/crates/experimentation_platform/src/api/experiments/types.rs
@@ -208,7 +208,7 @@ pub struct ExperimentListFilters {
     pub experiment_name: Option<String>,
     pub experiment_ids: Option<CommaSeparatedStringQParams>,
     pub created_by: Option<CommaSeparatedStringQParams>,
-    pub context: Option<String>,
+    pub context: Option<CommaSeparatedStringQParams>,
     pub sort_on: Option<ExperimentSortOn>,
     pub sort_by: Option<SortBy>,
 }

--- a/crates/frontend/src/components/button.rs
+++ b/crates/frontend/src/components/button.rs
@@ -7,6 +7,7 @@ pub fn button<F: Fn(MouseEvent) + 'static>(
     on_click: F,
     #[prop(default = String::new())] class: String,
     #[prop(default = String::new())] id: String,
+    #[prop(default = String::from("ri-edit-2-line"))] icon_class: String,
     #[prop(default = false)] loading: bool,
 ) -> impl IntoView {
     let mut button_class = format!("btn-purple font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 {class}");
@@ -22,7 +23,7 @@ pub fn button<F: Fn(MouseEvent) + 'static>(
                     </>
                 }
             } else {
-                view! { <>{text} <i class="ri-edit-2-line ml-2"></i></> }
+                view! { <>{text}<i class={format!("{icon_class} pl-2")}></i></> }
             }}
 
         </button>

--- a/crates/frontend/src/components/context_form/utils.rs
+++ b/crates/frontend/src/components/context_form/utils.rs
@@ -10,7 +10,7 @@ pub fn context_payload(
     description: String,
     change_reason: String,
 ) -> Value {
-    let context: Value = conditions.to_context_json();
+    let context: Value = conditions.as_context_json();
     let payload = json!({
         "override": overrides,
         "context": context,

--- a/crates/frontend/src/components/experiment_form/utils.rs
+++ b/crates/frontend/src/components/experiment_form/utils.rs
@@ -22,7 +22,7 @@ pub async fn create_experiment(
     let payload = ExperimentCreateRequest {
         name,
         variants: FromIterator::from_iter(variants),
-        context: conditions.to_context_json(),
+        context: conditions.as_context_json(),
         description,
         change_reason,
     };

--- a/crates/frontend/src/logic.rs
+++ b/crates/frontend/src/logic.rs
@@ -223,7 +223,7 @@ impl Display for Operator {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Condition {
     pub variable: String,
     pub expression: Expression,
@@ -288,6 +288,7 @@ impl Condition {
 #[derive(
     Clone,
     Debug,
+    PartialEq,
     derive_more::Deref,
     derive_more::DerefMut,
     Serialize,
@@ -312,12 +313,12 @@ impl Conditions {
             None => Condition::try_from_condition_map(context).map(|v| vec![v])?,
         }))
     }
-    pub fn to_context_json(self) -> serde_json::Value {
+    pub fn as_context_json(&self) -> serde_json::Value {
         json!({
             "and": self.iter().map(|v| v.to_condition_json()).collect::<Vec<serde_json::Value>>()
         })
     }
-    pub fn to_query_string(self) -> String {
+    pub fn as_query_string(&self) -> String {
         self.iter()
             .filter_map(|v| v.to_condition_query_str())
             .collect::<Vec<String>>()

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -1,23 +1,39 @@
 pub mod utils;
 
-use chrono::{prelude::Utc, TimeZone};
+use std::collections::HashSet;
+
+use chrono::{prelude::Utc, DateTime};
 use futures::join;
 use leptos::*;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
+use strum::IntoEnumIterator;
 use superposition_types::{
     api::default_config::DefaultConfigFilters,
     custom_query::PaginationParams,
-    database::{models::cac::DefaultConfig, types::DimensionWithMandatory},
-    PaginatedResponse, SortBy,
+    database::{
+        models::{cac::DefaultConfig, experimentation::ExperimentStatusType},
+        types::DimensionWithMandatory,
+    },
+    PaginatedResponse,
 };
 use utils::experiment_table_columns;
 
-use crate::components::drawer::{close_drawer, Drawer, DrawerBtn};
-use crate::components::skeleton::Skeleton;
-use crate::components::table::types::TablePaginationProps;
-use crate::components::{experiment_form::ExperimentForm, stat::Stat, table::Table};
 use crate::logic::Conditions;
+use crate::{
+    components::{
+        button::Button,
+        context_form::ContextForm,
+        drawer::{close_drawer, Drawer, DrawerBtn},
+        dropdown::DropdownDirection,
+        experiment_form::ExperimentForm,
+        input::DateInput,
+        skeleton::Skeleton,
+        stat::Stat,
+        table::{types::TablePaginationProps, Table},
+    },
+    types::StatusTypes,
+};
 
 use crate::providers::condition_collapse_provider::ConditionCollapseProvider;
 use crate::providers::editor_provider::EditorProvider;
@@ -36,35 +52,274 @@ struct CombinedResource {
 }
 
 #[component]
+fn experiment_table_filter_widget(
+    filters_rws: RwSignal<ExperimentListFilters>,
+    combined_resource: CombinedResource,
+) -> impl IntoView {
+    let filters = filters_rws.get_untracked();
+    let filters_buffer_rws = create_rw_signal(filters.clone());
+    let context = filters.context.unwrap_or_default();
+
+    let dim = combined_resource.dimensions;
+
+    let status_filter_management =
+        move |checked: bool, filter_status: ExperimentStatusType| {
+            let status_types = filters_buffer_rws.get().status.unwrap_or_default();
+            let mut old_status_vector: HashSet<ExperimentStatusType> =
+                HashSet::from_iter(status_types.clone().0);
+
+            if checked {
+                old_status_vector.insert(filter_status);
+            } else {
+                old_status_vector.remove(&filter_status);
+            }
+            let new_status_vector = old_status_vector.into_iter().collect();
+            let filters = ExperimentListFilters {
+                status: Some(StatusTypes(new_status_vector)),
+                ..filters_buffer_rws.get()
+            };
+            filters_buffer_rws.set(filters)
+        };
+    view! {
+        <DrawerBtn
+            drawer_id="experiment_filter_drawer".into()
+            style="cursor-pointer btn btn-purple-outline m-1 w-[8rem]".to_string()
+        >
+            Filters
+            <i class="ri-filter-3-line"></i>
+        </DrawerBtn>
+        <Drawer
+            id="experiment_filter_drawer".to_string()
+            header="Experiment Filters"
+            drawer_width="w-[50vw]"
+            handle_close=move || close_drawer("experiment_filter_drawer")
+        >
+            <div class="card-body">
+                <div class="my-4">
+                    <ContextForm
+                        dimensions=dim
+                        context
+                        dropdown_direction=DropdownDirection::Down
+                        handle_change=move |context: Conditions| {
+                            let current_filters = filters_buffer_rws.get();
+                            filters_buffer_rws
+                                .set(ExperimentListFilters {
+                                    context: Some(context),
+                                    ..current_filters
+                                });
+                        }
+                        heading_sub_text=String::from("Search By Context")
+                    />
+
+                </div>
+                <div class="w-full flex flex-row justify-start gap-10">
+                    <div class="form-control">
+                        <label class="label">
+                            <span class="label-text">Last Modified From</span>
+                        </label>
+                        <DateInput
+                            id="experiment_from_date_input".into()
+                            class="w-[19rem] flex-auto mt-3 mr-3".into()
+                            name="experiment_from_date".into()
+                            value=filters
+                                .from_date
+                                .map(|s| s.format("%Y-%m-%d").to_string())
+                                .unwrap_or_default()
+                            on_change=Callback::new(move |new_date: DateTime<Utc>| {
+                                let old_filters = filters_buffer_rws.get();
+                                let new_filters = ExperimentListFilters {
+                                    from_date: Some(new_date),
+                                    ..old_filters
+                                };
+                                filters_buffer_rws.set(new_filters);
+                            })
+                        />
+                    </div>
+                    <i class="mt-5 mr-3 text-3xl ri-arrow-right-line"></i>
+                    <div class="form-control">
+                        <label class="label">
+                            <span class="label-text">Last Modified To</span>
+                        </label>
+                        <DateInput
+                            id="experiment_to_date_input".into()
+                            class="w-[19rem] flex-auto mt-3 mr-3".into()
+                            name="experiment_to_date".into()
+                            on_change=Callback::new(move |new_date: DateTime<Utc>| {
+                                let old_filters = filters_buffer_rws.get();
+                                let new_filters = ExperimentListFilters {
+                                    to_date: Some(new_date),
+                                    ..old_filters
+                                };
+                                filters_buffer_rws.set(new_filters);
+                            })
+                        />
+                    </div>
+                </div>
+
+                <div class="form-control w-full">
+                    <label class="label">
+                        <span class="label-text">Experiment Status</span>
+                    </label>
+                    <div class="flex flex-row justify-start gap-10">
+                        {ExperimentStatusType::iter()
+                            .map(|status| {
+                                let current_status = status.to_string().to_lowercase();
+                                let label = status.to_string();
+                                let input_id = format!("{current_status}-checkbox");
+                                let input_peer_class = format!(
+                                    "hidden peer/{current_status}-checkbox",
+                                );
+                                let label_class = format!(
+                                    "px-6 h-[30px] py-2 badge peer-checked/{current_status}-checkbox:{} cursor-pointer transition duration-300 ease-in-out",
+                                    status.badge_color(),
+                                );
+                                view! {
+                                    <input
+                                        type="checkbox"
+                                        id=&input_id
+                                        class=&input_peer_class
+                                        checked=move || {
+                                            filters_buffer_rws
+                                                .get()
+                                                .status
+                                                .unwrap_or_default()
+                                                .iter()
+                                                .any(|item| *item == status)
+                                        }
+                                        on:change=move |event| {
+                                            let checked = event_target_checked(&event);
+                                            status_filter_management(checked, status)
+                                        }
+                                    />
+                                    <label for=&input_id class=&label_class>
+                                        {label}
+                                    </label>
+                                }
+                            })
+                            .collect::<Vec<_>>()}
+                    </div>
+                </div>
+                <div class="flex flex-col gap-5 justify-between">
+                    <div class="form-control">
+                        <label class="label">
+                            <span class="label-text">Experiment Name</span>
+                        </label>
+                        <input
+                            type="text"
+                            id="experiment-name-filter"
+                            placeholder="eg: city experiment"
+                            class="input input-bordered rounded-md resize-y w-full max-w-md"
+                            value=move || filters_rws.get().experiment_name
+                            on:change=move |event| {
+                                let experiment_name = event_target_value(&event);
+                                let experiment_name = if experiment_name.is_empty() {
+                                    None
+                                } else {
+                                    Some(experiment_name)
+                                };
+                                let filters = filters_buffer_rws.get();
+                                let filters = ExperimentListFilters {
+                                    experiment_name,
+                                    ..filters
+                                };
+                                filters_buffer_rws.set(filters);
+                            }
+                        />
+                    </div>
+                    <div class="form-control">
+                        <label class="label">
+                            <span class="label-text">Experiment IDs (Seperate by Comma)</span>
+                        </label>
+                        <input
+                            type="text"
+                            id="experiment-id-filter"
+                            class="input input-bordered rounded-md resize-y w-full max-w-md"
+                            value=move || filters_rws.get().experiment_ids
+                            placeholder="eg: 7259558160762015744"
+                            on:change=move |event| {
+                                let id = event_target_value(&event);
+                                let id = if id.is_empty() { None } else { Some(id) };
+                                filters_buffer_rws
+                                    .update(|filter| {
+                                        filter.experiment_ids = id;
+                                    });
+                            }
+                        />
+                    </div>
+                    <div class="form-control">
+                        <label class="label">
+                            <span class="label-text">Created By (Seperate by Comma)</span>
+                        </label>
+                        <input
+                            type="text"
+                            id="experiment-user-filter"
+                            class="input input-bordered rounded-md resize-y w-full max-w-md"
+                            placeholder="eg: user@superposition.io"
+                            value=move || filters_rws.get().created_by
+                            on:change=move |event| {
+                                let user_names = event_target_value(&event);
+                                let user_names = if user_names.is_empty() {
+                                    None
+                                } else {
+                                    Some(user_names)
+                                };
+                                let filters = filters_buffer_rws.get();
+                                let filters = ExperimentListFilters {
+                                    created_by: user_names,
+                                    ..filters
+                                };
+                                filters_buffer_rws.set(filters);
+                            }
+                        />
+
+                    </div>
+                </div>
+                <div class="flex justify-start mt-8">
+                    <Button
+                        class="w-48 px-[70px] h-12".to_string()
+                        text="Submit".to_string()
+                        on_click=move |event| {
+                            event.prevent_default();
+                            let filter = filters_buffer_rws.get();
+                            filters_rws.set(filter);
+                            close_drawer("experiment_filter_drawer")
+                        }
+                    />
+                    <Button
+                        class="px-[70px] h-12 w-48".to_string()
+                        text="Reset".to_string()
+                        icon_class="ri-restart-line".into()
+                        on_click=move |event| {
+                            event.prevent_default();
+                            let filters = ExperimentListFilters::default();
+                            filters_rws.set(filters);
+                            close_drawer("experiment_filter_drawer")
+                        }
+                    />
+
+                </div>
+            </div>
+        </Drawer>
+    }
+}
+
+#[component]
 pub fn experiment_list() -> impl IntoView {
     // acquire tenant
     let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
     let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
-    let (filters_rs, filters_ws) = create_signal(ExperimentListFilters {
-        status: None,
-        from_date: Utc.timestamp_opt(0, 0).single(),
-        to_date: Utc.timestamp_opt(4130561031, 0).single(),
-        experiment_name: None,
-        experiment_ids: None,
-        created_by: None,
-        context: None,
-        sort_on: Some(utils::ExperimentSortOn::LastModifiedAt),
-        sort_by: Some(SortBy::Desc),
-    });
+    let filters_rws = create_rw_signal(ExperimentListFilters::default());
 
     let (pagination_filters_rs, pagination_filters_ws) =
         create_signal(PaginationParams::default());
 
     let (reset_exp_form, set_exp_form) = create_signal(0);
 
-    let combined_resource: Resource<
-        (String, ExperimentListFilters, PaginationParams, String),
-        CombinedResource,
-    > = create_blocking_resource(
+    let combined_resource = create_blocking_resource(
         move || {
             (
                 tenant_rws.get().0,
-                filters_rs.get(),
+                filters_rws.get(),
                 pagination_filters_rs.get(),
                 org_rws.get().0,
             )
@@ -108,6 +363,7 @@ pub fn experiment_list() -> impl IntoView {
     );
 
     let handle_submit_experiment_form = move |_| {
+        filters_rws.set(ExperimentListFilters::default());
         combined_resource.refetch();
         set_exp_form.update(|val| {
             *val += 1;
@@ -127,7 +383,6 @@ pub fn experiment_list() -> impl IntoView {
         });
     });
 
-    // TODO: Add filters
     view! {
         <div class="p-8">
             <Suspense fallback=move || view! { <Skeleton /> }>
@@ -163,7 +418,7 @@ pub fn experiment_list() -> impl IntoView {
                         {move || {
                             let value = combined_resource.get();
                             let pagination = pagination_filters_rs.get();
-                            let table_columns = experiment_table_columns(filters_rs, filters_ws);
+                            let table_columns = experiment_table_columns(filters_rws);
                             match value {
                                 Some(v) => {
                                     let data = v
@@ -199,12 +454,17 @@ pub fn experiment_list() -> impl IntoView {
                                     };
                                     view! {
                                         <ConditionCollapseProvider>
+                                            <ExperimentTableFilterWidget
+                                                filters_rws
+                                                combined_resource=v
+                                            />
                                             <Table
                                                 rows=data
                                                 key_column="id".to_string()
                                                 columns=table_columns
                                                 pagination=pagination_props
                                             />
+
                                         </ConditionCollapseProvider>
                                     }
                                 }

--- a/crates/frontend/src/pages/experiment_list/utils.rs
+++ b/crates/frontend/src/pages/experiment_list/utils.rs
@@ -31,10 +31,9 @@ impl Default for ExperimentSortOn {
 }
 
 pub fn experiment_table_columns(
-    filters_rs: ReadSignal<ExperimentListFilters>,
-    filters_ws: WriteSignal<ExperimentListFilters>,
+    filters_rws: RwSignal<ExperimentListFilters>,
 ) -> Vec<Column> {
-    let current_filters = filters_rs.get();
+    let current_filters = filters_rws.get();
     let current_sort_on = current_filters.sort_on.unwrap_or_default();
     let current_sort_by = current_filters.sort_by.unwrap_or_default();
     vec![
@@ -173,14 +172,14 @@ pub fn experiment_table_columns(
             "created_at".to_string(),
             ColumnSortable::Yes {
                 sort_fn: Callback::new(move |_| {
-                    let filters = filters_rs.get();
+                    let filters = filters_rws.get();
                     let sort_by = filters.sort_by.unwrap_or_default().flip();
                     let new_filters = ExperimentListFilters {
                         sort_on: Some(ExperimentSortOn::CreatedAt),
                         sort_by: Some(sort_by),
                         ..filters
                     };
-                    filters_ws.set(new_filters);
+                    filters_rws.set(new_filters);
                 }),
                 sort_by: current_sort_by.clone(),
                 currently_sorted: current_sort_on == ExperimentSortOn::CreatedAt,
@@ -191,14 +190,14 @@ pub fn experiment_table_columns(
             "last_modified".to_string(),
             ColumnSortable::Yes {
                 sort_fn: Callback::new(move |_| {
-                    let filters = filters_rs.get();
+                    let filters = filters_rws.get();
                     let sort_by = filters.sort_by.as_ref().map(|i| i.flip());
                     let new_filters = ExperimentListFilters {
                         sort_on: Some(ExperimentSortOn::LastModifiedAt),
                         sort_by,
                         ..filters
                     };
-                    filters_ws.set(new_filters);
+                    filters_rws.set(new_filters);
                 }),
                 sort_by: current_sort_by,
                 currently_sorted: current_sort_on == ExperimentSortOn::LastModifiedAt,

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -270,7 +270,7 @@ pub fn home() -> impl IntoView {
         let context_updated = context_rs.get();
         // resolve the context and get the config that would apply
         spawn_local(async move {
-            let context = context_updated.to_query_string();
+            let context = context_updated.as_query_string();
             let mut config = match resolve_config(
                 tenant_rws.get_untracked().0,
                 context,

--- a/crates/frontend/tailwind.config.js
+++ b/crates/frontend/tailwind.config.js
@@ -7,6 +7,16 @@ module.exports = {
         './src/components/**/*.rs',
         './src/hoc/**/*.rs',
     ],
+    safelist: [
+        "peer/concluded-checkbox",
+        "peer/created-checkbox",
+        "peer/inprogress-checkbox",
+        "peer/discarded-checkbox",
+        "peer-checked/discarded-checkbox:badge-neutral",
+        "peer-checked/concluded-checkbox:badge-success",
+        "peer-checked/created-checkbox:badge-info",
+        "peer-checked/inprogress-checkbox:badge-warning",
+    ],
     theme: {
         extend: {
             keyframes: {

--- a/crates/superposition_types/Cargo.toml
+++ b/crates/superposition_types/Cargo.toml
@@ -22,6 +22,7 @@ log = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+strum = { workspace = true, optional = true }
 strum_macros = { workspace = true }
 superposition_derives = { path = "../superposition_derives", optional = true }
 thiserror = { version = "1.0.57", optional = true }
@@ -38,7 +39,7 @@ diesel_derives = [
 disable_db_data_validation = []
 result = ["dep:diesel", "dep:anyhow", "dep:thiserror", "dep:actix-web"]
 server = ["dep:actix-web"]
-experimentation = []
+experimentation = ["dep:strum"]
 api = []
 
 [lints]

--- a/crates/superposition_types/src/database/models/experimentation.rs
+++ b/crates/superposition_types/src/database/models/experimentation.rs
@@ -15,7 +15,16 @@ use crate::{Condition, Exp, Overrides};
 use super::super::schema::*;
 
 #[derive(
-    Debug, Clone, Copy, PartialEq, Deserialize, Serialize, strum_macros::Display,
+    Debug,
+    Clone,
+    Copy,
+    Eq,
+    Hash,
+    PartialEq,
+    Deserialize,
+    Serialize,
+    strum_macros::Display,
+    strum_macros::EnumIter,
 )]
 #[serde(rename_all = "UPPERCASE")]
 #[strum(serialize_all = "UPPERCASE")]
@@ -30,8 +39,8 @@ use super::super::schema::*;
 )]
 pub enum ExperimentStatusType {
     CREATED,
-    CONCLUDED,
     INPROGRESS,
+    CONCLUDED,
     DISCARDED,
 }
 
@@ -47,6 +56,15 @@ impl ExperimentStatusType {
         match self {
             Self::CREATED => true,
             Self::INPROGRESS | Self::CONCLUDED | Self::DISCARDED => false,
+        }
+    }
+
+    pub fn badge_color(&self) -> &'static str {
+        match self {
+            Self::CREATED => "badge-info",
+            Self::INPROGRESS => "badge-warning",
+            Self::CONCLUDED => "badge-success",
+            Self::DISCARDED => "badge-neutral",
         }
     }
 }


### PR DESCRIPTION
## Problem
It is hard to search for experiments

## Solution
Add the ability to filter and manage experiments. Search is done on the backend, so even paginated experiments can be searched for

https://github.com/user-attachments/assets/cc9f1344-fc7b-4868-885f-65f2a3085703



