### PR TITLE
fix: nix builds

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        system: [ x86_64-linux, aarch64-darwin ]
+        system: [ x86_64-linux ]
     steps:
       - uses: actions/checkout@v4
-      - run: om ci run --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} --systems "${{ matrix.system }}"
+      - run: om ci --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} run --systems "${{ matrix.system }}"


### PR DESCRIPTION
## Problem
the system aarch64-darwin has been taken down

## Solution
Remove it from our nix builds so that tests can pass