### PR TITLE
fix: corrected decode for post in resolve config

### DIFF
--- a/crates/context_aware_config/src/api/config/handlers.rs
+++ b/crates/context_aware_config/src/api/config/handlers.rs
@@ -748,6 +748,7 @@ async fn get_config(
         ))?
         .into_inner()
         .context
+        .into()
     };
     if !context.is_empty() {
         config = config.filter_by_dimensions(&context)
@@ -832,6 +833,7 @@ async fn get_resolved_config(
         ))?
         .into_inner()
         .context
+        .into()
     };
     let response = if show_reason {
         eval_cac_with_reasoning(

--- a/crates/superposition_types/src/api/config.rs
+++ b/crates/superposition_types/src/api/config.rs
@@ -1,8 +1,7 @@
 use serde::Deserialize;
-
-use crate::custom_query::QueryMap;
+use serde_json::{Map, Value};
 
 #[derive(Deserialize)]
 pub struct ContextPayload {
-    pub context: QueryMap,
+    pub context: Map<String, Value>,
 }

--- a/crates/superposition_types/src/custom_query.rs
+++ b/crates/superposition_types/src/custom_query.rs
@@ -180,6 +180,12 @@ impl IsEmpty for QueryMap {
     }
 }
 
+impl From<Map<String, Value>> for QueryMap {
+    fn from(value: Map<String, Value>) -> Self {
+        Self(value)
+    }
+}
+
 impl From<HashMap<String, String>> for QueryMap {
     fn from(value: HashMap<String, String>) -> Self {
         let value = value


### PR DESCRIPTION
## Problem
Deserialize fails for Post in resolve config since the serde instance has the flag to consider input to always be string. (As this is required for query params in get)

## Solution
Change the type of the post payload to Map<String,Value> then cast the same into type used by GET