### PR TITLE
fix: Make last_modified non-mandatory in experiments/list and fix UI …

### DIFF
--- a/crates/frontend/src/components/input.rs
+++ b/crates/frontend/src/components/input.rs
@@ -487,6 +487,7 @@ pub fn date_input(
     class: String,
     name: String,
     on_change: Callback<DateTime<Utc>, ()>,
+    #[prop(default = Callback::new(|_| {}))] on_clear: Callback<(), ()>,
     #[prop(into, default = Utc::now().format("%Y-%m-%d").to_string())] value: String,
     #[prop(default = false)] disabled: bool,
     #[prop(default = false)] required: bool,
@@ -508,6 +509,11 @@ pub fn date_input(
                 max=max
                 value=value
                 on:change=move |e| {
+                    let new_value = event_target_value(&e);
+                    if new_value.is_empty() {
+                        on_clear.call(());
+                        return;
+                    }
                     let date = format!("{}T00:00:00Z", event_target_value(&e));
                     logging::log!("The date selected is: {}", date);
                     match DateTime::parse_from_rfc3339(&date) {
@@ -518,11 +524,11 @@ pub fn date_input(
                         Err(e) => {
                             logging::log!("error occurred: {:?}", e);
                             error_ws.set(e.to_string());
-                        },
+                        }
                     }
                 }
             />
-            <Show when=move || !error_rs.get().is_empty() >
+            <Show when=move || !error_rs.get().is_empty()>
                 <span class="flex gap-2 px-4 text-xs font-semibold text-red-600">
                     <i class="ri-close-circle-line"></i>
                     {move || error_rs.get()}

--- a/crates/superposition_types/src/api/experiments.rs
+++ b/crates/superposition_types/src/api/experiments.rs
@@ -236,11 +236,10 @@ impl Display for ExperimentListFilters {
 
 impl Default for ExperimentListFilters {
     fn default() -> Self {
-        let now = Utc::now();
         Self {
             status: None,
-            from_date: Some(now - chrono::Duration::days(30)),
-            to_date: Some(now),
+            from_date: None,
+            to_date: None,
             experiment_name: None,
             experiment_ids: None,
             created_by: None,


### PR DESCRIPTION
## Problem
filter based on time range was mandatory params in experiment/list API via `from_date` and `to_date` params, which even if not provided was falling back to go time range of last 24 hours

## Solution
1. filter on time range only if either of `from_date` or `to_date` are being used
2. updated default value of `ExperimentListFilters` in accordance to the above change
3. fix behaviour of `date input` when clicked on `clear`
4. removed redundant `get` and `set` calls of signal by using `update`
