### PR TITLE
fix: Default value for dimensions while using in operator

### DIFF
--- a/crates/frontend/src/logic.rs
+++ b/crates/frontend/src/logic.rs
@@ -150,7 +150,7 @@ impl From<(SchemaType, Operator)> for Expression {
     fn from((r#type, operator): (SchemaType, Operator)) -> Self {
         match operator {
             Operator::Is => Expression::Is(r#type.default_value()),
-            Operator::In => Expression::In(Value::Array(vec![r#type.default_value()])),
+            Operator::In => Expression::In(Value::Array(vec![])),
             Operator::Has => Expression::Has(r#type.default_value()),
             Operator::Between => {
                 Expression::Between(r#type.default_value(), r#type.default_value())


### PR DESCRIPTION
## Problem
When `in` operator is used, the default value of the input instead of being `[]` is currently being used as `[""]`, `[false]`, `[0]` for string, boolean, integer arrays and so on

## Solution
Use `[]` as the default value for `in` operator
