### PR TITLE
fix delete dimension bug

### DIFF
--- a/crates/context_aware_config/src/api/dimension/handlers.rs
+++ b/crates/context_aware_config/src/api/dimension/handlers.rs
@@ -357,15 +357,18 @@ async fn delete_dimension(
                 .returning(Dimension::as_returning())
                 .schema_name(&schema_name)
                 .execute(transaction_conn)?;
+
+            let deleted_row = delete(dsl::dimensions.filter(dsl::dimension.eq(&name)))
+                .schema_name(&schema_name)
+                .execute(transaction_conn);
+
             diesel::update(dimensions::dsl::dimensions)
                 .filter(dimensions::position.gt(dimension_data.position))
                 .set(dimensions::position.eq(dimensions::position - 1))
                 .returning(Dimension::as_returning())
                 .schema_name(&schema_name)
                 .execute(transaction_conn)?;
-            let deleted_row = delete(dsl::dimensions.filter(dsl::dimension.eq(&name)))
-                .schema_name(&schema_name)
-                .execute(transaction_conn);
+
             match deleted_row {
                 Ok(0) => Err(not_found!("Dimension `{}` doesn't exists", name)),
                 Ok(_) => Ok(HttpResponse::NoContent().finish()),

--- a/crates/superposition_types/migrations/2024-12-05-172909_dimension_priority_default/up.sql
+++ b/crates/superposition_types/migrations/2024-12-05-172909_dimension_priority_default/up.sql
@@ -3,6 +3,4 @@ ALTER TABLE public.dimensions
 ALTER COLUMN priority SET DEFAULT 1;
 
 ALTER TABLE public.dimensions
-ADD CONSTRAINT dimension_unique_position UNIQUE (position) DEFERRABLE INITIALLY IMMEDIATE;
-
-SET CONSTRAINTS dimension_unique_position DEFERRED;
+ADD CONSTRAINT dimension_unique_position UNIQUE (position) DEFERRABLE INITIALLY DEFERRED;

--- a/docker-compose/postgres/db_init.sql
+++ b/docker-compose/postgres/db_init.sql
@@ -469,9 +469,7 @@ ALTER TABLE localorg_test.dimensions
 ALTER COLUMN priority SET DEFAULT 1;
 
 ALTER TABLE localorg_test.dimensions
-ADD CONSTRAINT dimension_unique_position UNIQUE (position) DEFERRABLE INITIALLY IMMEDIATE;
-
-SET CONSTRAINTS localorg_test.dimension_unique_position DEFERRED;
+ADD CONSTRAINT dimension_unique_position UNIQUE (position) DEFERRABLE INITIALLY DEFERRED;
 
 ALTER TABLE localorg_test.contexts ADD COLUMN IF NOT EXISTS description TEXT DEFAULT '' NOT NULL;
 ALTER TABLE localorg_test.contexts ADD COLUMN IF NOT EXISTS change_reason TEXT DEFAULT '' NOT NULL;
@@ -1046,9 +1044,7 @@ ALTER TABLE localorg_dev.dimensions
 ALTER COLUMN priority SET DEFAULT 1;
 
 ALTER TABLE localorg_dev.dimensions
-ADD CONSTRAINT dimension_unique_position UNIQUE (position) DEFERRABLE INITIALLY IMMEDIATE;
-
-SET CONSTRAINTS localorg_dev.dimension_unique_position DEFERRED;
+ADD CONSTRAINT dimension_unique_position UNIQUE (position) DEFERRABLE INITIALLY DEFERRED;
 
 ALTER TABLE localorg_dev.contexts ADD COLUMN IF NOT EXISTS description TEXT DEFAULT '' NOT NULL;
 ALTER TABLE localorg_dev.contexts ADD COLUMN IF NOT EXISTS change_reason TEXT DEFAULT '' NOT NULL;

--- a/workspace_template.sql
+++ b/workspace_template.sql
@@ -406,9 +406,7 @@ ALTER TABLE {replaceme}.dimensions
 ALTER COLUMN priority SET DEFAULT 1;
 
 ALTER TABLE {replaceme}.dimensions
-ADD CONSTRAINT dimension_unique_position UNIQUE (position) DEFERRABLE INITIALLY IMMEDIATE;
-
-SET CONSTRAINTS {replaceme}.dimension_unique_position DEFERRED;
+ADD CONSTRAINT dimension_unique_position UNIQUE (position) DEFERRABLE INITIALLY DEFERRED;
 
 ALTER TABLE {replaceme}.contexts ADD COLUMN IF NOT EXISTS description TEXT DEFAULT '' NOT NULL;
 ALTER TABLE {replaceme}.contexts ADD COLUMN IF NOT EXISTS change_reason TEXT DEFAULT '' NOT NULL;


### PR DESCRIPTION
## Problem
Delete dimension is not working and it gives , issue was in constraint instead of initially immediate
it should be initially deferred.

also without deferrable constraints create/update/delete apis not working , so deferrable is necessary

Constraint Type | Can Be Deferred? | Enforced When? | Behavior in Your Case
-- | -- | -- | --
UNIQUE (position) (non-deferrable) | ❌ No | Always immediately | ❌ Fails due to temporary duplicates
UNIQUE (position) DEFERRABLE INITIALLY IMMEDIATE | ✅ Yes | By default, immediately  (but deferrable by planner if safe) | ✅ Works, because PG planner handles it smartly



## Solution
Provide a brief summary of your solution so that reviewers can understand your code

## Environment variable changes

What ENVs need to be added or changed

## Pre-deployment activity
Things needed to be done before deploying this change (if any)

## Post-deployment activity
Things needed to be done after deploying this change (if any)

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
Describe any possible issues that could occur because of this change