### PR TITLE
fix: scope ownership in get config HP mode

### DIFF
--- a/crates/context_aware_config/src/api/config/handlers.rs
+++ b/crates/context_aware_config/src/api/config/handlers.rs
@@ -58,7 +58,7 @@ pub fn endpoints() -> Scope {
         .service(reduce_config)
         .service(get_config_versions);
     #[cfg(feature = "high-performance-mode")]
-    scope.service(get_config_fast);
+    let scope = scope.service(get_config_fast);
     scope
 }
 


### PR DESCRIPTION
## Problem
Scope is being moved out

```
error[E0382]: use of moved value: `scope`
#33 164.3    --> superposition/crates/context_aware_config/src/api/config/handlers.rs:62:5
#33 164.3     |
#33 164.3 55  |     let scope = Scope::new("")
#33 164.3     |         ----- move occurs because `scope` has type `actix_web::Scope`, which does not implement the `Copy` trait
#33 164.3 ...
#33 164.3 61  |     scope.service(get_config_fast);
#33 164.3     |           ------------------------ `scope` moved due to this method call
#33 164.3 62  |     scope
#33 164.3     |     ^^^^^ value used here after move
#33 164.3     |
#33 164.3 note: `actix_web::Scope::<T>::service` takes ownership of the receiver `self`, which moves `scope`
#33 164.3    --> /usr/local/cargo/registry/src/index.crates.io-6f17d22bba15001f/actix-web-4.5.1/src/scope.rs:233:27
#33 164.3     |
#33 164.3 233 |     pub fn service<F>(mut self, factory: F) -> Self
#33 164.3     |                           ^^^^
#33 164.3 
```

## Solution
use let