### PR TITLE
feat: Added support for completions in monaco editor.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,6 +2085,7 @@ dependencies = [
  "once_cell",
  "reqwest",
  "serde",
+ "serde-wasm-bindgen",
  "serde_json",
  "strum",
  "strum_macros",

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -2,6 +2,7 @@
 name = "frontend"
 version = "0.21.0"
 edition = "2021"
+include = ["src/**/*", "src-js/**/*"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
@@ -25,26 +26,27 @@ reqwest = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
 superposition_types = { path = "../superposition_types", features = [
-  "experimentation",
-  "api"
+    "experimentation",
+    "api",
 ], default-features = false }
 url = { workspace = true }
 wasm-bindgen = "=0.2.93"
 web-sys = { version = "0.3.64", features = [
-  "Event",
-  "Worker",
-  "Blob",
-  "Window",
-  "Storage",
+    "Event",
+    "Worker",
+    "Blob",
+    "Window",
+    "Storage",
 ] }
+serde-wasm-bindgen = "0.6.5"
 
 [features]
 csr = ["leptos/csr", "leptos_meta/csr", "leptos_router/csr"]
 hydrate = [
-  "leptos/hydrate",
-  "leptos_meta/hydrate",
-  "leptos_router/hydrate",
-  "console_error_panic_hook",
+    "leptos/hydrate",
+    "leptos_meta/hydrate",
+    "leptos_router/hydrate",
+    "console_error_panic_hook",
 ]
 ssr = ["leptos/ssr", "leptos_meta/ssr", "leptos_router/ssr"]
 

--- a/crates/frontend/src-js/utils.js
+++ b/crates/frontend/src-js/utils.js
@@ -1,0 +1,47 @@
+/**
+ * Sensible conversion of javascript value to string.
+ * @param {*} v
+ * @returns {string}
+ */
+function toStr(v) {
+    switch (typeof v) {
+        case "string":
+            return v;
+        case "object":
+            return JSON.stringify(v);
+        default:
+            return v.toString();
+    }
+}
+
+/**
+ * Constructor
+ * @param {Array} triggers
+ * @param {Array} suggestions
+ * @returns {CompletionItemProvider} https://microsoft.github.io/monaco-editor/docs.html#interfaces/languages.CompletionItemProvider.html
+ */
+export function newSuggestionsProvider(triggers, suggestions) {
+    if (typeof suggestions !== "object" || !Array.isArray(suggestions)) {
+        throw new Error(`suggestions: ${suggestions} is not an array!`);
+    }
+    if (typeof triggers !== "object" || !Array.isArray(triggers)) {
+        throw new Error(`triggers: ${triggers} is not an array!`);
+    }
+    return {
+        provideCompletionItems: function (model, position) {
+            return {
+                suggestions: suggestions.map((s) => ({
+                    // This is the text that shows up in the completion hover.
+                    label: toStr(s),
+                    // FIXME Coupling w/ private Enum, this can break w/ a newer version of
+                    // monaco.
+                    kind: 15, // Maps to the `Enum` varaint of `Kind`.
+                    insertText: toStr(s),
+                    detail: "Enum variant",
+                    documentation: "Json Enum",
+                })),
+            };
+        },
+        triggerCharacters: triggers,
+    };
+}

--- a/crates/frontend/src/components/default_config_form.rs
+++ b/crates/frontend/src/components/default_config_form.rs
@@ -288,7 +288,7 @@ where
                                     on_change=Callback::new(move |new_config_schema| {
                                         config_schema_ws.set(new_config_schema)
                                     })
-                                    r#type=InputType::Monaco
+                                    r#type=InputType::Monaco(vec![])
                                 />
 
                                 <Show when=move || {

--- a/crates/frontend/src/components/dimension_form.rs
+++ b/crates/frontend/src/components/dimension_form.rs
@@ -240,7 +240,7 @@ where
                                     on_change=Callback::new(move |new_type_schema| {
                                         dimension_schema_ws.set(new_type_schema)
                                     })
-                                    r#type=InputType::Monaco
+                                    r#type=InputType::Monaco(vec![])
                                 />
                             </EditorProvider>
                         </div>

--- a/crates/frontend/src/components/type_template_form.rs
+++ b/crates/frontend/src/components/type_template_form.rs
@@ -159,7 +159,7 @@ where
                                 on_change=Callback::new(move |new_type_schema| {
                                     type_schema_ws.set(new_type_schema)
                                 })
-                                r#type=InputType::Monaco
+                                r#type=InputType::Monaco(vec![])
                             />
                         </EditorProvider>
                     }

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -1,7 +1,15 @@
 { inputs, ... }:
 {
   debug = true;
-  perSystem = { config, self', pkgs, lib, system, ... }:
+  perSystem =
+    {
+      config,
+      self',
+      pkgs,
+      lib,
+      system,
+      ...
+    }:
     let
       inherit (pkgs.stdenv) isDarwin;
       inherit (pkgs.darwin) apple_sdk;
@@ -13,20 +21,37 @@
       rust-project = {
         # NOTE: It may be possible to obviate much of these buildInputs using
         # https://github.com/juspay/rust-flake/issues/14
+        # To avoid unnecessary rebuilds, start from cleaned source, and then add the Nix files necessary to `nix run` it. Finally, add any files required by the Rust build.
+        src =
+          let
+            # Like crane's filterCargoSources, but doesn't blindly include all TOML files!
+            filterCargoSources =
+              path: type:
+              config.rust-project.crane-lib.filterCargoSources path type
+              && !(lib.hasSuffix ".toml" path && !lib.hasSuffix "Cargo.toml" path);
+          in
+          lib.cleanSourceWith {
+            src = inputs.self;
+            filter = path: type:
+              filterCargoSources path type
+              ## Include js files from frontend.
+              || (lib.hasInfix "frontend/src-js" path && lib.hasSuffix ".js" path);
+          };
         crates = {
           "cac_client" = {
             imports = [ globalCrateConfig ];
             autoWire = true; # Used by Haskell client
             crane = {
               args = {
-                buildInputs = lib.optionals isDarwin
-                  ([
+                buildInputs =
+                  lib.optionals isDarwin ([
                     apple_sdk.frameworks.Security
                     pkgs.fixDarwinDylibNames
-                  ]) ++ [
-                  pkgs.postgresql_12
-                  pkgs.openssl
-                ];
+                  ])
+                  ++ [
+                    pkgs.postgresql_12
+                    pkgs.openssl
+                  ];
               };
               extraBuildArgs = {
                 # https://discourse.nixos.org/t/how-to-use-install-name-tool-on-darwin/9931/2
@@ -40,14 +65,15 @@
             autoWire = true; # Used by Haskell client
             crane = {
               args = {
-                buildInputs = lib.optionals isDarwin
-                  ([
+                buildInputs =
+                  lib.optionals isDarwin ([
                     apple_sdk.frameworks.Security
                     pkgs.fixDarwinDylibNames
-                  ]) ++ [
-                  pkgs.postgresql_12
-                  pkgs.openssl
-                ];
+                  ])
+                  ++ [
+                    pkgs.postgresql_12
+                    pkgs.openssl
+                  ];
               };
               extraBuildArgs = {
                 # https://discourse.nixos.org/t/how-to-use-install-name-tool-on-darwin/9931/2
@@ -60,12 +86,13 @@
           "experimentation_example" = {
             crane = {
               args = {
-                buildInputs = lib.optionals isDarwin
-                  ([
+                buildInputs =
+                  lib.optionals isDarwin ([
                     apple_sdk.frameworks.Security
-                  ]) ++ [
-                  pkgs.openssl
-                ];
+                  ])
+                  ++ [
+                    pkgs.openssl
+                  ];
               };
             };
           };
@@ -73,13 +100,14 @@
             imports = [ globalCrateConfig ];
             crane = {
               args = {
-                buildInputs = lib.optionals isDarwin
-                  ([
+                buildInputs =
+                  lib.optionals isDarwin ([
                     apple_sdk.frameworks.Security
-                  ]) ++ [
-                  pkgs.openssl
-                  pkgs.postgresql_12
-                ];
+                  ])
+                  ++ [
+                    pkgs.openssl
+                    pkgs.postgresql_12
+                  ];
               };
             };
           };
@@ -87,16 +115,17 @@
             imports = [ globalCrateConfig ];
             crane = {
               args = {
-                buildInputs = lib.optionals isDarwin
-                  ([
+                buildInputs =
+                  lib.optionals isDarwin ([
                     apple_sdk.frameworks.Security
                     apple_sdk.frameworks.SystemConfiguration
                     pkgs.fixDarwinDylibNames
-                  ]) ++ [
-                  pkgs.libiconv
-                  pkgs.openssl
-                  pkgs.postgresql_12
-                ];
+                  ])
+                  ++ [
+                    pkgs.libiconv
+                    pkgs.openssl
+                    pkgs.postgresql_12
+                  ];
                 nativeBuildInputs = with pkgs; [
                   pkg-config
                 ];


### PR DESCRIPTION
- Monaco input type now accepts a vector of json values to be used for completions.
- Added JS-FFI(via wasm-bindgen) to create a monaco completions object. This is required as we have to call another JS-FFI to register this object, and that FFI itself accepts a foreign JS type, so needed to write the constructor in JS.
- Completions get registered on render & cleaned up on de-render.

![tmp FEP15rxtNz](https://github.com/user-attachments/assets/e907b149-61cf-4c4c-9ab8-62d0dfd24c15)


