### PR TITLE
feat: Add QueryString proc_macro_derive

### DIFF
--- a/crates/experimentation_client/src/lib.rs
+++ b/crates/experimentation_client/src/lib.rs
@@ -14,7 +14,7 @@ use reqwest::StatusCode;
 use serde_json::{Map, Value};
 use superposition_types::{
     api::experiments::ExperimentListFilters,
-    custom_query::{CommaSeparatedQParams, PaginationParams},
+    custom_query::{CommaSeparatedQParams, PaginationParams, QueryString},
     database::models::experimentation::{
         Bucket, ExperimentGroup, ExperimentStatusType, Variant,
     },
@@ -322,7 +322,11 @@ async fn get_experiments(
         sort_by: None,
     };
     let pagination_params = PaginationParams::all_entries();
-    let endpoint = format!("{hostname}/experiments?{pagination_params}&{list_filters}");
+    let endpoint = format!(
+        "{hostname}/experiments?{}&{}",
+        pagination_params.to_query(),
+        list_filters.to_query()
+    );
     let experiment_response = http_client
         .get(endpoint)
         .header("x-tenant", tenant.to_string())
@@ -363,7 +367,10 @@ async fn get_experiment_groups(
     tenant: String,
 ) -> Result<ExperimentGroupStore, String> {
     let pagination_params = PaginationParams::all_entries();
-    let endpoint = format!("{hostname}/experiment-groups?{pagination_params}");
+    let endpoint = format!(
+        "{hostname}/experiment-groups?{}",
+        pagination_params.to_query()
+    );
 
     let experiment_group_response = http_client
         .get(endpoint)

--- a/crates/frontend/src/api.rs
+++ b/crates/frontend/src/api.rs
@@ -21,7 +21,7 @@ use superposition_types::{
         webhook::{CreateWebhookRequest, UpdateWebhookRequest, WebhookName},
         workspace::{CreateWorkspaceRequest, UpdateWorkspaceRequest, WorkspaceResponse},
     },
-    custom_query::{DimensionQuery, PaginationParams, QueryMap},
+    custom_query::{DimensionQuery, PaginationParams, QueryMap, QueryString},
     database::models::{
         cac::{ConfigVersion, Context, DefaultConfig, Function, TypeTemplate},
         experimentation::ExperimentGroup,
@@ -40,7 +40,7 @@ pub async fn fetch_dimensions(
     let client = reqwest::Client::new();
     let host = use_host_server();
 
-    let url = format!("{}/dimension?{}", host, filters);
+    let url = format!("{}/dimension?{}", host, filters.to_query());
     let response: PaginatedResponse<DimensionResponse> = client
         .get(url)
         .header("x-tenant", &tenant)
@@ -65,7 +65,12 @@ pub async fn fetch_default_config(
     let client = reqwest::Client::new();
     let host = use_host_server();
 
-    let url = format!("{}/default-config?{}&{}", host, pagination, filters);
+    let url = format!(
+        "{}/default-config?{}&{}",
+        host,
+        pagination.to_query(),
+        filters.to_query()
+    );
     let response: PaginatedResponse<DefaultConfig> = client
         .get(url)
         .header("x-tenant", tenant)
@@ -87,7 +92,7 @@ pub async fn fetch_snapshots(
     let client = reqwest::Client::new();
     let host = use_host_server();
 
-    let url = format!("{host}/config/versions?{}", filters);
+    let url = format!("{host}/config/versions?{}", filters.to_query());
     let response: PaginatedResponse<ConfigVersion> = client
         .get(url)
         .header("x-tenant", tenant)
@@ -140,9 +145,14 @@ pub async fn fetch_experiments(
 ) -> Result<PaginatedResponse<ExperimentResponse>, ServerFnError> {
     let client = reqwest::Client::new();
     let host = use_host_server();
-    let pagination = pagination.to_string();
 
-    let url = format!("{host}/experiments?{filters}&{pagination}&{dimension_params}");
+    let url = format!(
+        "{}/experiments?{}&{}&{}",
+        host,
+        filters.to_query(),
+        pagination.to_query(),
+        dimension_params.to_query()
+    );
     let response: PaginatedResponse<ExperimentResponse> = client
         .get(url)
         .header("x-tenant", tenant)
@@ -165,7 +175,12 @@ pub async fn fetch_functions(
 ) -> Result<PaginatedResponse<Function>, ServerFnError> {
     let client = reqwest::Client::new();
     let host = use_host_server();
-    let url = format!("{}/function?{}&{}", host, filters, pagination);
+    let url = format!(
+        "{}/function?{}&{}",
+        host,
+        filters.to_query(),
+        pagination.to_query()
+    );
     let response: PaginatedResponse<Function> = client
         .get(url)
         .header("x-tenant", tenant)
@@ -243,8 +258,12 @@ pub async fn fetch_context(
 ) -> Result<PaginatedResponse<Context>, ServerFnError> {
     let client = reqwest::Client::new();
     let host = use_host_server();
-    let url =
-        format!("{host}/context/list?{pagination}&{context_filters}&{dimension_params}");
+    let url = format!(
+        "{host}/context/list?{}&{}&{}",
+        pagination.to_query(),
+        context_filters.to_query(),
+        dimension_params.to_query()
+    );
 
     match client
         .get(url)
@@ -353,7 +372,7 @@ pub async fn fetch_types(
     org_id: String,
 ) -> Result<PaginatedResponse<TypeTemplate>, ServerFnError> {
     let host = use_host_server();
-    let url = format!("{host}/types?{}", filters);
+    let url = format!("{host}/types?{}", filters.to_query());
     let err_handler = |e: String| ServerFnError::new(e.to_string());
     let response = request::<()>(
         url,
@@ -377,7 +396,7 @@ pub mod workspaces {
         org_id: &str,
     ) -> Result<PaginatedResponse<WorkspaceResponse>, ServerFnError> {
         let host = use_host_server();
-        let url = format!("{}/workspaces?{}", host, filters);
+        let url = format!("{}/workspaces?{}", host, filters.to_query());
 
         let response = request::<()>(
             url,
@@ -525,7 +544,7 @@ pub async fn fetch_webhooks(
     let client = reqwest::Client::new();
     let host = use_host_server();
 
-    let url = format!("{}/webhook?{}", host, filters);
+    let url = format!("{}/webhook?{}", host, filters.to_query());
     let response: PaginatedResponse<Webhook> = client
         .get(url)
         .header("x-tenant", &tenant)
@@ -829,9 +848,13 @@ pub mod experiment_groups {
         org_id: &str,
     ) -> Result<PaginatedResponse<ExperimentGroup>, ServerFnError> {
         let host = use_host_server();
-        let pagination = pagination.to_string();
 
-        let url = format!("{}/experiment-groups?{}&{}", host, filters, pagination);
+        let url = format!(
+            "{}/experiment-groups?{}&{}",
+            host,
+            filters.to_query(),
+            pagination.to_query()
+        );
         let response = request::<()>(
             url,
             reqwest::Method::GET,

--- a/crates/frontend/src/pages/compare_overrides/types.rs
+++ b/crates/frontend/src/pages/compare_overrides/types.rs
@@ -1,35 +1,18 @@
-use std::{
-    collections::HashMap,
-    fmt::{self, Display},
-};
+use std::collections::HashMap;
 
 use derive_more::{Deref, DerefMut};
 use serde::{Deserialize, Deserializer};
 use serde_json::{Map, Value};
-use superposition_derives::IsEmpty;
+use superposition_derives::{IsEmpty, QueryString};
 use superposition_types::{
-    custom_query::{CustomQuery, DimensionQuery},
+    custom_query::{CustomQuery, DimensionQuery, QueryString},
     IsEmpty,
 };
 
-#[derive(PartialEq, Clone, IsEmpty)]
+#[derive(PartialEq, Clone, IsEmpty, QueryString)]
 pub(super) struct PageParams {
     pub(super) grouped: bool,
     pub(super) prefix: Option<String>,
-}
-
-impl Display for PageParams {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut parts = vec![];
-
-        parts.push(format!("grouped={}", self.grouped));
-
-        if let Some(ref prefix) = self.prefix {
-            parts.push(format!("prefix={}", prefix));
-        }
-
-        write!(f, "{}", parts.join("&"))
-    }
 }
 
 impl Default for PageParams {
@@ -101,10 +84,9 @@ impl ContextList {
     }
 }
 
-impl Display for ContextList {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let parts = self
-            .clone()
+impl QueryString for ContextList {
+    fn to_query(&self) -> String {
+        self.clone()
             .0
             .into_inner()
             .iter()
@@ -115,9 +97,8 @@ impl Display for ContextList {
                     Value::Object(context.clone())
                 )
             })
-            .collect::<Vec<_>>();
-
-        write!(f, "{}", parts.join("&"))
+            .collect::<Vec<_>>()
+            .join("&")
     }
 }
 

--- a/crates/frontend/src/pages/default_config_list/types.rs
+++ b/crates/frontend/src/pages/default_config_list/types.rs
@@ -1,27 +1,11 @@
-use std::fmt::{self, Display};
-
 use serde::{Deserialize, Deserializer};
-use superposition_derives::IsEmpty;
-use superposition_types::IsEmpty;
+use superposition_derives::{IsEmpty, QueryString};
+use superposition_types::{custom_query::QueryString, IsEmpty};
 
-#[derive(PartialEq, Clone, IsEmpty)]
+#[derive(PartialEq, Clone, IsEmpty, QueryString)]
 pub struct PageParams {
     pub grouped: bool,
     pub prefix: Option<String>,
-}
-
-impl Display for PageParams {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut parts = vec![];
-
-        parts.push(format!("grouped={}", self.grouped));
-
-        if let Some(ref prefix) = self.prefix {
-            parts.push(format!("prefix={}", prefix));
-        }
-
-        write!(f, "{}", parts.join("&"))
-    }
 }
 
 impl Default for PageParams {

--- a/crates/frontend/src/pages/function/types.rs
+++ b/crates/frontend/src/pages/function/types.rs
@@ -1,22 +1,10 @@
-use std::fmt::{self, Display};
-
 use serde::Deserialize;
-use superposition_derives::IsEmpty;
-use superposition_types::{api::functions::Stage, IsEmpty};
+use superposition_derives::{IsEmpty, QueryString};
+use superposition_types::{api::functions::Stage, custom_query::QueryString, IsEmpty};
 
-#[derive(Deserialize, PartialEq, Clone, IsEmpty)]
+#[derive(Deserialize, PartialEq, Clone, IsEmpty, QueryString)]
 pub(super) struct PageParams {
     pub(super) tab: Stage,
-}
-
-impl Display for PageParams {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut parts = vec![];
-
-        parts.push(format!("tab={}", self.tab));
-
-        write!(f, "{}", parts.join("&"))
-    }
 }
 
 impl Default for PageParams {

--- a/crates/frontend/src/query_updater.rs
+++ b/crates/frontend/src/query_updater.rs
@@ -1,17 +1,16 @@
-use std::fmt::Display;
-
 use leptos::*;
 use leptos_router::{use_location, use_navigate, use_query_map, NavigateOptions};
+use superposition_types::custom_query::QueryString;
 
 use crate::utils::use_service_prefix;
 
-pub trait DisplayDefault: Display {
+pub trait DisplayDefault: QueryString {
     fn default(&self) -> String;
 }
 
-impl<T: Display + Default> DisplayDefault for T {
+impl<T: QueryString + Default> DisplayDefault for T {
     fn default(&self) -> String {
-        T::default().to_string()
+        T::default().to_query()
     }
 }
 
@@ -23,7 +22,7 @@ pub fn use_param_updater(source: impl Fn() -> Vec<Box<dyn DisplayDefault>> + 'st
     Effect::new(move |_| {
         let desired_query = source()
             .into_iter()
-            .map(|s| s.to_string())
+            .map(|s| s.to_query())
             .filter(|s| !s.is_empty())
             .collect::<Vec<_>>()
             .join("&");

--- a/crates/superposition_derives/src/lib.rs
+++ b/crates/superposition_derives/src/lib.rs
@@ -196,3 +196,95 @@ pub fn derive_is_empty(input: TokenStream) -> TokenStream {
 
     TokenStream::from(expanded)
 }
+
+/// Implements `Display` trait for the struct, allowing it to be used as a query string
+///
+#[proc_macro_derive(QueryString, attributes(query_string))]
+pub fn derive_display_query(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let struct_name = input.ident;
+
+    let fields = if let Data::Struct(data) = input.data {
+        match data.fields {
+            Fields::Named(fields) => fields.named,
+            Fields::Unnamed(_) | Fields::Unit => {
+                return syn::Error::new_spanned(
+                    struct_name,
+                    "QueryString can only be derived for structs with named fields",
+                )
+                .to_compile_error()
+                .into()
+            }
+        }
+    } else {
+        return syn::Error::new_spanned(
+            struct_name,
+            "QueryString can only be derived for structs",
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    let mut query_parts = Vec::new();
+
+    for field in fields {
+        let field_name = field.ident.unwrap();
+        let field_str = field_name.to_string();
+
+        // detect if field has #[query_string(skip_if_empty)]
+        let mut skip_if_empty = false;
+        for attr in &field.attrs {
+            if attr.path().is_ident("query_string") {
+                let ident: syn::Ident = match attr.parse_args() {
+                    Ok(v) => v,
+                    Err(_) => continue,
+                };
+                if ident == "skip_if_empty" {
+                    skip_if_empty = true;
+                }
+            }
+        }
+
+        // check if the type is Option<_>
+        let is_option = matches!(&field.ty, Type::Path(type_path) if type_path.path.segments.first().is_some_and(|seg| seg.ident == "Option"));
+
+        if is_option && skip_if_empty {
+            query_parts.push(quote! {
+                if let Some(value) = &self.#field_name {
+                    if !value.is_empty() {
+                        query_params.push(format!("{}={}", #field_str, value));
+                    }
+                }
+            });
+        } else if is_option && !skip_if_empty {
+            query_parts.push(quote! {
+                if let Some(value) = &self.#field_name {
+                    query_params.push(format!("{}={}", #field_str, value));
+                }
+            });
+        } else if skip_if_empty {
+            query_parts.push(quote! {
+                if !self.#field_name.is_empty() {
+                    query_params.push(format!("{}={}", #field_str, self.#field_name));
+                }
+            });
+        } else {
+            query_parts.push(quote! {
+                query_params.push(format!("{}={}", #field_str, self.#field_name));
+            });
+        }
+    }
+
+    let expanded = quote! {
+        impl QueryString for #struct_name {
+            fn to_query(&self) -> String {
+                let mut query_params = Vec::new();
+                #(#query_parts)*
+
+                query_params.join("&")
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/crates/superposition_types/src/api/context.rs
+++ b/crates/superposition_types/src/api/context.rs
@@ -1,11 +1,9 @@
-use std::fmt::{self, Display};
-
 use bigdecimal::BigDecimal;
 use serde::{Deserialize, Serialize};
-use superposition_derives::IsEmpty;
+use superposition_derives::{IsEmpty, QueryString};
 
 use crate::{
-    custom_query::CommaSeparatedStringQParams,
+    custom_query::{CommaSeparatedStringQParams, QueryString},
     database::models::{cac::Context, ChangeReason, Description},
     Cac, Condition, IsEmpty, Overrides, SortBy,
 };
@@ -37,52 +35,17 @@ impl Default for SortOn {
     }
 }
 
-#[derive(Deserialize, PartialEq, Default, Clone, IsEmpty)]
+#[derive(Deserialize, PartialEq, Default, Clone, IsEmpty, QueryString)]
 pub struct ContextListFilters {
+    #[query_string(skip_if_empty)]
     pub prefix: Option<CommaSeparatedStringQParams>,
     pub sort_on: Option<SortOn>,
     pub sort_by: Option<SortBy>,
+    #[query_string(skip_if_empty)]
     pub created_by: Option<CommaSeparatedStringQParams>,
+    #[query_string(skip_if_empty)]
     pub last_modified_by: Option<CommaSeparatedStringQParams>,
     pub plaintext: Option<String>,
-}
-
-impl Display for ContextListFilters {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut parts = vec![];
-
-        if let Some(prefix) = &self.prefix {
-            if !prefix.is_empty() {
-                parts.push(format!("prefix={prefix}"));
-            }
-        }
-
-        if let Some(sort_on) = &self.sort_on {
-            parts.push(format!("sort_on={sort_on}"));
-        }
-
-        if let Some(sort_by) = &self.sort_by {
-            parts.push(format!("sort_by={sort_by}"));
-        }
-
-        if let Some(created_by) = &self.created_by {
-            if !created_by.is_empty() {
-                parts.push(format!("created_by={created_by}"));
-            }
-        }
-
-        if let Some(last_modified_by) = &self.last_modified_by {
-            if !last_modified_by.is_empty() {
-                parts.push(format!("last_modified_by={last_modified_by}"));
-            }
-        }
-
-        if let Some(plaintext) = &self.plaintext {
-            parts.push(format!("plaintext={plaintext}"));
-        }
-
-        write!(f, "{}", parts.join("&"))
-    }
 }
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq)]

--- a/crates/superposition_types/src/api/default_config.rs
+++ b/crates/superposition_types/src/api/default_config.rs
@@ -1,13 +1,11 @@
-use core::fmt;
-use std::fmt::Display;
-
 use derive_more::{AsRef, Deref, DerefMut, Into};
 #[cfg(feature = "diesel_derives")]
 use diesel::AsChangeset;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
-use superposition_derives::IsEmpty;
+use superposition_derives::{IsEmpty, QueryString};
 
+use crate::custom_query::QueryString;
 #[cfg(feature = "diesel_derives")]
 use crate::database::schema::default_configs;
 use crate::{
@@ -15,19 +13,11 @@ use crate::{
     IsEmpty, RegexEnum,
 };
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, IsEmpty)]
+#[derive(
+    Debug, Clone, PartialEq, Serialize, Deserialize, Default, QueryString, IsEmpty,
+)]
 pub struct DefaultConfigFilters {
     pub name: Option<String>,
-}
-
-impl Display for DefaultConfigFilters {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut query_params = vec![];
-        if let Some(key_name) = &self.name {
-            query_params.push(format!("name={}", key_name));
-        }
-        write!(f, "{}", query_params.join("&"))
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/crates/superposition_types/src/api/experiment_groups.rs
+++ b/crates/superposition_types/src/api/experiment_groups.rs
@@ -1,10 +1,7 @@
-use core::fmt;
-use std::fmt::Display;
-
 #[cfg(feature = "diesel_derives")]
 use crate::database::schema::experiment_groups;
 use crate::{
-    custom_query::CommaSeparatedQParams,
+    custom_query::{CommaSeparatedQParams, QueryString},
     database::models::{
         experimentation::{
             i64_vec_deserialize, i64_vec_formatter, GroupType, TrafficPercentage,
@@ -16,7 +13,7 @@ use crate::{
 #[cfg(feature = "diesel_derives")]
 use diesel::query_builder::AsChangeset;
 use serde::{Deserialize, Serialize};
-use superposition_derives::IsEmpty;
+use superposition_derives::{IsEmpty, QueryString};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ExpGroupCreateRequest {
@@ -66,13 +63,14 @@ pub enum SortOn {
     LastModifiedAt,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, IsEmpty)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, IsEmpty, QueryString)]
 pub struct ExpGroupFilters {
     pub name: Option<String>,
     pub created_by: Option<String>,
     pub last_modified_by: Option<String>,
     pub sort_on: Option<SortOn>,
     pub sort_by: Option<SortBy>,
+    #[query_string(skip_if_empty)]
     pub group_type: Option<CommaSeparatedQParams<GroupType>>,
 }
 
@@ -89,32 +87,5 @@ impl Default for ExpGroupFilters {
                 vec![GroupType::UserCreated].into_iter().collect(),
             )),
         }
-    }
-}
-
-impl Display for ExpGroupFilters {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut query_params = vec![];
-        if let Some(key_name) = &self.name {
-            query_params.push(format!("name={}", key_name));
-        }
-        if let Some(created_by) = &self.created_by {
-            query_params.push(format!("created_by={}", created_by));
-        }
-        if let Some(last_modified_by) = &self.last_modified_by {
-            query_params.push(format!("last_modified_by={}", last_modified_by));
-        }
-        if let Some(sort_on) = &self.sort_on {
-            query_params.push(format!("sort_on={}", sort_on));
-        }
-        if let Some(sort_by) = &self.sort_by {
-            query_params.push(format!("sort_by={}", sort_by));
-        }
-        if let Some(group_type) = &self.group_type {
-            if !group_type.is_empty() {
-                query_params.push(format!("group_type={}", group_type));
-            }
-        }
-        write!(f, "{}", query_params.join("&"))
     }
 }

--- a/crates/superposition_types/src/api/experiments.rs
+++ b/crates/superposition_types/src/api/experiments.rs
@@ -1,19 +1,18 @@
-use std::{collections::HashMap, fmt::Display};
+use std::collections::HashMap;
 
 use chrono::{DateTime, Utc};
-use core::fmt;
 #[cfg(feature = "diesel_derives")]
 use diesel::AsChangeset;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
 use strum_macros::Display;
-use superposition_derives::IsEmpty;
+use superposition_derives::{IsEmpty, QueryString};
 
 #[cfg(feature = "diesel_derives")]
 use crate::database::schema::experiments;
 use crate::{
     api::{deserialize_option_i64, i64_option_formatter},
-    custom_query::{CommaSeparatedQParams, CommaSeparatedStringQParams},
+    custom_query::{CommaSeparatedQParams, CommaSeparatedStringQParams, QueryString},
     database::models::{
         experimentation::{
             Experiment, ExperimentStatusType, ExperimentType, TrafficPercentage, Variant,
@@ -227,60 +226,21 @@ impl Default for ExperimentSortOn {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, IsEmpty)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, IsEmpty, QueryString)]
 pub struct ExperimentListFilters {
+    #[query_string(skip_if_empty)]
     pub status: Option<CommaSeparatedQParams<ExperimentStatusType>>,
     pub from_date: Option<DateTime<Utc>>,
     pub to_date: Option<DateTime<Utc>>,
     pub experiment_name: Option<String>,
+    #[query_string(skip_if_empty)]
     pub experiment_ids: Option<CommaSeparatedStringQParams>,
+    #[query_string(skip_if_empty)]
     pub experiment_group_ids: Option<CommaSeparatedStringQParams>,
+    #[query_string(skip_if_empty)]
     pub created_by: Option<CommaSeparatedStringQParams>,
     pub sort_on: Option<ExperimentSortOn>,
     pub sort_by: Option<SortBy>,
-}
-
-impl Display for ExperimentListFilters {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut query_params = vec![];
-        if let Some(status) = &self.status {
-            if !status.is_empty() {
-                query_params.push(format!("status={}", status));
-            }
-        }
-        if let Some(from_date) = self.from_date {
-            query_params.push(format!("from_date={}", from_date));
-        }
-        if let Some(to_date) = self.to_date {
-            query_params.push(format!("to_date={}", to_date));
-        }
-        if let Some(experiment_name) = &self.experiment_name {
-            query_params.push(format!("experiment_name={}", experiment_name));
-        }
-        if let Some(experiment_ids) = &self.experiment_ids {
-            if !experiment_ids.is_empty() {
-                query_params.push(format!("experiment_ids={}", experiment_ids));
-            }
-        }
-        if let Some(experiment_group_ids) = &self.experiment_group_ids {
-            if !experiment_group_ids.is_empty() {
-                query_params
-                    .push(format!("experiment_group_ids={}", experiment_group_ids));
-            }
-        }
-        if let Some(created_by) = &self.created_by {
-            if !created_by.is_empty() {
-                query_params.push(format!("created_by={}", created_by));
-            }
-        }
-        if let Some(sort_on) = self.sort_on {
-            query_params.push(format!("sort_on={}", sort_on));
-        }
-        if let Some(sort_by) = &self.sort_by {
-            query_params.push(format!("sort_by={}", sort_by));
-        }
-        write!(f, "{}", query_params.join("&"))
-    }
 }
 
 impl Default for ExperimentListFilters {

--- a/crates/superposition_types/src/api/functions.rs
+++ b/crates/superposition_types/src/api/functions.rs
@@ -1,17 +1,14 @@
-use core::fmt;
-use std::fmt::Display;
-
 use derive_more::{AsRef, Deref, DerefMut, Into};
 #[cfg(feature = "diesel_derives")]
 use diesel::AsChangeset;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use superposition_derives::IsEmpty;
+use superposition_derives::{IsEmpty, QueryString};
 
 #[cfg(feature = "diesel_derives")]
 use crate::database::schema::functions;
 use crate::{
-    custom_query::CommaSeparatedQParams,
+    custom_query::{CommaSeparatedQParams, QueryString},
     database::models::{
         cac::{FunctionCode, FunctionType},
         ChangeReason, Description,
@@ -130,19 +127,10 @@ pub struct FunctionExecutionResponse {
     pub function_type: FunctionType,
 }
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq, IsEmpty)]
+#[derive(
+    Debug, Default, Clone, Serialize, Deserialize, PartialEq, IsEmpty, QueryString,
+)]
 pub struct ListFunctionFilters {
+    #[query_string(skip_if_empty)]
     pub function_type: Option<CommaSeparatedQParams<FunctionType>>,
-}
-
-impl Display for ListFunctionFilters {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut query_params = vec![];
-        if let Some(fntype) = &self.function_type {
-            if !fntype.is_empty() {
-                query_params.push(format!("function_type={}", fntype));
-            }
-        }
-        write!(f, "{}", query_params.join("&"))
-    }
 }

--- a/crates/superposition_types/src/custom_query.rs
+++ b/crates/superposition_types/src/custom_query.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashMap, fmt::Display, str::FromStr};
 
-use core::fmt;
 use derive_more::{Deref, DerefMut};
 use regex::Regex;
 use serde::{
@@ -10,11 +9,15 @@ use serde::{
 use serde_json::{Map, Value};
 #[cfg(feature = "experimentation")]
 use strum::IntoEnumIterator;
-use superposition_derives::IsEmpty;
+use superposition_derives::{IsEmpty, QueryString};
 
 #[cfg(feature = "experimentation")]
 use crate::database::models::experimentation::ExperimentStatusType;
 use crate::IsEmpty;
+
+pub trait QueryString {
+    fn to_query(&self) -> String;
+}
 
 pub trait CustomQuery: Sized {
     type Inner: DeserializeOwned;
@@ -197,8 +200,8 @@ impl From<HashMap<String, String>> for QueryMap {
     }
 }
 
-impl Display for DimensionQuery<QueryMap> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl QueryString for DimensionQuery<QueryMap> {
+    fn to_query(&self) -> String {
         let parts = self
             .clone()
             .into_inner()
@@ -206,7 +209,7 @@ impl Display for DimensionQuery<QueryMap> {
             .map(|(key, value)| format!("dimension[{key}]={value}"))
             .collect::<Vec<_>>();
 
-        write!(f, "{}", parts.join("&"))
+        parts.join("&")
     }
 }
 
@@ -222,7 +225,7 @@ impl Default for DimensionQuery<QueryMap> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, IsEmpty)]
+#[derive(Debug, Clone, PartialEq, IsEmpty, QueryString)]
 pub struct PaginationParams {
     pub count: Option<i64>,
     pub page: Option<i64>,
@@ -254,26 +257,6 @@ impl Default for PaginationParams {
             page: Some(1),
             all: None,
         }
-    }
-}
-
-impl Display for PaginationParams {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut parts = vec![];
-
-        if let Some(page) = self.page {
-            parts.push(format!("page={}", page));
-        }
-
-        if let Some(count) = self.count {
-            parts.push(format!("count={}", count));
-        }
-
-        if let Some(all) = self.all {
-            parts.push(format!("all={}", all));
-        }
-
-        write!(f, "{}", parts.join("&"))
     }
 }
 


### PR DESCRIPTION
## Problem
Similar `Display` trait being written over and over for different struct for converting the struct to query param format. 
This often leads to confusion as to why a field is missed as it might not have been added in the implementation of the `Display` trait

## Solution
Added `QueryString` proc_macro_derive which derives the QueryString trait for the struct to get the desired query param. 
It being auto generated makes sure that newly added fields get auto added to the `QueryString` trait's implementation