### PR TITLE
fix: removing `and` block if context is empty

### DIFF
--- a/crates/frontend/src/logic.rs
+++ b/crates/frontend/src/logic.rs
@@ -314,6 +314,9 @@ impl Conditions {
         }))
     }
     pub fn as_context_json(&self) -> serde_json::Value {
+        if self.is_empty() {
+            return json!({});
+        }
         json!({
             "and": self.iter().map(|v| v.to_condition_json()).collect::<Vec<serde_json::Value>>()
         })


### PR DESCRIPTION
## Problem
Context with an empty `and` block evaluates as false for all cases.

## Solution
Prevent adding `and` block if the context is empty from frontend.