### PR TITLE
feat: generate multiple binaries for clients based on platform

### DIFF
--- a/.github/workflows/generate_client_bundles.yaml
+++ b/.github/workflows/generate_client_bundles.yaml
@@ -1,0 +1,83 @@
+name: Build and distribute clients for multiple platforms
+
+on: workflow_dispatch
+
+jobs:
+  generate-builds:
+    strategy:
+      max-parallel: 5
+      matrix:
+        platform:
+            - os: ubuntu-latest
+              target: x86_64-unknown-linux-gnu
+              cac_bin_name: libcac_client.so
+              exp_bin_name: libexperimentation_client.so
+              cac_zip_name: superposition_cac_client-x86_64-unknown-linux-gnu.zip
+              exp_zip_name: superposition_experimentation_client-x86_64-unknown-linux-gnu.zip
+            - os: macos-latest
+              target: x86_64-apple-darwin
+              cac_bin_name: libcac_client.dylib
+              exp_bin_name: libexperimentation_client.dylib
+              cac_zip_name: superposition_cac_client-x86_64-apple-darwin.zip
+              exp_zip_name: superposition_experimentation_client-x86_64-apple-darwin.zip
+            - os: macos-latest
+              target: aarch64-apple-darwin
+              cac_bin_name: libcac_client.dylib
+              exp_bin_name: libexperimentation_client.dylib
+              cac_zip_name: superposition_cac_client-aarch64-apple-darwin.zip
+              exp_zip_name: superposition_experimentation_client-aarch64-apple-darwin.zip
+            - os: windows-latest
+              target: x86_64-pc-windows-msvc
+              cac_bin_name: cac_client.dll
+              exp_bin_name: experimentation_client.dll
+              cac_zip_name: superposition_cac_client-x86_64-pc-windows-msvc.zip
+              exp_zip_name: superposition_experimentation_client-x86_64-pc-windows-msvc.zip
+    runs-on: ${{ matrix.platform.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+            fetch-depth: 0
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@master
+        with:
+            toolchain: 1.78.0
+            targets: ${{ matrix.platform.target }}
+            components: rustfmt, clippy
+
+      - name: Build and package for ${{ matrix.platform.os }}
+        if: matrix.platform.os != 'windows-latest'
+        run: |
+          cargo build --package cac_client --release --target ${{ matrix.platform.target }}
+          cargo build --package experimentation_client --release --target ${{ matrix.platform.target }}
+          zip -r ${{ matrix.platform.cac_zip_name }} target/${{ matrix.platform.target }}/release/${{ matrix.platform.cac_bin_name }} headers/libcac_client.h
+          zip -r ${{ matrix.platform.exp_zip_name }} target/${{ matrix.platform.target }}/release/${{ matrix.platform.exp_bin_name }} headers/libexperimentation_client.h
+
+      - name: Build and package for ${{ matrix.platform.os }} on windows
+        if: matrix.platform.os == 'windows-latest'
+        run: |
+          cargo build --package cac_client --release --target ${{ matrix.platform.target }}
+          cargo build --package experimentation_client --release --target ${{ matrix.platform.target }}
+          Compress-Archive -Path "target\${{ matrix.platform.target }}\release\${{ matrix.platform.cac_bin_name }}","headers\libcac_client.h" -DestinationPath ${{ matrix.platform.cac_zip_name }}
+          Compress-Archive -Path "target\${{ matrix.platform.target }}\release\${{ matrix.platform.exp_bin_name }}","headers\libexperimentation_client.h" -DestinationPath ${{ matrix.platform.exp_zip_name }}
+
+      - name: Upload cac artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform.cac_zip_name }}
+          path: ${{ matrix.platform.cac_zip_name }}
+
+      - name: Upload experimentation artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.platform.exp_zip_name }}
+          path: ${{ matrix.platform.exp_zip_name }}
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            ${{ matrix.platform.exp_zip_name }}
+            ${{ matrix.platform.cac_zip_name }}

--- a/crates/cac_client/src/interface.rs
+++ b/crates/cac_client/src/interface.rs
@@ -103,7 +103,8 @@ pub extern "C" fn cac_new_client(
     update_frequency: c_ulong,
     hostname: *const c_char,
 ) -> c_int {
-    let duration = Duration::new(update_frequency, 0);
+    #[allow(clippy::useless_conversion)] // done for windows support
+    let duration = Duration::new(update_frequency.into(), 0);
     let tenant = unwrap_safe!(cstring_to_rstring(tenant), return 1);
     let hostname = unwrap_safe!(cstring_to_rstring(hostname), return 1);
     // println!("Creating cac client thread for tenant {tenant}");
@@ -130,19 +131,21 @@ pub extern "C" fn cac_new_client_with_cache_properties(
     cache_ttl: c_ulong,
     cache_tti: c_ulong,
 ) -> c_int {
-    let duration = Duration::new(update_frequency, 0);
+    #[allow(clippy::useless_conversion)] // done for windows support
+    let duration = Duration::new(update_frequency.into(), 0);
     let tenant = unwrap_safe!(cstring_to_rstring(tenant), return 1);
     let hostname = unwrap_safe!(cstring_to_rstring(hostname), return 1);
     // println!("Creating cac client thread for tenant {tenant}");
     CAC_RUNTIME.block_on(async move {
+        #[allow(clippy::useless_conversion)]
         match CLIENT_FACTORY
             .create_client_with_cache_properties(
                 tenant.clone(),
                 duration,
                 hostname,
-                cache_max_capacity,
-                cache_ttl,
-                cache_tti,
+                cache_max_capacity.into(),
+                cache_ttl.into(),
+                cache_tti.into(),
             )
             .await
         {

--- a/crates/experimentation_client/src/interface.rs
+++ b/crates/experimentation_client/src/interface.rs
@@ -114,8 +114,9 @@ pub extern "C" fn expt_new_client(
 
     // println!("Creating cac client thread for tenant {tenant}");
     EXP_RUNTIME.block_on(async move {
+        #[allow(clippy::useless_conversion)]
         match CLIENT_FACTORY
-            .create_client(tenant.clone(), update_frequency, hostname)
+            .create_client(tenant.clone(), update_frequency.into(), hostname)
             .await
         {
             Ok(_) => 0,

--- a/scripts/setup_client.sh
+++ b/scripts/setup_client.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+
+download_binary() {
+  local url=$1
+  local zip_name=$2
+
+  if [ -z "$url" ]; then
+    echo "Unsupported platform/architecture combination"
+    return 1
+  fi
+
+  if ! curl "$url" -L -o "$zip_name"; then
+    echo "Failed to download binary: $?"
+    return 1
+  fi
+
+  unzip "$zip_name" -d "superposition"
+  rm "$zip_name"
+}
+
+
+# Define the URL for each platform
+declare -A cac_urls
+cac_urls["windows-x86_64"]="https://github.com/Datron/superposition/releases/download/testing/superposition_cac_client-x86_64-pc-windows-msvc.zip"
+cac_urls["linux-x86_64"]="https://github.com/Datron/superposition/releases/download/testing/superposition_cac_client-x86_64-unknown-linux-gnu.zip"
+cac_urls["darwin-x86_64"]="https://github.com/Datron/superposition/releases/download/testing/superposition_cac_client-x86_64-apple-darwin.zip"
+cac_urls["darwin-aarch64"]="https://github.com/Datron/superposition/releases/download/testing/superposition_cac_client-aarch64-apple-darwin.zip"
+
+declare -A exp_urls
+exp_urls["windows-x86_64"]="https://github.com/Datron/superposition/releases/download/testing/superposition_experimentation_client-x86_64-pc-windows-msvc.zip"
+exp_urls["linux-x86_64"]="https://github.com/Datron/superposition/releases/download/testing/superposition_experimentation_client-x86_64-unknown-linux-gnu.zip"
+exp_urls["darwin-x86_64"]="https://github.com/Datron/superposition/releases/download/testing/superposition_experimentation_client-x86_64-apple-darwin.zip"
+exp_urls["darwin-aarch64"]="https://github.com/Datron/superposition/releases/download/testing/superposition_experimentation_client-aarch64-apple-darwin.zip"
+
+# Determine the current platform
+platform=$(uname -s)
+arch=$(uname -m )
+
+# Map the platform and arch to the correct URL
+case $platform in
+  MINGW|Win32|MSYS|CYGWIN*)
+    platform="windows"
+    ;;
+  Linux)
+    platform="linux"
+    ;;
+  Darwin)
+    platform="darwin"
+    ;;
+  *)
+    echo "Unsupported platform: $platform"
+    exit 1
+    ;;
+esac
+
+case $arch in
+  x86_64)
+    arch="x86_64"
+    ;;
+  arm64)
+    arch="aarch64"
+    ;;
+  *)
+    echo "Unsupported architecture: $arch"
+    exit 1
+    ;;
+esac
+
+# Download the binary
+download_binary "${cac_urls[$platform-$arch]}" "superposition_cac_client.zip"
+download_binary "${exp_urls[$platform-$arch]}" "superposition_exp_client.zip"
+
+mv superposition/headers/* superposition/
+mv superposition/target/**/release/* superposition/
+rm -rf superposition/headers superposition/target


### PR DESCRIPTION
## Problem
We don't generate distributive binaries for our clients

## Solution
Add a workflow to generate builds for linux, macOS and update interface.rs to support windows builds in the future.