### PR TITLE
fix: update systems in nix CI action

### DIFF
--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -11,7 +11,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        system: [ x86_64-linux, aarch64-darwin ]
+        system: [ x86_64-linux ]
     steps:
       - uses: actions/checkout@v4
       - run: om ci run --extra-access-tokens ${{ secrets.GITHUB_TOKEN }} --systems "${{ matrix.system }}"


### PR DESCRIPTION
## Problem
The nix aarch64-darwin system has been removed

## Solution
Remove it from our CI stage so builds pass quickly
