### PR TITLE
fix: z-index of delete modal

### DIFF
--- a/crates/frontend/src/components/delete_modal.rs
+++ b/crates/frontend/src/components/delete_modal.rs
@@ -11,7 +11,7 @@ pub fn delete_modal(
 
     view! {
         <Show when=move || modal_visible.get()>
-            <div class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm flex items-center justify-center">
+            <div class="fixed inset-0 bg-black bg-opacity-50 backdrop-blur-sm flex items-center justify-center z-[99999999]">
                 <dialog id="my_modal_2" class="modal" open=modal_visible.get()>
                     <div class="modal-box bg-white rounded-lg p-6 shadow-xl border-2 border-lightgray">
                         <h4 class="text-xl font-semibold text-gray-800 mb-4">Confirm Delete</h4>


### PR DESCRIPTION
## Problem
sticky content of the tables are overlapping with the delete modal, as no z-index has been provided to the backdrop of the delete modal

## Solution
Add a high z-index value to the modal backdrop