### PR TITLE
fix: Empty check for keys of struct

### DIFF
--- a/crates/frontend/src/pages/config_version_list.rs
+++ b/crates/frontend/src/pages/config_version_list.rs
@@ -25,9 +25,7 @@ pub fn config_version_list() -> impl IntoView {
     let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
 
     let pagination_params_rws = use_signal_from_query(move |query_string| {
-        Query::<PaginationParams>::extract_query(&query_string)
-            .map(|q| q.into_inner())
-            .unwrap_or_default()
+        Query::<PaginationParams>::extract_non_empty(&query_string).into_inner()
     });
 
     use_param_updater(move || box_params!(pagination_params_rws.get()));

--- a/crates/frontend/src/pages/context_override.rs
+++ b/crates/frontend/src/pages/context_override.rs
@@ -221,7 +221,7 @@ fn context_filter_drawer(
                         on_click=move |event| {
                             event.prevent_default();
                             context_filters_rws.set(ContextListFilters::default());
-                            dimension_params_rws.set(DimensionQuery::from(Map::new()));
+                            dimension_params_rws.set(DimensionQuery::default());
                             pagination_params_rws.update(|f| f.page = None);
                             close_drawer("context_filter_drawer")
                         }
@@ -386,18 +386,13 @@ pub fn context_override() -> impl IntoView {
     let (delete_id, set_delete_id) = create_signal::<Option<String>>(None);
 
     let pagination_params_rws = use_signal_from_query(move |query_string| {
-        Query::<PaginationParams>::extract_query(&query_string)
-            .map(|q| q.into_inner())
-            .unwrap_or_default()
+        Query::<PaginationParams>::extract_non_empty(&query_string).into_inner()
     });
     let context_filters_rws = use_signal_from_query(move |query_string| {
-        Query::<ContextListFilters>::extract_query(&query_string)
-            .map(|q| q.into_inner())
-            .unwrap_or_default()
+        Query::<ContextListFilters>::extract_non_empty(&query_string).into_inner()
     });
     let dimension_params_rws = use_signal_from_query(move |query_string| {
-        DimensionQuery::<QueryMap>::extract_query(&query_string)
-            .unwrap_or(DimensionQuery::from(Map::new()))
+        DimensionQuery::<QueryMap>::extract_non_empty(&query_string)
     });
 
     use_param_updater(move || {
@@ -479,7 +474,7 @@ pub fn context_override() -> impl IntoView {
         close_drawer("context_and_override_drawer");
         if !edit {
             context_filters_rws.set(ContextListFilters::default());
-            dimension_params_rws.set(DimensionQuery::from(Map::new()));
+            dimension_params_rws.set(DimensionQuery::default());
             pagination_params_rws.update(|f| f.page = None);
         }
         set_form_mode.set(None);

--- a/crates/frontend/src/pages/default_config.rs
+++ b/crates/frontend/src/pages/default_config.rs
@@ -49,9 +49,7 @@ pub fn default_config() -> impl IntoView {
     let (delete_modal_visible_rs, delete_modal_visible_ws) = create_signal(false);
     let (delete_key_rs, delete_key_ws) = create_signal::<Option<String>>(None);
     let pagination_params_rws = use_signal_from_query(move |query_string| {
-        Query::<PaginationParams>::extract_query(&query_string)
-            .map(|q| q.into_inner())
-            .unwrap_or_default()
+        Query::<PaginationParams>::extract_non_empty(&query_string).into_inner()
     });
 
     use_param_updater(move || box_params!(pagination_params_rws.get()));

--- a/crates/frontend/src/pages/dimensions.rs
+++ b/crates/frontend/src/pages/dimensions.rs
@@ -36,9 +36,7 @@ pub fn dimensions() -> impl IntoView {
     let (delete_modal_visible_rs, delete_modal_visible_ws) = create_signal(false);
     let (delete_id_rs, delete_id_ws) = create_signal::<Option<String>>(None);
     let pagination_params_rws = use_signal_from_query(move |query_string| {
-        Query::<PaginationParams>::extract_query(&query_string)
-            .map(|q| q.into_inner())
-            .unwrap_or_default()
+        Query::<PaginationParams>::extract_non_empty(&query_string).into_inner()
     });
 
     use_param_updater(move || box_params!(pagination_params_rws.get()));

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -326,14 +326,10 @@ pub fn experiment_list() -> impl IntoView {
     let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
     let (reset_exp_form, set_exp_form) = create_signal(0);
     let filters_rws = use_signal_from_query(move |query_string| {
-        Query::<ExperimentListFilters>::extract_query(&query_string)
-            .map(|q| q.into_inner())
-            .unwrap_or_default()
+        Query::<ExperimentListFilters>::extract_non_empty(&query_string).into_inner()
     });
     let pagination_params_rws = use_signal_from_query(move |query_string| {
-        Query::<PaginationParams>::extract_query(&query_string)
-            .map(|q| q.into_inner())
-            .unwrap_or_default()
+        Query::<PaginationParams>::extract_non_empty(&query_string).into_inner()
     });
 
     use_param_updater(move || {

--- a/crates/frontend/src/pages/function/function_list.rs
+++ b/crates/frontend/src/pages/function/function_list.rs
@@ -29,9 +29,7 @@ pub fn function_list() -> impl IntoView {
     let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
     let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
     let pagination_params_rws = use_signal_from_query(move |query_string| {
-        Query::<PaginationParams>::extract_query(&query_string)
-            .map(|q| q.into_inner())
-            .unwrap_or_default()
+        Query::<PaginationParams>::extract_non_empty(&query_string).into_inner()
     });
 
     use_param_updater(move || box_params!(pagination_params_rws.get()));

--- a/crates/frontend/src/pages/workspace.rs
+++ b/crates/frontend/src/pages/workspace.rs
@@ -26,9 +26,7 @@ pub fn workspace() -> impl IntoView {
     let org_id: RwSignal<OrganisationId> =
         use_context::<RwSignal<OrganisationId>>().unwrap();
     let pagination_params_rws = use_signal_from_query(move |query_string| {
-        Query::<PaginationParams>::extract_query(&query_string)
-            .map(|q| q.into_inner())
-            .unwrap_or_default()
+        Query::<PaginationParams>::extract_non_empty(&query_string).into_inner()
     });
 
     use_param_updater(move || box_params!(pagination_params_rws.get()));

--- a/crates/frontend/src/query_updater.rs
+++ b/crates/frontend/src/query_updater.rs
@@ -1,26 +1,37 @@
 use std::fmt::Display;
 
 use leptos::*;
-use leptos_router::{use_location, use_navigate, use_query_map};
+use leptos_router::{use_location, use_navigate, use_query_map, NavigateOptions};
 
 use crate::utils::use_service_prefix;
 
-pub fn use_param_updater(source: impl Fn() -> Vec<Box<dyn Display>> + 'static) {
+pub trait DisplayDefault: Display {
+    fn default(&self) -> String;
+}
+
+impl<T: Display + Default> DisplayDefault for T {
+    fn default(&self) -> String {
+        T::default().to_string()
+    }
+}
+
+pub fn use_param_updater(source: impl Fn() -> Vec<Box<dyn DisplayDefault>> + 'static) {
     let navigate = use_navigate();
     let location = use_location();
     let service_prefix = use_service_prefix();
 
     Effect::new(move |_| {
-        let desired_query_parts = source()
+        let desired_query = source()
             .into_iter()
             .map(|s| s.to_string())
             .filter(|s| !s.is_empty())
-            .collect::<Vec<_>>();
+            .collect::<Vec<_>>()
+            .join("&");
 
-        let query_string = if desired_query_parts.is_empty() {
+        let query_string = if desired_query.is_empty() {
             String::new()
         } else {
-            format!("?{}", desired_query_parts.join("&"))
+            format!("?{}", desired_query)
         };
 
         let current_query_string = location.query.with_untracked(|q| q.to_query_string());
@@ -31,7 +42,23 @@ pub fn use_param_updater(source: impl Fn() -> Vec<Box<dyn Display>> + 'static) {
                 .map_or(path.clone(), String::from);
             let new_url = format!("{prefix_stripped_path}{query_string}");
 
-            navigate(&new_url, Default::default());
+            let default_query = source()
+                .into_iter()
+                .map(|s| s.default())
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+                .join("&");
+
+            let replace =
+                default_query == desired_query && current_query_string.is_empty();
+
+            navigate(
+                &new_url,
+                NavigateOptions {
+                    replace,
+                    ..NavigateOptions::default()
+                },
+            );
         }
     });
 }

--- a/crates/superposition_derives/Cargo.toml
+++ b/crates/superposition_derives/Cargo.toml
@@ -15,3 +15,6 @@ workspace = true
 
 [lib]
 proc-macro = true
+
+[features]
+diesel_derives = []

--- a/crates/superposition_derives/src/lib.rs
+++ b/crates/superposition_derives/src/lib.rs
@@ -1,10 +1,12 @@
 extern crate proc_macro;
+
 use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput};
+use syn::{parse_macro_input, Data, DeriveInput, Fields, Type};
 
 /// Implements `FromSql` trait for converting `Json` type to the type for `Pg` backend
 ///
+#[cfg(feature = "diesel_derives")]
 #[proc_macro_derive(JsonFromSql)]
 pub fn json_from_sql_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -24,6 +26,7 @@ pub fn json_from_sql_derive(input: TokenStream) -> TokenStream {
 
 /// Implements `ToSql` trait for converting the typed data to `Json` type for `Pg` backend
 ///
+#[cfg(feature = "diesel_derives")]
 #[proc_macro_derive(JsonToSql)]
 pub fn json_to_sql_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -49,6 +52,7 @@ pub fn json_to_sql_derive(input: TokenStream) -> TokenStream {
 
 /// Implements `FromSql` trait for converting `Text` type to the type for `Pg` backend
 ///
+#[cfg(feature = "diesel_derives")]
 #[proc_macro_derive(TextFromSql)]
 pub fn text_from_sql_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -66,6 +70,7 @@ pub fn text_from_sql_derive(input: TokenStream) -> TokenStream {
 
 /// Implements `ToSql` trait for converting the typed data to `Json` type for `Pg` backend
 ///
+#[cfg(feature = "diesel_derives")]
 #[proc_macro_derive(TextToSql)]
 pub fn text_to_sql_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -90,6 +95,7 @@ pub fn text_to_sql_derive(input: TokenStream) -> TokenStream {
 
 /// Implements `FromSql` trait for converting `Text` type to the type for `Pg` backend without running validations on it
 ///
+#[cfg(feature = "diesel_derives")]
 #[proc_macro_derive(TextFromSqlNoValidation)]
 pub fn text_from_sql_derive_no_validation(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
@@ -103,4 +109,90 @@ pub fn text_from_sql_derive_no_validation(input: TokenStream) -> TokenStream {
             }
         }
     }.into()
+}
+
+/// Implements `IsEmpty` trait for structs
+///
+/// This trait is used to check if a struct is empty based on its fields.
+/// If a struct has any non-Option fields, it is considered non-empty.
+/// If all fields are Option types, it is considered empty if all Options are None.
+/// The macro generates an implementation of the `IsEmpty` trait for the struct.
+/// The macro checks the fields of the struct and generates the appropriate implementation.
+/// The macro can only be used on structs with named fields.
+/// If the struct has no fields or has unnamed fields, an error is returned.
+///
+#[proc_macro_derive(IsEmpty)]
+pub fn derive_is_empty(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let struct_name = input.ident;
+
+    let fields = if let Data::Struct(data) = input.data {
+        match data.fields {
+            Fields::Named(fields) => fields.named,
+            Fields::Unnamed(_) | Fields::Unit => {
+                return syn::Error::new_spanned(
+                    struct_name,
+                    "IsEmpty can only be derived for structs with named fields",
+                )
+                .to_compile_error()
+                .into()
+            }
+        }
+    } else {
+        return syn::Error::new_spanned(
+            struct_name,
+            "IsEmpty can only be derived for structs",
+        )
+        .to_compile_error()
+        .into();
+    };
+
+    let mut checks = Vec::new();
+    let mut has_mandatory = false;
+
+    for field in fields {
+        let field_name = field.ident.unwrap();
+        let ty = field.ty;
+
+        if let Type::Path(type_path) = &ty {
+            if type_path
+                .path
+                .segments
+                .first()
+                .map_or(false, |seg| seg.ident == "Option")
+            {
+                checks.push(quote! {
+                    if self.#field_name.is_some() {
+                        return false;
+                    }
+                });
+                continue;
+            }
+        }
+
+        has_mandatory = true;
+        break;
+    }
+
+    let expanded = if has_mandatory {
+        quote! {
+            impl IsEmpty for #struct_name {
+                fn is_empty(&self) -> bool {
+                    false
+                }
+            }
+        }
+    } else {
+        quote! {
+            impl IsEmpty for #struct_name {
+                fn is_empty(&self) -> bool {
+                    #(#checks)*
+
+                    true
+                }
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
 }

--- a/crates/superposition_types/Cargo.toml
+++ b/crates/superposition_types/Cargo.toml
@@ -25,7 +25,7 @@ serde_json = { workspace = true }
 serde_urlencoded = { version = "0.7.1" }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-superposition_derives = { path = "../superposition_derives", optional = true }
+superposition_derives = { path = "../superposition_derives" }
 thiserror = { version = "1.0.57", optional = true }
 uuid = { workspace = true }
 
@@ -33,7 +33,7 @@ uuid = { workspace = true }
 default = ["server"]
 diesel_derives = [
     "dep:diesel",
-    "dep:superposition_derives",
+    "superposition_derives/diesel_derives",
     "dep:diesel-derive-enum",
     "dep:base64",
 ]

--- a/crates/superposition_types/src/api/context.rs
+++ b/crates/superposition_types/src/api/context.rs
@@ -1,8 +1,9 @@
 use std::fmt::{self, Display};
 
 use serde::Deserialize;
+use superposition_derives::IsEmpty;
 
-use crate::{custom_query::CommaSeparatedStringQParams, SortBy};
+use crate::{custom_query::CommaSeparatedStringQParams, IsEmpty, SortBy};
 
 #[derive(
     Deserialize, PartialEq, Clone, strum_macros::EnumIter, strum_macros::Display,
@@ -31,7 +32,7 @@ impl Default for SortOn {
     }
 }
 
-#[derive(Deserialize, PartialEq, Default, Clone)]
+#[derive(Deserialize, PartialEq, Default, Clone, IsEmpty)]
 pub struct ContextListFilters {
     pub prefix: Option<CommaSeparatedStringQParams>,
     pub sort_on: Option<SortOn>,

--- a/crates/superposition_types/src/api/experiments.rs
+++ b/crates/superposition_types/src/api/experiments.rs
@@ -5,6 +5,7 @@ use core::fmt;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
 use strum_macros::Display;
+use superposition_derives::IsEmpty;
 
 use crate::{
     custom_query::{CommaSeparatedQParams, CommaSeparatedStringQParams},
@@ -14,7 +15,7 @@ use crate::{
         },
         ChangeReason, Description,
     },
-    Condition, Exp, Overrides, SortBy,
+    Condition, Exp, IsEmpty, Overrides, SortBy,
 };
 
 /********** Experiment Response Type **************/
@@ -184,7 +185,7 @@ impl Default for ExperimentSortOn {
     }
 }
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Deserialize, Serialize, Debug, Clone, PartialEq, IsEmpty)]
 pub struct ExperimentListFilters {
     pub status: Option<CommaSeparatedQParams<ExperimentStatusType>>,
     pub from_date: Option<DateTime<Utc>>,

--- a/crates/superposition_types/src/custom_query.rs
+++ b/crates/superposition_types/src/custom_query.rs
@@ -10,9 +10,11 @@ use serde::{
 use serde_json::{Map, Value};
 #[cfg(feature = "experimentation")]
 use strum::IntoEnumIterator;
+use superposition_derives::IsEmpty;
 
 #[cfg(feature = "experimentation")]
 use crate::database::models::experimentation::ExperimentStatusType;
+use crate::IsEmpty;
 
 pub trait CustomQuery: Sized {
     type Inner: DeserializeOwned;
@@ -53,6 +55,19 @@ pub trait CustomQuery: Sized {
             .captures(key)
             .and_then(|captures| captures.name(Self::capture_group()))
             .map(|m| m.as_str().to_owned())
+    }
+
+    fn extract_non_empty(query_string: &str) -> Self
+    where
+        Self::Inner: Default + IsEmpty,
+    {
+        let res = Self::extract_query(query_string)
+            .ok()
+            .map(|value| value.into_inner())
+            .filter(|value| !value.is_empty())
+            .unwrap_or_default();
+
+        Self::new(res)
     }
 
     fn new(inner: Self::Inner) -> Self;
@@ -159,6 +174,12 @@ where
 #[serde(from = "HashMap<String,String>")]
 pub struct QueryMap(Map<String, Value>);
 
+impl IsEmpty for QueryMap {
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
 impl From<HashMap<String, String>> for QueryMap {
     fn from(value: HashMap<String, String>) -> Self {
         let value = value
@@ -189,7 +210,13 @@ impl From<Map<String, Value>> for DimensionQuery<QueryMap> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+impl Default for DimensionQuery<QueryMap> {
+    fn default() -> Self {
+        Self::from(Map::new())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, IsEmpty)]
 pub struct PaginationParams {
     pub count: Option<i64>,
     pub page: Option<i64>,

--- a/crates/superposition_types/src/lib.rs
+++ b/crates/superposition_types/src/lib.rs
@@ -30,6 +30,10 @@ pub use crate::config::{Condition, Config, Context, Overrides};
 pub use crate::contextual::Contextual;
 pub use crate::overridden::Overridden;
 
+pub trait IsEmpty {
+    fn is_empty(&self) -> bool;
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct User {
     pub email: String,


### PR DESCRIPTION
## Problem
When reading params from url and no params are being provided in frontend, since all keys of the filter being `Option` type leads to the type getting successfully created with all as `None` values.
This leads to the default value not being used as the extract was a success.
For experiments, default time range is last `30days` in the type and last `24hours` in the backend, so when no params are sent to frontend, it is not going to the type default. Thus `experiments` of last 24 hours are being shown.

## Solution

1. Added `extract_non_empty` function to extract query and fallback to default if all keys are `None`
2. Added `IsEmpty` proc_macro_derive to auto derive `IsEmpty` trait for structs having `Named` fields
3. Added check in `use_param_updater` to consider `no params` and `default params` generated via default as same

