### PR TITLE
fix: Removed copy of superposition.cac.toml, since the file was removed in an earlier revision

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,6 @@ RUN ls -l target
 FROM debian:bookworm-slim as runtime
 
 RUN mkdir -p /app/crates/superposition
-COPY --from=builder /build/crates/superposition/Superposition.cac.toml /app/crates/superposition/Superposition.cac.toml
 ENV NODE_VERSION=18.19.0
 WORKDIR /app
 


### PR DESCRIPTION
## Problem
docker build -t . fails since we are trying to copy a toml file does not exist

## Solution
Remove said line from the docker file

## Possible Issues in the future
If this file get's added back. We need to ensure the copy operation is added back as well