### PR TITLE
fix: Override update/clone/experiment after key filter

### DIFF
--- a/crates/frontend/src/api.rs
+++ b/crates/frontend/src/api.rs
@@ -578,3 +578,22 @@ pub async fn resume_experiment(
 
     parse_json_response(response).await
 }
+
+pub async fn get_context(
+    context_id: &str,
+    tenant: &str,
+    org_id: &str,
+) -> Result<Context, String> {
+    let host = use_host_server();
+    let url = format!("{host}/context/{context_id}");
+
+    let response = request(
+        url,
+        reqwest::Method::GET,
+        None::<serde_json::Value>,
+        construct_request_headers(&[("x-tenant", tenant), ("x-org-id", org_id)])?,
+    )
+    .await?;
+
+    parse_json_response(response).await
+}

--- a/crates/frontend/src/components/experiment_form.rs
+++ b/crates/frontend/src/components/experiment_form.rs
@@ -30,21 +30,18 @@ fn get_init_state(variants: &[VariantFormT]) -> Vec<(String, VariantFormT)> {
 }
 
 #[component]
-pub fn experiment_form<NF>(
+pub fn experiment_form(
     #[prop(default = false)] edit: bool,
     #[prop(default = String::new())] id: String,
     name: String,
     context: Conditions,
     variants: VariantFormTs,
-    handle_submit: NF,
+    #[prop(into)] handle_submit: Callback<String, ()>,
     default_config: Vec<DefaultConfig>,
     dimensions: Vec<DimensionWithMandatory>,
     #[prop(default = String::new())] description: String,
     metrics: Metrics,
-) -> impl IntoView
-where
-    NF: Fn(String) + 'static + Clone,
-{
+) -> impl IntoView {
     let init_variants = get_init_state(&variants);
     let default_config = StoredValue::new(default_config);
     let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
@@ -86,7 +83,6 @@ where
         let tenant = tenant_rws.get().0;
         let org = org_rws.get().0;
         let experiment_id = id.clone();
-        let handle_submit_clone = handle_submit.clone();
 
         logging::log!("Experiment name {:?}", f_experiment_name);
         logging::log!("Context Experiment form {:?}", f_context);
@@ -120,7 +116,7 @@ where
 
                 match result {
                     Ok(res) => {
-                        handle_submit_clone(res.id);
+                        handle_submit.call(res.id);
                         let success_message = if edit {
                             "Experiment updated successfully!"
                         } else {


### PR DESCRIPTION
## Problem
On updating/cloning/experimenting on a override after a key filter has been applied, the operation is done only with the remaining set of keys

## Solution
use the context id to fetch the data of the context on which the operation is to be performed