### PR TITLE
fix: Params being sent in resolve page

### DIFF
--- a/crates/frontend/src/logic.rs
+++ b/crates/frontend/src/logic.rs
@@ -116,34 +116,10 @@ impl Expression {
             }
         }
     }
-    fn to_expression_query_str(&self, var: &str) -> String {
+    fn to_expression_query_str(&self, var: &str) -> Option<String> {
         match self {
-            Expression::Is(c) => {
-                format!("{}{}{}", var, "==", c.html_display())
-            }
-            Expression::In(c) => {
-                format!("{}{}{}", var, "in", c.html_display())
-            }
-            Expression::Has(c) => {
-                format!("{}{}{}", var, "in", c.html_display())
-            }
-            Expression::Between(c1, c2) => {
-                let c_str = format!("{},{}", c1.html_display(), c2.html_display());
-                format!("{}{}{}", var, "<=", c_str)
-            }
-            Expression::Other(operator, operands) => {
-                let c_str = operands
-                    .iter()
-                    .filter_map(|operand| {
-                        if is_variable(operand) {
-                            return None;
-                        }
-                        Some(operand.html_display())
-                    })
-                    .collect::<Vec<String>>()
-                    .join(",");
-                format!("{}{}{}", var, operator, c_str)
-            }
+            Expression::Is(c) => Some(format!("{var}={value}", value = c.html_display())),
+            _ => None,
         }
     }
     pub fn to_constants_vec(&self) -> Vec<serde_json::Value> {
@@ -304,7 +280,7 @@ impl Condition {
         self.expression.to_expression_json(&self.variable)
     }
 
-    pub fn to_condition_query_str(&self) -> String {
+    pub fn to_condition_query_str(&self) -> Option<String> {
         self.expression.to_expression_query_str(&self.variable)
     }
 }
@@ -343,7 +319,7 @@ impl Conditions {
     }
     pub fn to_query_string(self) -> String {
         self.iter()
-            .map(|v| v.to_condition_query_str())
+            .filter_map(|v| v.to_condition_query_str())
             .collect::<Vec<String>>()
             .join("&")
     }


### PR DESCRIPTION
## Problem
params for resolve being sent with the operator like: `key==value`, `keyinvalue`, instead of a simple `key=value`.
For resolve a simple assign is expected and no other operator

example:
`http://localhost:8080/config/resolve?clientId==studio1&platform==web&show_reasoning=true`


## Solution
Generate `key=value` while generating the params only, operators other than `==` are not expected in this flow