### PR TITLE
Fixed stack overflow in applicable variants and updated versions for …

### DIFF
--- a/clients/generated/smithy/rust/Cargo.toml
+++ b/clients/generated/smithy/rust/Cargo.toml
@@ -9,19 +9,19 @@ edition = "2021"
 [package.metadata.smithy]
 codegen-version = "18e06e0a61e4ce792a2b17271d25a1f524d90ed4"
 [dependencies.aws-smithy-async]
-path = "smithy/repository/rust/software/amazon/rustruntime/aws-smithy-async"
+version = "1.2.5"
 [dependencies.aws-smithy-http]
-path = "smithy/repository/rust/software/amazon/rustruntime/aws-smithy-http"
+version = "0.62.1"
 [dependencies.aws-smithy-json]
-path = "smithy/repository/rust/software/amazon/rustruntime/aws-smithy-json"
+version = "0.61.3"
 [dependencies.aws-smithy-runtime]
-path = "smithy/repository/rust/software/amazon/rustruntime/aws-smithy-runtime"
+version = "1.8.2"
 features = ["client", "http-auth"]
 [dependencies.aws-smithy-runtime-api]
-path = "smithy/repository/rust/software/amazon/rustruntime/aws-smithy-runtime-api"
+version = "1.7.4"
 features = ["client", "http-02x", "http-auth"]
 [dependencies.aws-smithy-types]
-path = "smithy/repository/rust/software/amazon/rustruntime/aws-smithy-types"
+version = "1.3.0"
 [dependencies.bytes]
 version = "1.4.0"
 [dependencies.fastrand]

--- a/crates/superposition_types/src/api/experiments.rs
+++ b/crates/superposition_types/src/api/experiments.rs
@@ -188,7 +188,10 @@ pub struct ApplicableVariantsRequest {
 
 impl From<ApplicableVariantsRequest> for ApplicableVariantsQuery {
     fn from(value: ApplicableVariantsRequest) -> Self {
-        value.into()
+        Self {
+            context: value.context,
+            toss: value.toss,
+        }
     }
 }
 

--- a/smithy/smithy-build.json
+++ b/smithy/smithy-build.json
@@ -21,7 +21,7 @@
   "plugins": {
     "rust-client-codegen": {
         "runtimeConfig": {
-            "relativePath": "smithy/repository/rust/software/amazon/rustruntime"
+            "version": "1.2.5"
         },
         "codegen": {
           "addMessageToErrors": true,


### PR DESCRIPTION
…the smithy client

## Problem
1. There is an infinite recursion in converting Request Body to the Query param type in Query string
2. Rust smithy client has the wrong versioning

## Solution
1. Write a manual type conversion
2. Change the smithy-build-config.json to put correct versions for the aws runtime packages

## Possible Issues in the future
Need to test the rust SDK for issues based on incompatibility from selected version