### PR TITLE
fix: removed explicit err handling for FKValidation & removed redundant crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ members = [
     "crates/service_utils",
     "crates/context_aware_config",
     "crates/experimentation_platform",
-    "crates/service_utils",
     "crates/experimentation_client",
     "crates/cac_client",
     "crates/frontend",

--- a/crates/context_aware_config/src/api/functions/handlers.rs
+++ b/crates/context_aware_config/src/api/functions/handlers.rs
@@ -200,18 +200,12 @@ async fn delete_function(
     let deleted_row =
         delete(functions::functions.filter(functions::function_name.eq(&f_name)))
             .schema_name(&schema_name)
-            .execute(&mut conn);
+            .execute(&mut conn)?;
     match deleted_row {
-        Ok(0) => Err(not_found!("Function {} doesn't exists", f_name)),
-        Ok(_) => {
+        0 => Err(not_found!("Function {} doesn't exists", f_name)),
+        _ => {
             log::info!("{f_name} function deleted by {}", user.get_email());
             Ok(HttpResponse::NoContent().finish())
-        }
-        Err(e) => {
-            log::error!("function delete query failed with error: {e}");
-            Err(unexpected_error!(
-                "Something went wrong, failed to delete the function"
-            ))
         }
     }
 }


### PR DESCRIPTION
## Problem

Issue #473 

## Solution

Removed explicit match for FKValidation. Using the ? operator to let the error propagate. It should now be handled by AppError by default

## Environment variable changes

None

## Pre-deployment activity
Things needed to be done before deploying this change (if any)

## Post-deployment activity
Things needed to be done after deploying this change (if any)

## API changes
None
## Possible Issues in the future
None