### PR TITLE
refactor: Refactored organisation smtihy model w/ mixin for requests.

### DIFF
--- a/smithy/models/organisation.smithy
+++ b/smithy/models/organisation.smithy
@@ -31,36 +31,27 @@ enum OrgStatus {
     PendingKyb = "PendingKyb"
 }
 
-structure CreateOrganisationRequest for Organisation {
+@mixin
+structure OrganisationFields for Organisation {
     $country_code
-
     $contact_email
-
     $contact_phone
+    $admin_email
+    $sector
+}
 
+structure CreateOrganisationRequest for Organisation with [OrganisationFields] {
     @required
     $admin_email
 
     @required
     $name
-
-    $sector
 }
 
-structure UpdateOrganisationRequest for Organisation {
+structure UpdateOrganisationRequest for Organisation with [OrganisationFields] {
     @httpLabel
     @required
     $id
-
-    $country_code
-
-    $contact_email
-
-    $contact_phone
-
-    $admin_email
-
-    $sector
 
     $status
 }


### PR DESCRIPTION
Refactored organisation smtihy model w/ mixin for requests. I thought that smithy fields could not be redefined after using a mixin but looks like you can if you don't change the type, see: https://smithy.io/2.0/spec/mixins.html#mixin-members-must-not-conflict
Courtesy: @sauraww 