### PR TITLE
fix: UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2179,6 +2179,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "superposition_derives",
  "superposition_macros",
  "superposition_types",
  "url",

--- a/crates/experimentation_client/src/lib.rs
+++ b/crates/experimentation_client/src/lib.rs
@@ -257,7 +257,6 @@ async fn get_experiments(
         experiment_name: None,
         experiment_ids: None,
         created_by: None,
-        context: None,
         sort_on: None,
         sort_by: None,
     };

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -26,6 +26,7 @@ serde-wasm-bindgen = "0.6.5"
 reqwest = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
+superposition_derives = { path = "../superposition_derives" }
 superposition_macros = { path = "../superposition_macros" }
 superposition_types = { path = "../superposition_types", features = [
     "experimentation",
@@ -38,7 +39,6 @@ web-sys = { version = "0.3.64", features = [
     "Worker",
     "Blob",
     "Window",
-    "Storage",
     "Element",
     "DomRect",
     "HtmlElement",

--- a/crates/frontend/src/api.rs
+++ b/crates/frontend/src/api.rs
@@ -136,6 +136,7 @@ pub async fn delete_context(
 pub async fn fetch_experiments(
     filters: &ExperimentListFilters,
     pagination: &PaginationParams,
+    dimension_params: &DimensionQuery<QueryMap>,
     tenant: String,
     org_id: String,
 ) -> Result<PaginatedResponse<ExperimentResponse>, ServerFnError> {
@@ -143,11 +144,7 @@ pub async fn fetch_experiments(
     let host = use_host_server();
     let pagination = pagination.to_string();
 
-    let url = if pagination.is_empty() {
-        format!("{}/experiments?{}", host, filters)
-    } else {
-        format!("{}/experiments?{}&{}", host, filters, pagination)
-    };
+    let url = format!("{host}/experiments?{filters}&{pagination}&{dimension_params}");
     let response: PaginatedResponse<ExperimentResponse> = client
         .get(url)
         .header("x-tenant", tenant)

--- a/crates/frontend/src/app.rs
+++ b/crates/frontend/src/app.rs
@@ -89,8 +89,7 @@ pub fn app(app_envs: Envs) -> impl IntoView {
                         }
                     }}
                 }
-            }}
-            // sets the document title
+            }} // sets the document title
             <Title text="Welcome to Superposition" />
             <script type_="text/javascript">"__APP_ENVS=" {json!(app_envs).to_string()}</script>
             <Router base=service_prefix>

--- a/crates/frontend/src/app.rs
+++ b/crates/frontend/src/app.rs
@@ -94,7 +94,7 @@ pub fn app(app_envs: Envs) -> impl IntoView {
             <Title text="Welcome to Superposition" />
             <script type_="text/javascript">"__APP_ENVS=" {json!(app_envs).to_string()}</script>
             <Router base=service_prefix>
-                <body class="m-0 min-h-screen bg-gray-50 font-mono">
+                <body class="m-0 min-h-screen bg-gray-50">
                     <AlertProvider>
                         <Routes base=service_prefix.to_string()>
                             <Route

--- a/crates/frontend/src/components.rs
+++ b/crates/frontend/src/components.rs
@@ -18,6 +18,7 @@ pub mod experiment_discard_form;
 pub mod experiment_form;
 pub mod experiment_group_form;
 pub mod experiment_ramp_form;
+pub mod form;
 pub mod function_form;
 pub mod info_modal;
 pub mod input;

--- a/crates/frontend/src/components/badge.rs
+++ b/crates/frontend/src/components/badge.rs
@@ -24,8 +24,7 @@ where
                         let label = option.with_value(|o| o.label());
                         view! {
                             <div class="flex justify-between badge badge-primary badge-outline">
-                                {label.to_string()}
-                                <Show when=move || { deletable.get_value() }>
+                                {label.to_string()} <Show when=move || { deletable.get_value() }>
                                     <button
                                         class="btn btn-xs btn-circle btn-ghost"
                                         on:click=move |_| { handle_remove.call(option.get_value()) }

--- a/crates/frontend/src/components/badge.rs
+++ b/crates/frontend/src/components/badge.rs
@@ -4,7 +4,7 @@ use super::dropdown::utils::DropdownOption;
 
 #[component]
 pub fn badge<T>(
-    options: ReadSignal<Vec<T>>,
+    #[prop(into)] options: Signal<Vec<T>>,
     #[prop(default=Callback::new(|_| {}))] handle_remove: Callback<T, ()>,
     #[prop(default = false)] deletable: bool,
 ) -> impl IntoView

--- a/crates/frontend/src/components/badge.rs
+++ b/crates/frontend/src/components/badge.rs
@@ -1,3 +1,5 @@
+use std::fmt::Display;
+
 use leptos::*;
 
 use super::dropdown::utils::DropdownOption;
@@ -39,4 +41,54 @@ where
             </div>
         </Show>
     }
+}
+
+#[component]
+pub fn gray_pill(
+    text: String,
+    #[prop(into, default = Callback::new(move |_| () ))] on_delete: Callback<()>,
+) -> impl IntoView {
+    view! {
+        <div class="badge badge-sm !h-fit py-[1px] bg-gray-200 flex gap-1">
+            {text}
+            <i class="ri-close-line cursor-pointer" on:click=move |_| { on_delete.call(()) } />
+        </div>
+    }
+}
+
+#[component]
+pub fn list_pills<T>(
+    #[prop(into)] label: String,
+    #[prop(into)] items: Vec<T>,
+    #[prop(into)] on_delete: Callback<usize>,
+) -> impl IntoView
+where
+    T: Display,
+{
+    if items.is_empty() {
+        return ().into_view();
+    }
+
+    view! {
+        <div class="flex gap-2 items-center">
+            <div class="min-w-fit flex items-center gap-[2px] text-xs">
+                {label} <span class="text-[10px] text-slate-400">"(any of)"</span>
+            </div>
+            <div class="flex gap-[2px] items-center flex-wrap">
+                {items
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, item)| {
+                        view! {
+                            <GrayPill
+                                text=item.to_string()
+                                on_delete=move |_| on_delete.call(idx)
+                            />
+                        }
+                    })
+                    .collect_view()}
+            </div>
+        </div>
+    }
+    .into_view()
 }

--- a/crates/frontend/src/components/button.rs
+++ b/crates/frontend/src/components/button.rs
@@ -23,7 +23,7 @@ pub fn button<F: Fn(MouseEvent) + 'static>(
                     </>
                 }
             } else {
-                view! { <>{text}<i class={format!("{icon_class} pl-2")}></i></> }
+                view! { <>{text}<i class=format!("{icon_class} pl-2")></i></> }
             }}
 
         </button>

--- a/crates/frontend/src/components/button.rs
+++ b/crates/frontend/src/components/button.rs
@@ -3,11 +3,11 @@ use web_sys::MouseEvent;
 
 #[component]
 pub fn button<F: Fn(MouseEvent) + 'static>(
-    text: String,
+    #[prop(into)] text: String,
     on_click: F,
-    #[prop(default = String::new())] class: String,
-    #[prop(default = String::new())] id: String,
-    #[prop(default = String::from("ri-edit-2-line"))] icon_class: String,
+    #[prop(into, default = String::new())] class: String,
+    #[prop(into, default = String::new())] id: String,
+    #[prop(into, default = String::from("ri-edit-2-line"))] icon_class: String,
     #[prop(default = false)] loading: bool,
 ) -> impl IntoView {
     let mut button_class = format!("btn-purple font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 {class}");

--- a/crates/frontend/src/components/change_form.rs
+++ b/crates/frontend/src/components/change_form.rs
@@ -1,13 +1,15 @@
 use leptos::*;
 
+use crate::components::form::label::Label;
+
 #[component]
 pub fn change_form(
-    title: String,
-    placeholder: String,
-    #[prop(default = String::new())] class: String,
-    #[prop(default = "textarea textarea-bordered w-full max-w-md".to_string())]
+    #[prop(into)] title: String,
+    #[prop(into)] placeholder: String,
+    #[prop(into, default = String::new())] class: String,
+    #[prop(into, default = "textarea textarea-bordered w-full max-w-md".to_string())]
     textarea_class: String,
-    value: String,
+    #[prop(into)] value: String,
     #[prop(into)] on_change: Callback<String, ()>,
     #[prop(default = false)] disabled: bool,
 ) -> impl IntoView {
@@ -17,9 +19,7 @@ pub fn change_form(
     };
     view! {
         <div class=format!("form-control {class}")>
-            <label class="label">
-                <span class="label-text">{title}</span>
-            </label>
+            <Label title />
             <textarea
                 type="text"
                 disabled=disabled

--- a/crates/frontend/src/components/condition_pills.rs
+++ b/crates/frontend/src/components/condition_pills.rs
@@ -76,10 +76,10 @@ pub fn condition_expression(
                     }
                 >
 
-                    <span class="font-mono font-medium context_condition text-gray-500">
+                    <span class="font-medium context_condition text-gray-500">
                         {dimension}
                     </span>
-                    <span class="font-mono font-medium text-gray-650 context_condition">
+                    <span class="font-medium text-gray-650 context_condition">
                         {operator.to_string()}
                     </span>
 
@@ -87,13 +87,13 @@ pub fn condition_expression(
                         Expression::Between(c1, c2) => {
                             view! {
                                 <>
-                                    <span class="font-mono font-semibold context_condition">
+                                    <span class="font-semibold context_condition">
                                         {c1.html_display()}
                                     </span>
-                                    <span class="font-mono font-medium text-gray-650 context_condition">
+                                    <span class="font-medium text-gray-650 context_condition">
                                         {"and"}
                                     </span>
-                                    <span class="font-mono font-semibold context_condition">
+                                    <span class="font-semibold context_condition">
                                         {c2.html_display()}
                                     </span>
                                 </>

--- a/crates/frontend/src/components/condition_pills.rs
+++ b/crates/frontend/src/components/condition_pills.rs
@@ -76,9 +76,7 @@ pub fn condition_expression(
                     }
                 >
 
-                    <span class="font-medium context_condition text-gray-500">
-                        {dimension}
-                    </span>
+                    <span class="font-medium context_condition text-gray-500">{dimension}</span>
                     <span class="font-medium text-gray-650 context_condition">
                         {operator.to_string()}
                     </span>

--- a/crates/frontend/src/components/condition_pills.rs
+++ b/crates/frontend/src/components/condition_pills.rs
@@ -33,6 +33,7 @@ pub fn condition_expression(
     #[prop(into)] id: String,
     #[prop(into)] list_id: String,
     condition: Condition,
+    strict_mode: bool,
 ) -> impl IntoView {
     let id = store_value(id);
     let condition = store_value(condition);
@@ -57,12 +58,17 @@ pub fn condition_expression(
             } else {
                 ("condition-item-collapsed", "condition-value-collapsed")
             };
-            let (dimension, operator, operands): (String, Operator, Vec<String>) = condition
+            let (dimension, operator, operands) = condition
                 .with_value(|v| {
                     (
                         v.variable.clone(),
-                        <&Condition as Into<Operator>>::into(v),
-                        v.expression.to_constants_vec().iter().map(|c| c.html_display()).collect(),
+                        Operator::from(v),
+                        v
+                            .expression
+                            .to_constants_vec()
+                            .iter()
+                            .map(|c| c.html_display())
+                            .collect::<Vec<_>>(),
                     )
                 });
             view! {
@@ -78,7 +84,11 @@ pub fn condition_expression(
 
                     <span class="font-medium context_condition text-gray-500">{dimension}</span>
                     <span class="font-medium text-gray-650 context_condition">
-                        {operator.to_string()}
+                        {if strict_mode {
+                            operator.strict_mode_display()
+                        } else {
+                            operator.to_string()
+                        }}
                     </span>
 
                     {match condition.get_value().expression {
@@ -116,6 +126,7 @@ pub fn condition(
     #[prop(into)] conditions: Conditions,
     #[prop(into, default=String::new())] class: String,
     #[prop(default = true)] grouped_view: bool,
+    strict_mode: bool,
 ) -> impl IntoView {
     let conditions = store_value(conditions);
 
@@ -140,6 +151,7 @@ pub fn condition(
                                 condition=condition.clone()
                                 id=item_id
                                 list_id=id.clone()
+                                strict_mode
                             />
                         }
                     })

--- a/crates/frontend/src/components/context_card.rs
+++ b/crates/frontend/src/components/context_card.rs
@@ -1,6 +1,8 @@
 use leptos::*;
 use serde_json::{Map, Value};
-use superposition_types::database::models::cac::Context;
+use superposition_types::{
+    api::workspace::WorkspaceResponse, database::models::cac::Context,
+};
 
 use crate::{
     components::{
@@ -98,6 +100,7 @@ pub fn context_card(
     #[prop(into)] handle_clone: Callback<String, ()>,
     #[prop(into)] handle_delete: Callback<String, ()>,
 ) -> impl IntoView {
+    let workspace_settings = use_context::<StoredValue<WorkspaceResponse>>().unwrap();
     let conditions: Conditions = (&context).try_into().unwrap_or_default();
     let description = context.description.clone();
     let change_reason = context.change_reason.clone();
@@ -217,6 +220,7 @@ pub fn context_card(
                     conditions=conditions
                     id=context.with_value(|c| c.id.clone())
                     class="xl:w-[400px] h-fit"
+                    strict_mode=workspace_settings.with_value(|w| w.strict_mode)
                 />
                 <Table
                     rows=override_table_rows

--- a/crates/frontend/src/components/context_card.rs
+++ b/crates/frontend/src/components/context_card.rs
@@ -22,7 +22,7 @@ fn option(
 ) -> impl IntoView {
     view! {
         <li on:click=move |_| on_click.call(())>
-            <div class="flex gap-2">
+            <div class="flex justify-end gap-2">
                 <i class=format!("w-fit {icon} ri-lg {icon_color_class}") />
                 <span>{label}</span>
             </div>

--- a/crates/frontend/src/components/context_card.rs
+++ b/crates/frontend/src/components/context_card.rs
@@ -132,7 +132,7 @@ pub fn context_card(
         <div class="rounded-lg shadow bg-base-100 p-6 flex flex-col gap-4">
             <div class="flex justify-between">
                 <div class="flex gap-4 items-center">
-                    <h3 class="card-title text-base timeline-box text-gray-800 bg-base-100 shadow-md font-mono m-0 w-max">
+                    <h3 class="card-title text-base timeline-box text-gray-800 bg-base-100 shadow-md m-0 w-max">
                         "Condition"
                     </h3>
                     <InfoDescription description=description change_reason=change_reason />

--- a/crates/frontend/src/components/context_form.rs
+++ b/crates/frontend/src/components/context_form.rs
@@ -2,6 +2,7 @@ pub mod utils;
 
 use std::collections::{HashMap, HashSet};
 
+use crate::components::form::label::Label;
 use crate::components::input::{Input, InputType};
 use crate::logic::{Condition, Conditions, Expression, Operator};
 use crate::schema::EnumVariants;
@@ -197,7 +198,7 @@ pub fn context_form<NF>(
     fn_environment: Memo<Value>,
     #[prop(default = false)] disabled: bool,
     #[prop(default = false)] resolve_mode: bool,
-    #[prop(default = String::new())] heading_sub_text: String,
+    #[prop(into, default = String::new())] heading_sub_text: String,
     #[prop(default = DropdownDirection::Right)] dropdown_direction: DropdownDirection,
 ) -> impl IntoView
 where
@@ -365,12 +366,7 @@ where
 
     view! {
         <div class="form-control w-full">
-            <div class="gap-1">
-                <label class="label flex-col justify-center items-start">
-                    <span class="label-text font-semibold text-base">Context</span>
-                    <span class="label-text text-slate-400">{heading_sub_text}</span>
-                </label>
-            </div>
+            <Label title="Context" description=heading_sub_text />
             <div class="card w-full bg-slate-50">
                 <div class="card-body">
                     <Show when=move || context_rs.get().is_empty()>

--- a/crates/frontend/src/components/context_form.rs
+++ b/crates/frontend/src/components/context_form.rs
@@ -347,8 +347,8 @@ where
         String::new()
     };
 
-    let tenant = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_id = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org_id = use_context::<Signal<OrganisationId>>().unwrap();
     let autocomplete_callbacks = dimensions
         .get_value()
         .iter()
@@ -357,7 +357,7 @@ where
                 d.dimension.clone(),
                 d.autocomplete_function_name.clone(),
                 fn_environment,
-                tenant.get_untracked().0,
+                workspace.get_untracked().0,
                 org_id.get_untracked().0,
             )
         })

--- a/crates/frontend/src/components/context_form.rs
+++ b/crates/frontend/src/components/context_form.rs
@@ -84,7 +84,7 @@ pub fn condition_input(
     view! {
         <div class="flex gap-x-6">
             <div class="form-control">
-                <label class="label font-mono text-sm">
+                <label class="label text-sm">
                     <span class="label-text">Dimension</span>
                 </label>
                 <input
@@ -95,7 +95,7 @@ pub fn condition_input(
                 />
             </div>
             <div class="form-control w-20">
-                <label class="label font-medium font-mono text-sm">
+                <label class="label font-medium text-sm">
                     <span class="label-text">Operator</span>
                 </label>
 
@@ -132,7 +132,7 @@ pub fn condition_input(
             </div>
         </div>
         <div class="form-control">
-            <label class="label font-mono text-sm">
+            <label class="label text-sm">
                 <span class="label-text">Value</span>
             </label>
 
@@ -471,7 +471,7 @@ where
                                     if last_idx.get() != idx {
                                         view! {
                                             <div class="my-3 ml-7">
-                                                <span class="font-mono text-xs font-bold">"&&"</span>
+                                                <span class="text-xs font-bold">"&&"</span>
                                             </div>
                                         }
                                             .into_view()

--- a/crates/frontend/src/components/context_form.rs
+++ b/crates/frontend/src/components/context_form.rs
@@ -465,7 +465,7 @@ where
                                     on_value_change
                                     on_operator_change
                                     tooltip_text
-                                    autocomplete_callbacks = autocomplete_callbacks.clone()
+                                    autocomplete_callbacks=autocomplete_callbacks.clone()
                                 />
                                 {move || {
                                     if last_idx.get() != idx {

--- a/crates/frontend/src/components/default_config_form.rs
+++ b/crates/frontend/src/components/default_config_form.rs
@@ -17,6 +17,7 @@ use crate::{
         button::Button,
         change_form::ChangeForm,
         dropdown::{Dropdown, DropdownBtnType, DropdownDirection},
+        form::label::Label,
         input::{Input, InputType},
     },
     schema::{EnumVariants, HtmlDisplay, JsonSchemaType, SchemaType},
@@ -201,11 +202,9 @@ where
 
     view! {
         <EditorProvider>
-            <form class="form-control w-full space-y-4 bg-white text-gray-700">
+            <form class="w-full flex flex-col gap-5 text-gray-700 bg-white">
                 <div class="form-control">
-                    <label class="label">
-                        <span class="label-text">"Key Name"</span>
-                    </label>
+                    <Label title="Key Name" />
                     <div class="input input-bordered w-full max-w-md p-0 flex" disabled=edit>
                         <div
                             node_ref=scroll_ref
@@ -270,9 +269,7 @@ where
                                 })
                             />
                             <div class="form-control">
-                                <label class="label">
-                                    <span class="label-text">Set Schema</span>
-                                </label>
+                                <Label title="Set Schema" />
                                 <Dropdown
                                     dropdown_width="w-100"
                                     dropdown_icon="".to_string()
@@ -341,9 +338,7 @@ where
                         };
                         return view! {
                             <div class="form-control">
-                                <label class="label">
-                                    <span class="label-text">Default Value</span>
-                                </label>
+                                <Label title="Default Value" />
                                 <div class="tooltip text-left w-full max-w-md" data-tip=tooltip_txt>
                                     <textarea
                                         type="text"
@@ -370,10 +365,7 @@ where
                     };
                     view! {
                         <div class="form-control">
-                            <label class="label">
-                                <span class="label-text">Default Value</span>
-                            </label>
-
+                            <Label title="Default Value" />
                             <Input
                                 id="default-config-value-input"
                                 class
@@ -413,72 +405,56 @@ where
                             });
                         view! {
                             <div class="form-control">
-                                <div class="gap-1">
-                                    <label class="label flex-col justify-center items-start">
-                                        <span class="label-text">Validation Function Name</span>
-                                        <span class="label-text text-slate-400">
-                                            Assign Function validation to your key
-                                        </span>
-                                    </label>
-                                </div>
+                                <Label
+                                    title="Validation Function"
+                                    description="Function to add validation logic to your key"
+                                />
+                                <Dropdown
+                                    dropdown_width="w-100"
+                                    dropdown_icon="".to_string()
+                                    dropdown_text=validation_fn_name_rs
+                                        .get()
+                                        .map_or("Add Function".to_string(), |v| v.to_string())
+                                    dropdown_direction=DropdownDirection::Down
+                                    dropdown_btn_type=DropdownBtnType::Select
+                                    dropdown_options=validation_function_names
+                                    on_select=handle_select_dropdown_option_validation
+                                />
 
-                                <div class="mt-2">
-                                    <Dropdown
-                                        dropdown_width="w-100"
-                                        dropdown_icon="".to_string()
-                                        dropdown_text=validation_fn_name_rs
-                                            .get()
-                                            .map_or("Add Function".to_string(), |v| v.to_string())
-                                        dropdown_direction=DropdownDirection::Down
-                                        dropdown_btn_type=DropdownBtnType::Select
-                                        dropdown_options=validation_function_names
-                                        on_select=handle_select_dropdown_option_validation
-                                    />
-                                </div>
                             </div>
 
                             <div class="form-control">
-                                <div class="gap-1">
-                                    <label class="label flex-col justify-center items-start">
-                                        <span class="label-text">AutoComplete Function Name</span>
-                                        <span class="label-text text-slate-400">
-                                            Assign Autocomplete Function to your key
-                                        </span>
-                                    </label>
-                                </div>
-
-                                <div class="mt-2">
-                                    <Dropdown
-                                        dropdown_width="w-100"
-                                        dropdown_icon="".to_string()
-                                        dropdown_text=autocomplete_fn_name_rs
-                                            .get()
-                                            .map_or("Add Function".to_string(), |v| v.to_string())
-                                        dropdown_direction=DropdownDirection::Down
-                                        dropdown_btn_type=DropdownBtnType::Select
-                                        dropdown_options=autocomplete_function_names
-                                        on_select=handle_select_dropdown_option_autocomplete
-                                    />
-                                </div>
+                                <Label
+                                    title="AutoComplete Function"
+                                    description="Function to add auto complete suggestion to your key"
+                                />
+                                <Dropdown
+                                    dropdown_width="w-100"
+                                    dropdown_icon="".to_string()
+                                    dropdown_text=autocomplete_fn_name_rs
+                                        .get()
+                                        .map_or("Add Function".to_string(), |v| v.to_string())
+                                    dropdown_direction=DropdownDirection::Down
+                                    dropdown_btn_type=DropdownBtnType::Select
+                                    dropdown_options=autocomplete_function_names
+                                    on_select=handle_select_dropdown_option_autocomplete
+                                />
                             </div>
                         }
                     }}
-
                 </Suspense>
-
-                <div class="form-control grid w-full justify-start">
-                    {move || {
-                        let loading = req_inprogess_rs.get();
-                        view! {
-                            <Button
-                                class="pl-[70px] pr-[70px] w-48 h-12".to_string()
-                                text="Submit".to_string()
-                                on_click=on_submit.clone()
-                                loading
-                            />
-                        }
-                    }}
-                </div>
+                {move || {
+                    let loading = req_inprogess_rs.get();
+                    view! {
+                        <Button
+                            class="self-end h-12 w-48"
+                            text="Submit"
+                            icon_class="ri-send-plane-line"
+                            on_click=on_submit.clone()
+                            loading
+                        />
+                    }
+                }}
             </form>
         </EditorProvider>
     }

--- a/crates/frontend/src/components/default_config_form.rs
+++ b/crates/frontend/src/components/default_config_form.rs
@@ -212,9 +212,11 @@ where
                             class="w-full px-4 py-2 flex items-center overflow-x-scroll whitespace-nowrap"
                             style="scrollbar-gutter: stable;"
                         >
-                            {prefix.as_ref().map(|p| view! {
-                                <span class="text-gray-500 select-none">{p}</span>
-                            })}
+                            {prefix
+                                .as_ref()
+                                .map(|p| {
+                                    view! { <span class="text-gray-500 select-none">{p}</span> }
+                                })}
                             <input
                                 disabled=edit
                                 type="text"
@@ -229,7 +231,9 @@ where
                                 on:input=move |ev| {
                                     let value = event_target_value(&ev);
                                     config_key_ws
-                                        .set(format!("{}{value}", prefix.clone().unwrap_or_default()));
+                                        .set(
+                                            format!("{}{value}", prefix.clone().unwrap_or_default()),
+                                        );
                                 }
                             />
                         </div>

--- a/crates/frontend/src/components/default_config_form.rs
+++ b/crates/frontend/src/components/default_config_form.rs
@@ -201,7 +201,7 @@ where
 
     view! {
         <EditorProvider>
-            <form class="form-control w-full space-y-4 bg-white text-gray-700 font-mono">
+            <form class="form-control w-full space-y-4 bg-white text-gray-700">
                 <div class="form-control">
                     <label class="label">
                         <span class="label-text">"Key Name"</span>

--- a/crates/frontend/src/components/default_config_form.rs
+++ b/crates/frontend/src/components/default_config_form.rs
@@ -46,8 +46,8 @@ pub fn default_config_form<NF>(
 where
     NF: Fn() + 'static + Clone,
 {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
 
     let (config_key_rs, config_key_ws) = create_signal(
         prefix
@@ -76,7 +76,7 @@ where
 
     let validation_functions_resource: Resource<(String, String), Vec<Function>> =
         create_blocking_resource(
-            move || (tenant_rws.get().0, org_rws.get().0),
+            move || (workspace.get().0, org.get().0),
             |(current_tenant, org)| async move {
                 let fn_filters = ListFunctionFilters {
                     function_type: None,
@@ -93,7 +93,7 @@ where
         );
 
     let type_template_resource = create_blocking_resource(
-        move || (tenant_rws.get().0, org_rws.get().0),
+        move || (workspace.get().0, org.get().0),
         |(current_tenant, org)| async move {
             fetch_types(&PaginationParams::all_entries(), current_tenant, org)
                 .await
@@ -131,8 +131,8 @@ where
                     // Call update_default_config when edit is true
                     update_default_config(
                         f_name,
-                        tenant_rws.get_untracked().0,
-                        org_rws.get_untracked().0,
+                        workspace.get_untracked().0,
+                        org.get_untracked().0,
                         f_value,
                         f_schema,
                         fun_name,
@@ -144,8 +144,8 @@ where
                 } else {
                     // Call create_default_config when edit is false
                     create_default_config(
-                        tenant_rws.get_untracked().0,
-                        org_rws.get_untracked().0,
+                        workspace.get_untracked().0,
+                        org.get_untracked().0,
                         config_key_rs.get_untracked(),
                         f_value,
                         f_schema,

--- a/crates/frontend/src/components/delete_modal.rs
+++ b/crates/frontend/src/components/delete_modal.rs
@@ -25,7 +25,7 @@ pub fn delete_modal(
                                 placeholder="Enter a reason for this change".to_string()
                                 class="my-4".to_string()
                                 value=change_reason_rws.get_untracked()
-                                on_change=Callback::new(move |new_reason| change_reason_rws.set(new_reason))
+                                on_change=move |new_reason| change_reason_rws.set(new_reason)
                             />
                         </Show>
                         <div class="flex justify-end space-x-4">

--- a/crates/frontend/src/components/dimension_form.rs
+++ b/crates/frontend/src/components/dimension_form.rs
@@ -341,8 +341,12 @@ where
             <Suspense>
                 {move || {
                     let mut functions = functions_resource.get().unwrap_or_default();
-                    let mut validation_function_names: Vec<FunctionsName> = vec!["None".to_string()];
-                    let mut autocomplete_function_names: Vec<FunctionsName> = vec!["None".to_string()];
+                    let mut validation_function_names: Vec<FunctionsName> = vec![
+                        "None".to_string(),
+                    ];
+                    let mut autocomplete_function_names: Vec<FunctionsName> = vec![
+                        "None".to_string(),
+                    ];
                     functions.sort_by(|a, b| a.function_name.cmp(&b.function_name));
                     functions
                         .iter()

--- a/crates/frontend/src/components/dimension_form.rs
+++ b/crates/frontend/src/components/dimension_form.rs
@@ -15,14 +15,17 @@ use types::{DimensionCreateReq, DimensionUpdateReq};
 use utils::{create_dimension, update_dimension};
 use web_sys::MouseEvent;
 
-use crate::providers::alert_provider::enqueue_alert;
-use crate::providers::editor_provider::EditorProvider;
-use crate::schema::{JsonSchemaType, SchemaType};
 use crate::types::FunctionsName;
 use crate::{api::fetch_functions, components::button::Button};
 use crate::{
     api::fetch_types,
     types::{OrganisationId, Tenant},
+};
+use crate::{components::form::label::Label, providers::alert_provider::enqueue_alert};
+use crate::{components::skeleton::Skeleton, providers::editor_provider::EditorProvider};
+use crate::{
+    components::skeleton::SkeletonVariant,
+    schema::{JsonSchemaType, SchemaType},
 };
 use crate::{
     components::{
@@ -192,9 +195,7 @@ where
     view! {
         <form class="form-control w-full space-y-4 bg-white text-gray-700">
             <div class="form-control">
-                <label class="label">
-                    <span class="label-text">Dimension</span>
-                </label>
+                <Label title="Dimension" />
                 <input
                     disabled=edit
                     type="text"
@@ -206,24 +207,19 @@ where
                         dimension_name_ws.set(value);
                     }
                 />
-
             </div>
 
             <ChangeForm
                 title="Description".to_string()
                 placeholder="Enter a description".to_string()
                 value=description_rs.get_untracked()
-                on_change=Callback::new(move |new_description| {
-                    description_ws.set(new_description)
-                })
+                on_change=move |new_description| { description_ws.set(new_description) }
             />
             <ChangeForm
                 title="Reason for Change".to_string()
                 placeholder="Enter a reason for this change".to_string()
                 value=change_reason_rs.get_untracked()
-                on_change=Callback::new(move |new_change_reason| {
-                    change_reason_ws.set(new_change_reason)
-                })
+                on_change=move |new_change_reason| { change_reason_ws.set(new_change_reason) }
             />
 
             <Suspense>
@@ -241,9 +237,7 @@ where
                     );
                     view! {
                         <div class="form-control">
-                            <label class="label">
-                                <span class="label-text">Set Schema</span>
-                            </label>
+                            <Label title="Set Schema" />
                             <Dropdown
                                 dropdown_width="w-100"
                                 dropdown_icon="".to_string()
@@ -272,15 +266,12 @@ where
                         </div>
                     }
                 }}
-
             </Suspense>
 
             {move || {
                 view! {
                     <div class="form-control">
-                        <label class="label">
-                            <span class="label-text">Position</span>
-                        </label>
+                        <Label title="Position" />
                         <input
                             type="Number"
                             min=0
@@ -320,9 +311,7 @@ where
                     .collect::<Vec<_>>();
                 view! {
                     <div class="form-control">
-                        <label class="label">
-                            <span class="label-text">Dependencies</span>
-                        </label>
+                        <Label title="Dependencies" />
                         <Dropdown
                             dropdown_text="Add Dependencies".to_string()
                             dropdown_direction=DropdownDirection::Down
@@ -337,7 +326,9 @@ where
                 }
             }}
 
-            <Suspense>
+            <Suspense fallback=move || {
+                view! { <Skeleton variant=SkeletonVariant::Block style_class="h-10" /> }
+            }>
                 {move || {
                     let mut functions = functions_resource.get().unwrap_or_default();
                     let mut validation_function_names: Vec<FunctionsName> = vec![
@@ -358,82 +349,58 @@ where
                         });
                     view! {
                         <div class="form-control">
-                            <div class="gap-1">
-                                <label class="label flex-col justify-center items-start">
-                                    <span class="label-text">Validation Function Name</span>
-                                    <span class="label-text text-slate-400">
-                                        Assign Function validation to your key
-                                    </span>
-                                </label>
-                            </div>
-
-                            <div class="mt-2">
-                                <Dropdown
-                                    dropdown_width="w-100"
-                                    dropdown_icon="".to_string()
-                                    dropdown_text=validation_fn_name_rs
-                                        .get()
-                                        .map_or("Add Function".to_string(), |v| v.to_string())
-                                    dropdown_direction=DropdownDirection::Down
-                                    dropdown_btn_type=DropdownBtnType::Select
-                                    dropdown_options=validation_function_names
-                                    on_select=handle_validation_fn_select
-                                />
-                            </div>
+                            <Label
+                                title="Validation Function"
+                                description="Function to add validation logic to your dimension"
+                            />
+                            <Dropdown
+                                dropdown_width="w-100"
+                                dropdown_icon="".to_string()
+                                dropdown_text=validation_fn_name_rs
+                                    .get()
+                                    .map_or("Add Function".to_string(), |v| v.to_string())
+                                dropdown_direction=DropdownDirection::Down
+                                dropdown_btn_type=DropdownBtnType::Select
+                                dropdown_options=validation_function_names
+                                on_select=handle_validation_fn_select
+                            />
                         </div>
 
                         <div class="form-control">
-                            <div class="gap-1">
-                                <label class="label flex-col justify-center items-start">
-                                    <span class="label-text">AutoComplete Function Name</span>
-                                    <span class="label-text text-slate-400">
-                                        Assign Autocomplete Function to your key
-                                    </span>
-                                </label>
-                            </div>
-
-                            <div class="mt-2">
-                                <Dropdown
-                                    dropdown_width="w-100"
-                                    dropdown_icon="".to_string()
-                                    dropdown_text=autocomplete_fn_name_rs
-                                        .get()
-                                        .map_or("Add Function".to_string(), |v| v.to_string())
-                                    dropdown_direction=DropdownDirection::Down
-                                    dropdown_btn_type=DropdownBtnType::Select
-                                    dropdown_options=autocomplete_function_names
-                                    on_select=handle_autocomplete_fn_select
-                                />
-                            </div>
+                            <Label
+                                title="AutoComplete Function"
+                                description="Function to add auto complete suggestion to your dimension"
+                            />
+                            <Dropdown
+                                dropdown_width="w-100"
+                                dropdown_icon="".to_string()
+                                dropdown_text=autocomplete_fn_name_rs
+                                    .get()
+                                    .map_or("Add Function".to_string(), |v| v.to_string())
+                                dropdown_direction=DropdownDirection::Down
+                                dropdown_btn_type=DropdownBtnType::Select
+                                dropdown_options=autocomplete_function_names
+                                on_select=handle_autocomplete_fn_select
+                            />
                         </div>
                     }
                 }}
-
             </Suspense>
 
-            <div class="form-control grid w-full justify-start">
-                {move || {
-                    let loading = req_inprogess_rs.get();
-                    view! {
-                        <Button
-                            class="pl-[70px] pr-[70px] w-48 h-12".to_string()
-                            text="Submit".to_string()
-                            on_click=on_submit.clone()
-                            loading
-                        />
-                    }
-                }}
-
-            </div>
-
-            {
+            {move || {
+                let loading = req_inprogess_rs.get();
                 view! {
-                    <div>
-                        <p class="text-red-500">{move || error_message.get()}</p>
-                    </div>
+                    <Button
+                        class="self-end h-12 w-48"
+                        text="Submit"
+                        icon_class="ri-send-plane-line"
+                        on_click=on_submit.clone()
+                        loading
+                    />
                 }
-            }
+            }}
 
+            <p class="text-red-500">{move || error_message.get()}</p>
         </form>
     }
 }

--- a/crates/frontend/src/components/dimension_form.rs
+++ b/crates/frontend/src/components/dimension_form.rs
@@ -51,8 +51,8 @@ pub fn dimension_form<NF>(
 where
     NF: Fn() + 'static + Clone,
 {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
 
     let (position_rs, position_ws) = create_signal(position);
     let (dimension_name_rs, dimension_name_ws) = create_signal(dimension_name);
@@ -68,7 +68,7 @@ where
     let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
     let functions_resource: Resource<(String, String), Vec<Function>> =
         create_blocking_resource(
-            move || (tenant_rws.get().0, org_rws.get().0),
+            move || (workspace.get().0, org.get().0),
             |(current_tenant, org)| async move {
                 let fn_filters = ListFunctionFilters {
                     function_type: None,
@@ -85,7 +85,7 @@ where
         );
 
     let type_template_resource = create_blocking_resource(
-        move || (tenant_rws.get().0, org_rws.get().0),
+        move || (workspace.get().0, org.get().0),
         |(current_tenant, org)| async move {
             fetch_types(&PaginationParams::all_entries(), current_tenant, org)
                 .await
@@ -144,10 +144,10 @@ where
                         change_reason: change_reason_rs.get(),
                     };
                     update_dimension(
-                        tenant_rws.get().0,
+                        workspace.get().0,
                         dimension_name,
                         update_payload,
-                        org_rws.get().0,
+                        org.get().0,
                     )
                     .await
                 } else {
@@ -161,8 +161,7 @@ where
                         description: description_rs.get(),
                         change_reason: change_reason_rs.get(),
                     };
-                    create_dimension(tenant_rws.get().0, create_payload, org_rws.get().0)
-                        .await
+                    create_dimension(workspace.get().0, create_payload, org.get().0).await
                 };
 
                 req_inprogress_ws.set(false);

--- a/crates/frontend/src/components/dimension_form.rs
+++ b/crates/frontend/src/components/dimension_form.rs
@@ -191,7 +191,7 @@ where
         });
     };
     view! {
-        <form class="form-control w-full space-y-4 bg-white text-gray-700 font-mono">
+        <form class="form-control w-full space-y-4 bg-white text-gray-700">
             <div class="form-control">
                 <label class="label">
                     <span class="label-text">Dimension</span>

--- a/crates/frontend/src/components/drawer.rs
+++ b/crates/frontend/src/components/drawer.rs
@@ -28,16 +28,16 @@ pub enum DrawerButtonStyle {
 
 #[component]
 pub fn drawer_btn(
-    drawer_id: String,
+    #[prop(into)] drawer_id: String,
     children: Children,
     #[prop(default = Callback::new(|_| {}))] on_click: Callback<MouseEvent, ()>,
-    #[prop(default = String::new())] class: String,
+    #[prop(into, default = String::new())] class: String,
     #[prop(default = DrawerButtonStyle::Fill)] style: DrawerButtonStyle,
 ) -> impl IntoView {
     let open_drawer_id = drawer_id.clone();
     let style = match style {
-        DrawerButtonStyle::Fill => "btn-purple drawer-button me-2 mb-2 px-5 py-2.5 font-medium rounded-lg text-sm text-center",
-        DrawerButtonStyle::Outline => "btn btn-purple-outline w-[8rem] m-1 cursor-pointer",
+        DrawerButtonStyle::Fill => "btn-purple drawer-button mr-2 mb-2 px-5 py-2.5 font-medium rounded-lg text-sm text-center",
+        DrawerButtonStyle::Outline => "btn btn-purple-outline w-[8rem] cursor-pointer",
     }.to_string();
 
     view! {

--- a/crates/frontend/src/components/drawer.rs
+++ b/crates/frontend/src/components/drawer.rs
@@ -30,7 +30,7 @@ pub enum DrawerButtonStyle {
 pub fn drawer_btn(
     #[prop(into)] drawer_id: String,
     children: Children,
-    #[prop(default = Callback::new(|_| {}))] on_click: Callback<MouseEvent, ()>,
+    #[prop(into, default = Callback::new(|_| {}))] on_click: Callback<MouseEvent, ()>,
     #[prop(into, default = String::new())] class: String,
     #[prop(default = DrawerButtonStyle::Fill)] style: DrawerButtonStyle,
 ) -> impl IntoView {

--- a/crates/frontend/src/components/experiment.rs
+++ b/crates/frontend/src/components/experiment.rs
@@ -363,7 +363,7 @@ where
             <ExperimentInfo experiment />
             <div class="card bg-base-100 max-w-screen shadow">
                 <div class="card-body">
-                    <h2 class="card-title">Context</h2>
+                    <h2 class="card-title">"Context"</h2>
                     <div class="flex flex-row flex-wrap gap-2">
 
                         {contexts
@@ -455,7 +455,7 @@ where
             </Show>
             <div class="card bg-base-100 max-w-screen shadow">
                 <div class="card-body">
-                    <h2 class="card-title">Variants</h2>
+                    <h2 class="card-title">"Variants"</h2>
                     <Table
                         rows=variant_rows
                         key_column="overrides".to_string()

--- a/crates/frontend/src/components/experiment.rs
+++ b/crates/frontend/src/components/experiment.rs
@@ -23,10 +23,6 @@ fn badge_class(status_type: ExperimentStatusType) -> &'static str {
     }
 }
 
-use super::table::types::{
-    default_column_formatter, default_formatter, ColumnSortable, Expandable,
-};
-
 #[component]
 fn experiment_info(experiment: StoredValue<ExperimentResponse>) -> impl IntoView {
     view! {
@@ -275,14 +271,7 @@ pub fn gen_variant_table(variants: &[Variant]) -> (Vec<Map<String, Value>>, Vec<
             VariantType::CONTROL => format!("{}", variant.variant_type),
             VariantType::EXPERIMENTAL => format!("Variant-{}", i),
         };
-        columns.push(Column::new(
-            name.clone(),
-            false,
-            default_formatter,
-            ColumnSortable::No,
-            Expandable::Enabled(100),
-            default_column_formatter,
-        ));
+        columns.push(Column::default(name.clone()));
         for (config, value) in variant.overrides.clone().into_inner().into_iter() {
             match row_map.get_mut(&config) {
                 Some(c) => {

--- a/crates/frontend/src/components/experiment_action_form.rs
+++ b/crates/frontend/src/components/experiment_action_form.rs
@@ -27,8 +27,8 @@ pub fn experiment_action_form(
     #[prop(into)] handle_submit: Callback<(), ()>,
     #[prop(into)] handle_close: Callback<(), ()>,
 ) -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let (change_reason_rs, change_reason_ws) = create_signal(change_reason(&popup_type));
     let (req_inprogress_rs, req_inprogress_ws) = create_signal(false);
     let popup_type = StoredValue::new(popup_type);
@@ -68,8 +68,8 @@ pub fn experiment_action_form(
         let change_reason_value = change_reason_rs.get();
 
         spawn_local(async move {
-            let tenant = tenant_rws.get_untracked().0;
-            let org = org_rws.get_untracked().0;
+            let tenant = workspace.get_untracked().0;
+            let org = org.get_untracked().0;
 
             let result = match popup_type {
                 PopupType::ExperimentPause => {

--- a/crates/frontend/src/components/experiment_conclude_form.rs
+++ b/crates/frontend/src/components/experiment_conclude_form.rs
@@ -143,13 +143,17 @@ pub fn experiment_conclude_form(
                             let disabled = req_inprogess_rws.get();
                             let (label, button_type_class) = match variant.variant_type {
                                 VariantType::CONTROL => ("Control".to_string(), "btn-info"),
-                                VariantType::EXPERIMENTAL => (format!("Variant-{idx}"), "btn-success"),
+                                VariantType::EXPERIMENTAL => {
+                                    (format!("Variant-{idx}"), "btn-success")
+                                }
                             };
 
                             view! {
                                 <button
                                     disabled=disabled
-                                    class=format!("max-w-md btn btn-block btn-outline {button_type_class}")
+                                    class=format!(
+                                        "max-w-md btn btn-block btn-outline {button_type_class}",
+                                    )
                                     class=("cursor-disabled", disabled)
                                     on:click=move |e| {
                                         e.prevent_default();
@@ -159,8 +163,6 @@ pub fn experiment_conclude_form(
                                     {label}
                                 </button>
                             }
-
-
                         })
                         .collect_view()
                 }

--- a/crates/frontend/src/components/experiment_conclude_form.rs
+++ b/crates/frontend/src/components/experiment_conclude_form.rs
@@ -20,8 +20,8 @@ pub fn experiment_conclude_form(
     experiment: ExperimentResponse,
     #[prop(into)] handle_submit: Callback<(), ()>,
 ) -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let experiment = StoredValue::new(experiment);
     let (change_reason_rs, change_reason_ws) = create_signal(String::new());
     let req_inprogess_rws = RwSignal::new(false);
@@ -30,8 +30,8 @@ pub fn experiment_conclude_form(
     let handle_conclude_experiment = move |variant_id: String| {
         req_inprogess_rws.set(true);
         spawn_local(async move {
-            let tenant = tenant_rws.get_untracked().0;
-            let org = org_rws.get_untracked().0;
+            let tenant = workspace.get_untracked().0;
+            let org = org.get_untracked().0;
             let result = conclude_experiment(
                 experiment.with_value(|e| e.id.clone()),
                 variant_id,
@@ -66,8 +66,8 @@ pub fn experiment_conclude_form(
 
     let handle_discard_experiment = move |change_reason: String| {
         req_inprogess_rws.set(true);
-        let tenant = tenant_rws.get_untracked().0;
-        let org = org_rws.get_untracked().0;
+        let tenant = workspace.get_untracked().0;
+        let org = org.get_untracked().0;
         spawn_local(async move {
             let result = discard_experiment(
                 &experiment.with_value(|e| e.id.clone()),

--- a/crates/frontend/src/components/experiment_discard_form.rs
+++ b/crates/frontend/src/components/experiment_discard_form.rs
@@ -22,8 +22,8 @@ where
     NF: Fn() + 'static + Clone,
 {
     let (change_reason, set_change_reason) = create_signal(String::new());
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
     let experiment_rc = Rc::new(experiment);
 
@@ -33,8 +33,8 @@ where
         let experiment_id = experiment_rc.id.clone();
         let handle_submit_clone = handle_submit.clone();
         spawn_local(async move {
-            let tenant = tenant_rws.get().0;
-            let org = org_rws.get().0;
+            let tenant = workspace.get().0;
+            let org = org.get().0;
             let change_reason_value = change_reason.get();
             let result =
                 discard_experiment(&experiment_id, &tenant, &org, change_reason_value)

--- a/crates/frontend/src/components/experiment_form.rs
+++ b/crates/frontend/src/components/experiment_form.rs
@@ -291,8 +291,8 @@ pub fn experiment_form(
                 view! {
                     <ContextForm
                         dimensions=dimensions.get_value()
-                        context_rs
-                        context_ws
+                        context=context_rs.get_untracked()
+                        on_context_change=move |new_context| context_ws.set(new_context)
                         handle_change=handle_context_form_change
                         resolve_mode=workspace_settings.get_value().strict_mode
                         disabled=edit_id.get_value().is_some()

--- a/crates/frontend/src/components/experiment_form.rs
+++ b/crates/frontend/src/components/experiment_form.rs
@@ -26,6 +26,7 @@ use crate::{
         change_form::ChangeForm,
         context_form::ContextForm,
         dropdown::{Dropdown, DropdownBtnType, DropdownDirection},
+        form::label::Label,
         metrics_form::MetricsForm,
         skeleton::{Skeleton, SkeletonVariant},
         variant_form::{DeleteVariantForm, VariantForm},
@@ -217,11 +218,9 @@ pub fn experiment_form(
     };
 
     view! {
-        <div>
+        <div class="flex flex-col gap-5">
             <div class="form-control w-full">
-                <label class="label">
-                    <span class="label-text">Experiment Name</span>
-                </label>
+                <Label title="Experiment Name" />
                 <input
                     disabled=edit_id.get_value().is_some()
                     value=move || experiment_name.get()
@@ -248,7 +247,7 @@ pub fn experiment_form(
             />
 
             <Suspense fallback=move || {
-                view! { <Skeleton variant=SkeletonVariant::Block style_class="h-10".to_string() /> }
+                view! { <Skeleton variant=SkeletonVariant::Block style_class="h-10" /> }
             }>
                 {move || {
                     let experiment_groups = experiment_groups_resource.get().unwrap_or_default();
@@ -259,9 +258,7 @@ pub fn experiment_form(
                     experiment_options.insert(0, None);
                     view! {
                         <div class="form-control">
-                            <label class="label">
-                                <span class="label-text">Experiment Group</span>
-                            </label>
+                            <Label title="Experiment Group" />
                             <Dropdown
                                 dropdown_width="w-100"
                                 dropdown_icon="".to_string()
@@ -290,26 +287,23 @@ pub fn experiment_form(
                 })
             />
 
-            <div class="my-4">
-                {move || {
-                    view! {
-                        <ContextForm
-                            dimensions=dimensions.get_value()
-                            context_rs
-                            context_ws
-                            handle_change=handle_context_form_change
-                            resolve_mode=workspace_settings.get_value().strict_mode
-                            disabled=edit_id.get_value().is_some()
-                                || (experiment_form_type.get_value() != ExperimentFormType::Default)
-                            heading_sub_text=String::from(
-                                "Define rules under which this experiment would run",
-                            )
-                            fn_environment
-                        />
-                    }
-                }}
-
-            </div>
+            {move || {
+                view! {
+                    <ContextForm
+                        dimensions=dimensions.get_value()
+                        context_rs
+                        context_ws
+                        handle_change=handle_context_form_change
+                        resolve_mode=workspace_settings.get_value().strict_mode
+                        disabled=edit_id.get_value().is_some()
+                            || (experiment_form_type.get_value() != ExperimentFormType::Default)
+                        heading_sub_text=String::from(
+                            "Define rules under which this experiment would run",
+                        )
+                        fn_environment
+                    />
+                }
+            }}
 
             {move || {
                 let variants = variants_rs.get();
@@ -341,20 +335,18 @@ pub fn experiment_form(
                 }
             }}
 
-            <div class="flex justify-start mt-8">
-                {move || {
-                    let loading = req_inprogess_rs.get();
-                    view! {
-                        <Button
-                            class="pl-[70px] pr-[70px] w-48 h-12".to_string()
-                            text="Submit".to_string()
-                            on_click=on_submit
-                            loading
-                        />
-                    }
-                }}
-
-            </div>
+            {move || {
+                let loading = req_inprogess_rs.get();
+                view! {
+                    <Button
+                        class="self-end h-12 w-48"
+                        text="Submit"
+                        icon_class="ri-send-plane-line"
+                        on_click=on_submit
+                        loading
+                    />
+                }
+            }}
         </div>
     }
 }

--- a/crates/frontend/src/components/experiment_form.rs
+++ b/crates/frontend/src/components/experiment_form.rs
@@ -87,8 +87,8 @@ pub fn experiment_form(
     let edit_id = StoredValue::new(edit_id);
     let dimensions = StoredValue::new(dimensions);
     let experiment_form_type = StoredValue::new(experiment_form_type);
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let workspace_settings = use_context::<StoredValue<WorkspaceResponse>>().unwrap();
 
     let (experiment_name, set_experiment_name) = create_signal(name);
@@ -104,7 +104,7 @@ pub fn experiment_form(
 
     let experiment_groups_resource: Resource<(String, String), Vec<ExperimentGroup>> =
         create_blocking_resource(
-            move || (tenant_rws.get().0, org_rws.get().0),
+            move || (workspace.get().0, org.get().0),
             |(current_tenant, org)| async move {
                 experiment_groups::fetch_all(
                     &ExpGroupFilters::default(),
@@ -151,8 +151,8 @@ pub fn experiment_form(
             .into_iter()
             .map(|(_, variant)| variant)
             .collect::<Vec<VariantFormT>>();
-        let tenant = tenant_rws.get().0;
-        let org = org_rws.get().0;
+        let tenant = workspace.get().0;
+        let org = org.get().0;
 
         spawn_local({
             async move {

--- a/crates/frontend/src/components/experiment_form.rs
+++ b/crates/frontend/src/components/experiment_form.rs
@@ -247,7 +247,9 @@ pub fn experiment_form(
                 on_change=Callback::new(move |metrics| metrics_rws.set(metrics))
             />
 
-            <Suspense fallback=move || view! { <Skeleton variant=SkeletonVariant::Block style_class="h-10".to_string() /> }>
+            <Suspense fallback=move || {
+                view! { <Skeleton variant=SkeletonVariant::Block style_class="h-10".to_string() /> }
+            }>
                 {move || {
                     let experiment_groups = experiment_groups_resource.get().unwrap_or_default();
                     let mut experiment_options: Vec<Option<String>> = experiment_groups

--- a/crates/frontend/src/components/experiment_group_form.rs
+++ b/crates/frontend/src/components/experiment_group_form.rs
@@ -25,6 +25,7 @@ use crate::{
         button::Button,
         change_form::ChangeForm,
         context_form::ContextForm,
+        form::label::Label,
         input::{Input, InputType},
     },
     logic::Conditions,
@@ -109,9 +110,7 @@ pub fn add_experiment_to_group_form(
                 }
             />
             <div class="form-control w-full">
-                <label class="label">
-                    <span class="label-text">Experiment Group Members</span>
-                </label>
+                <Label title="Experiment Group Members" />
                 <Input
                     id="experiment_group_members"
                     class="mt-5 rounded-md resize-y w-full max-w-md pt-3"
@@ -154,8 +153,9 @@ pub fn add_experiment_to_group_form(
                 let loading = loading_rws.get();
                 view! {
                     <Button
-                        class="pl-[70px] pr-[70px] w-48 h-12".to_string()
-                        text="Submit".to_string()
+                        class="self-end h-12 w-48"
+                        text="Submit"
+                        icon_class="ri-send-plane-line"
                         on_click=on_submit
                         loading
                     />
@@ -302,11 +302,9 @@ pub fn experiment_group_form(
     };
     view! {
         <EditorProvider>
-            <div>
+            <div class="flex flex-col gap-5">
                 <div class="form-control w-full">
-                    <label class="label">
-                        <span class="label-text">Experiment Group Name</span>
-                    </label>
+                    <Label title="Experiment Group Name" />
                     <input
                         disabled=is_edit
                         value=group_name_rws.get_untracked()
@@ -319,22 +317,20 @@ pub fn experiment_group_form(
                     />
                 </div>
 
-                <div class="my-4">
-                    <ContextForm
-                        dimensions=dimensions
-                        context_rs
-                        context_ws
-                        handle_change=move |new_context: Conditions| {
-                            context_ws.set_untracked(new_context);
-                        }
-                        resolve_mode=workspace_settings.get_value().strict_mode
-                        disabled=is_edit
-                        heading_sub_text=String::from(
-                            "Define rules under which this experiment group would function",
-                        )
-                        fn_environment
-                    />
-                </div>
+                <ContextForm
+                    dimensions=dimensions
+                    context_rs
+                    context_ws
+                    handle_change=move |new_context: Conditions| {
+                        context_ws.set_untracked(new_context);
+                    }
+                    resolve_mode=workspace_settings.get_value().strict_mode
+                    disabled=is_edit
+                    heading_sub_text=String::from(
+                        "Define rules under which this experiment group would function",
+                    )
+                    fn_environment
+                />
 
                 <ChangeForm
                     title="Description".to_string()
@@ -354,9 +350,7 @@ pub fn experiment_group_form(
                 />
 
                 <div class="form-control w-full">
-                    <label class="label">
-                        <span class="label-text">Traffic Percentage</span>
-                    </label>
+                    <Label title="Traffic Percentage" />
                     <input
                         value=traffic_percentage_rws.get_untracked().to_string()
                         on:input=move |ev| {
@@ -383,12 +377,10 @@ pub fn experiment_group_form(
 
                 <Show when=move || !is_edit>
                     <div class="form-control w-full">
-                        <label class="label">
-                            <span class="label-text">Experiment Group Members (Optional)</span>
-                        </label>
+                        <Label title="Experiment Group Members" info="(optional)" />
                         <Input
                             id="experiment_group_members"
-                            class="mt-5 rounded-md resize-y w-full max-w-md pt-3"
+                            class="w-full max-w-md pt-3 rounded-md resize-y"
                             schema_type=SchemaType::Single(JsonSchemaType::Array)
                             value=Value::Array(
                                 group_members_rws
@@ -429,8 +421,9 @@ pub fn experiment_group_form(
                     let loading = loading_rws.get();
                     view! {
                         <Button
-                            class="pl-[70px] pr-[70px] w-48 h-12".to_string()
-                            text="Submit".to_string()
+                            class="h-12 w-48"
+                            text="Submit"
+                            icon_class="ri-send-plane-line"
                             on_click=on_submit
                             loading
                         />

--- a/crates/frontend/src/components/experiment_group_form.rs
+++ b/crates/frontend/src/components/experiment_group_form.rs
@@ -38,8 +38,8 @@ pub fn add_experiment_to_group_form(
     experiment_group: StoredValue<ExperimentGroup>,
     handle_submit: Callback<()>,
 ) -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
 
     let members_selected_rws = create_rw_signal(Vec::new());
     let change_reason_rws = create_rw_signal(String::new());
@@ -49,8 +49,8 @@ pub fn add_experiment_to_group_form(
         loading_rws.set(true);
         event.prevent_default();
 
-        let tenant = tenant_rws.get().0;
-        let org_id = org_rws.get().0;
+        let tenant = workspace.get().0;
+        let org_id = org.get().0;
 
         let change_reason =
             match ChangeReason::try_from(change_reason_rws.get_untracked()) {
@@ -177,8 +177,8 @@ pub fn experiment_group_form(
     is_edit: bool,
     handle_submit: Callback<()>,
 ) -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let experiment_group_id_rws = create_rw_signal(group_id);
     let workspace_settings = use_context::<StoredValue<WorkspaceResponse>>().unwrap();
     let (context_rs, context_ws) = create_signal(context);
@@ -201,8 +201,8 @@ pub fn experiment_group_form(
         loading_rws.set(true);
         event.prevent_default();
 
-        let tenant = tenant_rws.get().0;
-        let org_id = org_rws.get().0;
+        let tenant = workspace.get().0;
+        let org_id = org.get().0;
 
         let change_reason =
             match ChangeReason::try_from(change_reason_rws.get_untracked()) {

--- a/crates/frontend/src/components/experiment_group_form.rs
+++ b/crates/frontend/src/components/experiment_group_form.rs
@@ -104,7 +104,9 @@ pub fn add_experiment_to_group_form(
                 title="Reason for Change".to_string()
                 placeholder="Enter a reason for this change".to_string()
                 value=change_reason_rws.get_untracked()
-                on_change=Callback::new(move |new_change_reason| change_reason_rws.set_untracked(new_change_reason))
+                on_change=move |new_change_reason| {
+                    change_reason_rws.set_untracked(new_change_reason)
+                }
             />
             <div class="form-control w-full">
                 <label class="label">

--- a/crates/frontend/src/components/experiment_group_form.rs
+++ b/crates/frontend/src/components/experiment_group_form.rs
@@ -319,8 +319,8 @@ pub fn experiment_group_form(
 
                 <ContextForm
                     dimensions=dimensions
-                    context_rs
-                    context_ws
+                    context=context_rs.get_untracked()
+                    on_context_change=move |new_context| context_ws.set(new_context)
                     handle_change=move |new_context: Conditions| {
                         context_ws.set_untracked(new_context);
                     }

--- a/crates/frontend/src/components/experiment_ramp_form.rs
+++ b/crates/frontend/src/components/experiment_ramp_form.rs
@@ -22,8 +22,8 @@ where
     NF: Fn() + 'static + Clone,
 {
     let (traffic, set_traffic) = create_signal(*experiment.traffic_percentage);
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
     let range_max = 100 / experiment.variants.len();
     let experiment_rc = Rc::new(experiment);
@@ -33,8 +33,8 @@ where
         let experiment_clone = experiment_rc.clone();
         let handle_submit_clone = handle_submit.clone();
         spawn_local(async move {
-            let tenant = tenant_rws.get_untracked().0;
-            let org = org_rws.get_untracked().0;
+            let tenant = workspace.get_untracked().0;
+            let org = org.get_untracked().0;
             let traffic_value = traffic.get_untracked();
             let result =
                 ramp_experiment(&experiment_clone.id, traffic_value, None, &tenant, &org)

--- a/crates/frontend/src/components/form.rs
+++ b/crates/frontend/src/components/form.rs
@@ -1,0 +1,1 @@
+pub mod label;

--- a/crates/frontend/src/components/form/label.rs
+++ b/crates/frontend/src/components/form/label.rs
@@ -1,0 +1,37 @@
+use leptos::*;
+
+#[component]
+pub fn label(
+    #[prop(into)] title: String,
+    #[prop(into, optional)] info: Option<String>,
+    #[prop(into, optional)] extra_info: Option<String>,
+    #[prop(into, optional)] description: Option<String>,
+    #[prop(into, default = String::new())] class: String,
+) -> impl IntoView {
+    view! {
+        <label class=format!("label flex flex-col items-start justify-center {class}")>
+            <div class="flex items-center gap-1 label-text font-semibold text-base">
+                {title}
+                {info
+                    .map(|info| {
+                        view! { <span class="text-sm font-normal text-slate-400">{info}</span> }
+                    })}
+                {extra_info
+                    .map(|extra_info| {
+                        view! {
+                            <div class="group relative inline-block text-[10px] text-gray-700 cursor-pointer">
+                                <p class="z-[1000] hidden absolute top-full left-1/2 w-[320px] p-2.5 group-hover:flex flex-col gap-4 bg-black text-white leading-relaxed rounded shadow-[0_4px_6px_rgba(0,0,0,0.1)] whitespace-normal translate-x-[20px] -translate-y-1/2">
+                                    {extra_info}
+                                </p>
+                                <i class="ri-information-line ri-lg" />
+                            </div>
+                        }
+                    })}
+            </div>
+            {description
+                .map(|description| {
+                    view! { <span class="label-text text-slate-400">{description}</span> }
+                })}
+        </label>
+    }
+}

--- a/crates/frontend/src/components/function_form.rs
+++ b/crates/frontend/src/components/function_form.rs
@@ -71,8 +71,8 @@ pub fn function_editor<NF>(
 where
     NF: Fn() + 'static + Clone,
 {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let (function_name, set_function_name) = create_signal(function_name);
     let (function_code_rs, function_code_ws) = create_signal(function);
     let (runtime_version, set_runtime_version) = create_signal(runtime_version);
@@ -89,8 +89,8 @@ where
         event.prevent_default();
         logging::log!("Submitting function form");
 
-        let tenant = tenant_rws.get().0;
-        let org = org_rws.get().0;
+        let tenant = workspace.get().0;
+        let org = org.get().0;
         let f_function_name = function_name.get();
         let f_function = function_code_rs.get();
         let f_runtime_version = runtime_version.get();
@@ -280,8 +280,8 @@ pub fn test_form(
     function_args: FunctionExecutionRequest,
     stage: String,
 ) -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let (error_message, set_error_message) = create_signal(String::new());
     let (output_message_rs, out_message_ws) =
         create_signal::<Option<FunctionExecutionResponse>>(None);
@@ -292,8 +292,8 @@ pub fn test_form(
         event.prevent_default();
         logging::log!("Submitting function form");
 
-        let tenant = tenant_rws.get().0;
-        let org = org_rws.get().0;
+        let tenant = workspace.get().0;
+        let org = org.get().0;
         let f_function_name = function_name.clone();
         let f_args = function_args_rs.get();
         let f_stage = stage.clone();

--- a/crates/frontend/src/components/function_form.rs
+++ b/crates/frontend/src/components/function_form.rs
@@ -253,8 +253,9 @@ where
                                 let loading = req_inprogess_rs.get();
                                 view! {
                                     <Button
-                                        class="pl-[70px] pr-[70px] w-48 h-12".to_string()
-                                        text="Submit".to_string()
+                                        class="h-12 w-48"
+                                        text="Submit"
+                                        icon_class="ri-send-plane-line"
                                         on_click=on_submit.clone()
                                         loading
                                     />
@@ -496,8 +497,9 @@ pub fn test_form(
                         let loading = req_inprogess_rs.get();
                         view! {
                             <Button
-                                class="pl-[70px] pr-[70px] w-48 h-12".to_string()
-                                text="Submit".to_string()
+                                class="h-12 w-48"
+                                text="Submit"
+                                icon_class="ri-send-plane-line"
                                 on_click=on_submit.clone()
                                 loading
                             />

--- a/crates/frontend/src/components/input.rs
+++ b/crates/frontend/src/components/input.rs
@@ -547,11 +547,11 @@ pub fn monaco_input(
 
 #[component]
 pub fn date_input(
-    id: String,
-    class: String,
-    name: String,
-    on_change: Callback<DateTime<Utc>, ()>,
-    #[prop(default = Callback::new(|_| {}))] on_clear: Callback<(), ()>,
+    #[prop(into)] id: String,
+    #[prop(into, default = String::new())] class: String,
+    #[prop(into)] name: String,
+    #[prop(into)] on_change: Callback<DateTime<Utc>, ()>,
+    #[prop(into, default = Callback::new(|_| {}))] on_clear: Callback<(), ()>,
     #[prop(into, default = Utc::now().format("%Y-%m-%d").to_string())] value: String,
     #[prop(default = false)] disabled: bool,
     #[prop(default = false)] required: bool,

--- a/crates/frontend/src/components/metrics_form.rs
+++ b/crates/frontend/src/components/metrics_form.rs
@@ -3,7 +3,10 @@ use serde_json::Value;
 use superposition_types::database::models::{MetricSource, Metrics};
 
 use crate::{
-    components::input::{Input, InputType, Toggle},
+    components::{
+        form::label::Label,
+        input::{Input, InputType, Toggle},
+    },
     schema::{JsonSchemaType, SchemaType},
 };
 
@@ -182,17 +185,14 @@ pub fn metrics_form(
     };
 
     view! {
-        <div class="pt-2 flex flex-col">
-            <label class="label w-fit flex items-center gap-2">
+        <div class="flex flex-col">
+            <div class="w-fit flex items-center gap-2">
                 <Toggle value=metrics_rws.with_untracked(|m| m.enabled) on_change=toggle_enabled />
-                <span class="label-text">"Metrics"</span>
-                <div class="group relative inline-block text-[10px] text-gray-700 cursor-pointer">
-                    <p class="z-[1000] hidden absolute top-full left-1/2 w-[320px] p-2.5 group-hover:flex flex-col gap-4 bg-black text-white rounded shadow-[0_4px_6px_rgba(0,0,0,0.1)] whitespace-normal translate-x-[20px] -translate-y-1/2">
-                        "To view metrics from Grafana, make sure that your setup allows iframe embedding. Also, experiment viewers must have access to the Grafana instance, to view the metrics."
-                    </p>
-                    <i class="ri-information-line ri-lg" />
-                </div>
-            </label>
+                <Label
+                    title="Metrics"
+                    extra_info="To view metrics from Grafana, make sure that your setup allows iframe embedding. Also, experiment viewers must have access to the Grafana instance, to view the metrics."
+                />
+            </div>
 
             <Show when=move || {
                 metrics_rws

--- a/crates/frontend/src/components/override_form.rs
+++ b/crates/frontend/src/components/override_form.rs
@@ -184,8 +184,8 @@ pub fn override_form(
         };
     });
 
-    let tenant = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_id = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org_id = use_context::<Signal<OrganisationId>>().unwrap();
 
     let autocomplete_callbacks = default_config
         .get_value()
@@ -195,7 +195,7 @@ pub fn override_form(
                 d.key.clone(),
                 d.autocomplete_function_name.clone(),
                 fn_environment,
-                tenant.get_untracked().0,
+                workspace.get_untracked().0,
                 org_id.get_untracked().0,
             )
         })

--- a/crates/frontend/src/components/override_form.rs
+++ b/crates/frontend/src/components/override_form.rs
@@ -64,7 +64,7 @@ fn override_input(
     view! {
         <div class="flex flex-col">
             <div class="form-control">
-                <label class="label justify-start font-mono text-sm gap-2">
+                <label class="label justify-start text-sm gap-2">
                     <span class="label-text font-bold text-gray-500">{key.get_value()} ":"</span>
                     <div class="flex gap-1">
                         <TypeBadge r#type=r#type.clone() />

--- a/crates/frontend/src/components/pagination.rs
+++ b/crates/frontend/src/components/pagination.rs
@@ -7,8 +7,7 @@ pub fn pagination(
     #[prop(default = String::new())] class: String,
     current_page: i64,
     total_pages: i64,
-    next: Callback<i64>,
-    previous: Callback<i64>,
+    #[prop(into)] on_change: Callback<i64>,
 ) -> impl IntoView {
     let current_page = max(1, current_page);
     let total_pages = max(1, total_pages);
@@ -25,15 +24,59 @@ pub fn pagination(
         current_page
     };
 
+    let input_page = RwSignal::new(current_page.to_string());
+    let input_invalid = RwSignal::new(false);
+
+    let handle_jump = move || {
+        if let Ok(page) = input_page.get().parse::<i64>() {
+            if page < 1 || page > total_pages {
+                input_invalid.set(true);
+            } else {
+                input_invalid.set(false);
+                if page != current_page {
+                    on_change.call(page);
+                }
+            }
+        } else {
+            input_invalid.set(true);
+        }
+    };
+
     view! {
         <div class=format!("join {class}")>
-            <button class="join-item btn" on:click=move |_| previous.call(previous_page)>
+            <button class="join-item btn" on:click=move |_| on_change.call(previous_page)>
                 "«"
             </button>
             <button class="join-item btn">
                 {format!("Page {} / {}", current_page, total_pages)}
             </button>
-            <button class="join-item btn" on:click=move |_| next.call(next_page)>
+            <div class="join-item btn !px-1">
+                <div class=move || {
+                    format!(
+                        "input input-sm h-max w-20 px-1 flex justify-between items-center rounded-lg {}",
+                        if input_invalid.get() { "input-error" } else { "" },
+                    )
+                }>
+                    <input
+                        type="number"
+                        min="1"
+                        max=total_pages
+                        class="w-full rounded"
+                        value=input_page
+                        on:input=move |ev| {
+                            input_page.set(event_target_value(&ev));
+                            input_invalid.set(false);
+                        }
+                        on:keydown=move |ev| {
+                            if ev.key() == "Enter" {
+                                handle_jump();
+                            }
+                        }
+                    />
+                    <i class="ri-corner-down-left-line text-gray-400" />
+                </div>
+            </div>
+            <button class="join-item btn" on:click=move |_| on_change.call(next_page)>
                 "»"
             </button>
         </div>

--- a/crates/frontend/src/components/side_nav.rs
+++ b/crates/frontend/src/components/side_nav.rs
@@ -111,19 +111,12 @@ pub fn side_nav(
     });
 
     view! {
-        <div class="max-w-xs z-990 fixed my-4 ml-4 block w-full h-full flex-wrap inset-y-0 items-center justify-between overflow-y-auto rounded-2xl border-0 bg-white p-0 shadow-none -translate-x-full transition-transform duration-200 xl:left-0 xl:translate-x-0 xl:bg-transparent">
-            <div class="h-19.5">
-                <A
-                    href="/admin"
-                    class="block px-8 py-6 m-0 text-sm whitespace-nowrap text-slate-700"
-                >
-                    <span class="ml-1 font-semibold transition-all duration-200">
-                        Superposition Platform
-                    </span>
-                </A>
-            </div>
+        <div class="fixed z-990 inset-y-0 xl:left-0 h-full w-full max-w-xs py-4 pl-4 flex flex-col gap-2 overflow-y-auto bg-white xl:bg-transparent rounded-2xl -translate-x-full xl:translate-x-0 transition-transform duration-200">
+            <A href="/admin" class="flex-0 px-8 py-6 text-sm font-semibold text-center text-slate-700 whitespace-nowrap transition-all duration-200">
+                    Superposition Platform
+            </A>
             <Suspense fallback=move || {
-                view! { <Skeleton variant=SkeletonVariant::Content /> }
+                view! { <Skeleton variant=SkeletonVariant::Block style_class="h-10" /> }
             }>
                 <select
                     value=tenant_rws.get().0
@@ -154,10 +147,8 @@ pub fn side_nav(
                         let navigate = use_navigate();
                         navigate(redirect_url.as_str(), Default::default())
                     }
-
-                    class="select w-full max-w-xs shadow-md"
+                    class="flex-0 select w-full max-w-xs shadow-md"
                 >
-
                     {move || {
                         let workspaces = workspace_resource
                             .get()
@@ -185,33 +176,29 @@ pub fn side_nav(
                             }
                         }
                     }}
-
                 </select>
-                // <hr class="h-px mt-0 mb-1 bg-transparent bg-gradient-to-r from-transparent via-black/40 to-transparent"/>
-                <div class="items-center block w-auto max-h-screen overflow-auto h-sidenav grow basis-full">
-                    <ul class="menu">
-                        <For
-                            each=move || app_routes.get()
-                            key=|route: &AppRoute| route.key.to_string()
-                            children=move |route: AppRoute| {
-                                let path = route.path.to_string();
-                                let is_active = location.pathname.get().contains(&path);
-                                view! {
-                                    <li class="mt-1 w-full">
-                                        <NavItem
-                                            href=route.path.to_string()
-                                            icon=route.icon.to_string()
-                                            text=route.label.to_string()
-                                            is_active=is_active
-                                        />
-                                    </li>
-                                }
-                            }
-                        />
-
-                    </ul>
-                </div>
             </Suspense>
+            // <hr class="h-px mt-0 mb-1 bg-transparent bg-gradient-to-r from-transparent via-black/40 to-transparent"/>
+            <ul class="menu flex-1 h-full flex-nowrap gap-1 overflow-auto">
+                <For
+                    each=move || app_routes.get()
+                    key=|route: &AppRoute| route.key.to_string()
+                    children=move |route: AppRoute| {
+                        let path = route.path.to_string();
+                        let is_active = location.pathname.get().contains(&path);
+                        view! {
+                            <li class="w-full">
+                                <NavItem
+                                    href=route.path.to_string()
+                                    icon=route.icon.to_string()
+                                    text=route.label.to_string()
+                                    is_active=is_active
+                                />
+                            </li>
+                        }
+                    }
+                />
+            </ul>
         </div>
     }
 }

--- a/crates/frontend/src/components/side_nav.rs
+++ b/crates/frontend/src/components/side_nav.rs
@@ -112,8 +112,11 @@ pub fn side_nav(
 
     view! {
         <div class="fixed z-990 inset-y-0 xl:left-0 h-full w-full max-w-xs py-4 pl-4 flex flex-col gap-2 overflow-y-auto bg-white xl:bg-transparent rounded-2xl -translate-x-full xl:translate-x-0 transition-transform duration-200">
-            <A href="/admin" class="flex-0 px-8 py-6 text-sm font-semibold text-center text-slate-700 whitespace-nowrap transition-all duration-200">
-                    Superposition Platform
+            <A
+                href="/admin"
+                class="flex-0 px-8 py-6 text-sm font-semibold text-center text-slate-700 whitespace-nowrap transition-all duration-200"
+            >
+                Superposition Platform
             </A>
             <Suspense fallback=move || {
                 view! { <Skeleton variant=SkeletonVariant::Block style_class="h-10" /> }

--- a/crates/frontend/src/components/side_nav.rs
+++ b/crates/frontend/src/components/side_nav.rs
@@ -1,12 +1,13 @@
-use crate::components::nav_item::NavItem;
-use crate::components::skeleton::{Skeleton, SkeletonVariant};
+use leptos::*;
+use leptos_router::{use_location, use_route, A};
+use superposition_types::{api::workspace::WorkspaceResponse, PaginatedResponse};
+
+use crate::components::{
+    nav_item::NavItem,
+    skeleton::{Skeleton, SkeletonVariant},
+};
 use crate::types::{AppRoute, OrganisationId, Tenant};
 use crate::utils::use_url_base;
-
-use leptos::*;
-use leptos_router::{use_location, use_navigate, A};
-use superposition_types::{api::workspace::WorkspaceResponse, PaginatedResponse};
-use web_sys::Event;
 
 fn create_routes(org: &str, tenant: &str) -> Vec<AppRoute> {
     let base = use_url_base();
@@ -81,25 +82,142 @@ fn create_routes(org: &str, tenant: &str) -> Vec<AppRoute> {
 }
 
 #[component]
+pub fn workspace_selector(
+    workspace_resource: Resource<String, PaginatedResponse<WorkspaceResponse>>,
+    #[prop(into)] app_routes: Signal<Vec<AppRoute>>,
+) -> impl IntoView {
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+
+    let base = use_url_base();
+    let route_context = use_route();
+    let original_path = StoredValue::new(String::from(
+        route_context.original_path().replace(&base, ""),
+    ));
+    let resolved_path = StoredValue::new({
+        let curr_path = route_context.path();
+        app_routes
+            .get_untracked()
+            .iter()
+            .find_map(|r| curr_path.contains(&r.path).then_some(r.path.clone()))
+            .unwrap_or(curr_path)
+            .replace(&base, "")
+    });
+
+    let search_term_rws = RwSignal::new(String::new());
+    let csr_rws = RwSignal::new(false);
+    Effect::new(move |_| csr_rws.set(true));
+
+    let node_ref = create_node_ref::<html::Input>();
+
+    view! {
+        <Suspense fallback=move || {
+            view! { <Skeleton variant=SkeletonVariant::Block style_class="h-10" /> }
+        }>
+            <div class="dropdown dropdown-downm w-full max-w-xs">
+                <label
+                    tabindex="0"
+                    class="select flex items-center shadow-md"
+                    on:click:undelegated=move |_| {
+                        if let Some(element) = node_ref.get() {
+                            let _ = element.focus();
+                        }
+                    }
+                >
+                    {move || { workspace.get().0 }}
+                </label>
+                <ul
+                    tabindex="0"
+                    class="dropdown-content menu z-[1] max-h-96 w-[inherit] p-2 flex-nowrap bg-base-100 rounded-box overflow-y-scroll overflow-x-hidden shadow"
+                >
+                    <Show when=move || csr_rws.get()>
+                        <label class="input input-bordered mb-3 flex items-center gap-2 h-10">
+                            <i class="ri-search-line"></i>
+                            <input
+                                type="text"
+                                class="grow"
+                                placeholder="Search"
+                                ref_=node_ref
+                                value=search_term_rws.get_untracked()
+                                on:input=move |ev| search_term_rws.set(event_target_value(&ev))
+                            />
+                        </label>
+                    </Show>
+                    {move || {
+                        let workspaces = workspace_resource
+                            .with(|r| r.as_ref().map(|r| r.data.clone()).unwrap_or_default())
+                            .into_iter()
+                            .filter_map(|workspace| {
+                                workspace
+                                    .workspace_name
+                                    .starts_with(search_term_rws.get().as_str())
+                                    .then_some(workspace.workspace_name)
+                            })
+                            .collect::<Vec<_>>();
+                        match workspaces.is_empty() {
+                            false => {
+                                workspaces
+                                    .into_iter()
+                                    .map(move |option| {
+                                        let resolved_path = resolved_path.get_value();
+                                        let original_path = original_path.get_value();
+                                        let redirect_url = std::iter::zip(
+                                                original_path.split('/'),
+                                                resolved_path.split('/'),
+                                            )
+                                            .map(|(o_token, r_token)| match o_token {
+                                                ":tenant" => &option,
+                                                _ => r_token,
+                                            })
+                                            .map(String::from)
+                                            .collect::<Vec<_>>()
+                                            .join("/");
+                                        let selected = workspace.get_untracked().0 == option;
+                                        let disable_class = if selected {
+                                            "pointer-events-none cursor-default"
+                                        } else {
+                                            ""
+                                        };
+
+                                        view! {
+                                            <li class=format!("w-full {disable_class}")>
+                                                <A class="w-full flex justify-between" href=redirect_url>
+                                                    {option}
+                                                    <Show when=move || selected>
+                                                        <i class="ri-check-line" />
+                                                    </Show>
+                                                </A>
+                                            </li>
+                                        }
+                                    })
+                                    .collect_view()
+                            }
+                            true => {
+                                view! { <option disabled=true>{"Loading..."}</option> }.into_view()
+                            }
+                        }
+                    }}
+                </ul>
+            </div>
+        </Suspense>
+    }
+}
+
+#[component]
 pub fn side_nav(
-    resolved_path: String,
-    original_path: String,
     workspace_resource: Resource<String, PaginatedResponse<WorkspaceResponse>>,
 ) -> impl IntoView {
     let location = use_location();
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
-    let (app_routes, set_app_routes) = create_signal(create_routes(
-        org_rws.get_untracked().as_str(),
-        tenant_rws.get_untracked().as_str(),
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
+    let app_routes_rws = RwSignal::new(create_routes(
+        org.get_untracked().as_str(),
+        workspace.get_untracked().as_str(),
     ));
-    let resolved_path = create_rw_signal(resolved_path);
-    let original_path = create_rw_signal(original_path);
 
     create_effect(move |_| {
         let current_path = location.pathname.get();
 
-        set_app_routes.update(|app_routes| {
+        app_routes_rws.update(|app_routes| {
             for route in app_routes {
                 if current_path.contains(&route.path) {
                     route.key = format!("{}-{}", route.path, "active");
@@ -118,73 +236,11 @@ pub fn side_nav(
             >
                 Superposition Platform
             </A>
-            <Suspense fallback=move || {
-                view! { <Skeleton variant=SkeletonVariant::Block style_class="h-10" /> }
-            }>
-                <select
-                    value=tenant_rws.get().0
-                    on:change=move |event: Event| {
-                        let selected_tenant = event_target_value(&event);
-                        let base = use_url_base();
-                        let resolved_path_c = resolved_path.get().replace(&base, "");
-                        let original_path_c = original_path.get().replace(&base, "");
-                        logging::log!("ORIGINAL_PATH: {:?}", original_path_c);
-                        let redirect_url = std::iter::zip(
-                                original_path_c.split('/'),
-                                resolved_path_c.split('/'),
-                            )
-                            .map(|(o_token, r_token)| match o_token {
-                                ":tenant" => selected_tenant.clone(),
-                                _ => r_token.to_string(),
-                            })
-                            .collect::<Vec<String>>()
-                            .join("/");
-                        tenant_rws.set(Tenant(selected_tenant.clone()));
-                        set_app_routes
-                            .set(
-                                create_routes(
-                                    org_rws.get_untracked().as_str(),
-                                    selected_tenant.as_str(),
-                                ),
-                            );
-                        let navigate = use_navigate();
-                        navigate(redirect_url.as_str(), Default::default())
-                    }
-                    class="flex-0 select w-full max-w-xs shadow-md"
-                >
-                    {move || {
-                        let workspaces = workspace_resource
-                            .get()
-                            .unwrap_or_default()
-                            .data
-                            .into_iter()
-                            .map(|workspace| workspace.workspace_name)
-                            .collect::<Vec<String>>();
-                        match workspaces.is_empty() {
-                            false => {
-                                workspaces
-                                    .iter()
-                                    .map(|tenant| {
-                                        view! {
-                                            <option selected=tenant
-                                                == tenant_rws.get().as_str()>{tenant}</option>
-                                        }
-                                    })
-                                    .collect::<Vec<_>>()
-                            }
-                            true => {
-                                vec![
-                                    view! { <option disabled=true>{"Loading tenants..."}</option> },
-                                ]
-                            }
-                        }
-                    }}
-                </select>
-            </Suspense>
+            <WorkspaceSelector workspace_resource app_routes=app_routes_rws />
             // <hr class="h-px mt-0 mb-1 bg-transparent bg-gradient-to-r from-transparent via-black/40 to-transparent"/>
             <ul class="menu flex-1 h-full flex-nowrap gap-1 overflow-auto">
                 <For
-                    each=move || app_routes.get()
+                    each=move || app_routes_rws.get()
                     key=|route: &AppRoute| route.key.to_string()
                     children=move |route: AppRoute| {
                         let path = route.path.to_string();

--- a/crates/frontend/src/components/side_nav.rs
+++ b/crates/frontend/src/components/side_nav.rs
@@ -90,9 +90,8 @@ pub fn workspace_selector(
 
     let base = use_url_base();
     let route_context = use_route();
-    let original_path = StoredValue::new(String::from(
-        route_context.original_path().replace(&base, ""),
-    ));
+    let original_path =
+        StoredValue::new(route_context.original_path().replace(&base, ""));
     let resolved_path = StoredValue::new({
         let curr_path = route_context.path();
         app_routes

--- a/crates/frontend/src/components/skeleton.rs
+++ b/crates/frontend/src/components/skeleton.rs
@@ -10,7 +10,7 @@ pub enum SkeletonVariant {
 
 #[component]
 pub fn skeleton(
-    #[prop(default = String::from("w-full"))] style_class: String,
+    #[prop(into, default = String::from("w-full"))] style_class: String,
     #[prop(default = SkeletonVariant::Page)] variant: SkeletonVariant,
 ) -> impl IntoView {
     let container_div_styles = format!("flex flex-col gap-4 {style_class}");

--- a/crates/frontend/src/components/table.rs
+++ b/crates/frontend/src/components/table.rs
@@ -19,7 +19,9 @@ pub fn expandable_text(
     let get_child = move |val: &str| formatter(val, &row);
     let (is_expanded_rs, is_expanded_ws) = create_signal(false);
     view! {
-        <td class=format!("{class_name} align-top")>
+        <td class=format!(
+            "{class_name} align-top",
+        )>
             {move || {
                 let value = stored_value.get_value();
                 let is_expanded = is_expanded_rs.get();
@@ -175,7 +177,9 @@ pub fn table(
                                                     value
                                                     formatter=column.formatter
                                                     row=row.clone()
-                                                    class_name=format!("min-w-48 max-w-106 px-3 break-words {cell_class_clone} {sticky_class}")
+                                                    class_name=format!(
+                                                        "min-w-48 max-w-106 px-3 break-words {cell_class_clone} {sticky_class}",
+                                                    )
                                                     is_expandable=column.expandable
                                                 />
                                             }

--- a/crates/frontend/src/components/table.rs
+++ b/crates/frontend/src/components/table.rs
@@ -175,7 +175,7 @@ pub fn table(
                                                     value
                                                     formatter=column.formatter
                                                     row=row.clone()
-                                                    class_name=format!("min-w-48 max-w-106 px-3 break-words font-mono {cell_class_clone} {sticky_class}")
+                                                    class_name=format!("min-w-48 max-w-106 px-3 break-words {cell_class_clone} {sticky_class}")
                                                     is_expandable=column.expandable
                                                 />
                                             }

--- a/crates/frontend/src/components/table.rs
+++ b/crates/frontend/src/components/table.rs
@@ -197,15 +197,14 @@ pub fn table(
         }>
 
             {move || {
-                let TablePaginationProps { current_page, total_pages, on_prev, on_next, .. } = pagination_props
+                let TablePaginationProps { current_page, total_pages, on_page_change, .. } = pagination_props
                     .get_value();
                 view! {
                     <div class="mt-2 flex justify-end">
                         <Pagination
                             current_page=current_page
                             total_pages=total_pages
-                            next=on_next
-                            previous=on_prev
+                            on_change=on_page_change
                         />
                     </div>
                 }

--- a/crates/frontend/src/components/table.rs
+++ b/crates/frontend/src/components/table.rs
@@ -82,7 +82,7 @@ pub fn table(
             <table class="table table-zebra">
                 <thead class=head_class>
                     <tr class="bg-white">
-                        <th class="sticky left-0 z-20 bg-inherit min-w-[5rem] px-3"></th>
+                        <th class="sticky left-0 z-20 bg-inherit min-w-[5rem] px-3" />
 
                         {columns
                             .iter()
@@ -100,32 +100,35 @@ pub fn table(
                                         view! {
                                             <th
                                                 class=format!(
-                                                    "uppercase cursor-pointer px-3 {}",
-                                                    sticky_class,
+                                                    "px-3 flex items-center gap-1 cursor-pointer {sticky_class}",
                                                 )
                                                 on:click=move |_| sort_fn.call(())
                                             >
                                                 {col_formatter(&column.name)}
                                                 {match (currently_sorted, sort_by) {
                                                     (false, _) => {
-                                                        view! { <i class="ri-expand-up-down-line"></i> }
+                                                        view! {
+                                                            <i class="ri-expand-up-down-fill ri-xl self-center" />
+                                                        }
                                                     }
                                                     (_, SortBy::Desc) => {
-                                                        view! { <i class="ri-arrow-down-s-line"></i> }
+                                                        view! {
+                                                            <i class="ri-arrow-down-s-fill ri-xl text-purple-700" />
+                                                        }
                                                     }
                                                     (_, SortBy::Asc) => {
-                                                        view! { <i class="ri-arrow-up-s-line"></i> }
+                                                        view! {
+                                                            <i class="ri-arrow-up-s-fill ri-xl text-purple-700" />
+                                                        }
                                                     }
                                                 }}
-
                                             </th>
                                         }
                                     }
                                     types::ColumnSortable::No => {
                                         view! {
                                             <th class=format!(
-                                                "uppercase px-3 {}",
-                                                sticky_class,
+                                                "px-3 {sticky_class}",
                                             )>{col_formatter(&column.name)}</th>
                                         }
                                     }

--- a/crates/frontend/src/components/table/types.rs
+++ b/crates/frontend/src/components/table/types.rs
@@ -113,8 +113,7 @@ pub struct TablePaginationProps {
     pub current_page: i64,
     pub total_pages: i64,
     pub count: i64,
-    pub on_next: Callback<i64>,
-    pub on_prev: Callback<i64>,
+    pub on_page_change: Callback<i64>,
 }
 
 impl Default for TablePaginationProps {
@@ -124,8 +123,7 @@ impl Default for TablePaginationProps {
             current_page: 0,
             total_pages: 0,
             count: 0,
-            on_next: Callback::new(move |_| {}),
-            on_prev: Callback::new(move |_| {}),
+            on_page_change: Callback::new(|_| {}),
         }
     }
 }

--- a/crates/frontend/src/components/type_template_form.rs
+++ b/crates/frontend/src/components/type_template_form.rs
@@ -26,8 +26,8 @@ pub fn type_template_form<NF>(
 where
     NF: Fn() + 'static + Clone,
 {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
 
     let (error_message, set_error_message) = create_signal("".to_string());
     let (type_name_rs, type_name_ws) = create_signal(type_name);
@@ -53,7 +53,7 @@ where
                         "description": description_rs.get(),
                         "change_reason": change_reason_rs.get(),
                     });
-                    update_type(tenant_rws.get().0, type_name, payload, org_rws.get().0)
+                    update_type(workspace.get().0, type_name, payload, org.get().0)
                         .await
                 } else {
                     let description = description_rs.get();
@@ -64,8 +64,7 @@ where
                         "description": description,
                         "change_reason": change_reason
                     });
-                    create_type(tenant_rws.get().0, payload.clone(), org_rws.get().0)
-                        .await
+                    create_type(workspace.get().0, payload.clone(), org.get().0).await
                 };
 
                 req_inprogress_ws.set(false);

--- a/crates/frontend/src/components/type_template_form.rs
+++ b/crates/frontend/src/components/type_template_form.rs
@@ -1,5 +1,6 @@
 pub mod utils;
 
+use crate::components::form::label::Label;
 use crate::components::type_template_form::utils::create_type;
 use crate::components::{
     alert::AlertType,
@@ -53,8 +54,7 @@ where
                         "description": description_rs.get(),
                         "change_reason": change_reason_rs.get(),
                     });
-                    update_type(workspace.get().0, type_name, payload, org.get().0)
-                        .await
+                    update_type(workspace.get().0, type_name, payload, org.get().0).await
                 } else {
                     let description = description_rs.get();
                     let change_reason = change_reason_rs.get();
@@ -91,11 +91,9 @@ where
         });
     };
     view! {
-        <form class="form-control w-full space-y-4 bg-white text-gray-700">
+        <form class="w-full flex flex-col gap-5 bg-white text-gray-700">
             <div class="form-control">
-                <label class="label">
-                    <span class="label-text">Type Name</span>
-                </label>
+                <Label title="Type Name" />
                 <input
                     disabled=edit
                     type="text"
@@ -109,7 +107,6 @@ where
                         type_name_ws.set(value);
                     }
                 />
-
             </div>
 
             <ChangeForm
@@ -130,9 +127,7 @@ where
             />
 
             <div class="form-control">
-                <label class="label">
-                    <span class="label-text">Type Schema</span>
-                </label>
+                <Label title="Type Schema" />
                 {move || {
                     let schem = type_schema_rs.get();
                     let schema_type = SchemaType::Single(JsonSchemaType::from(&schem));
@@ -140,12 +135,10 @@ where
                         <EditorProvider>
                             <Input
                                 id="type-schema"
-                                class="mt-5 rounded-md resize-y w-full max-w-md pt-3"
+                                class="w-full max-w-md pt-3 rounded-md resize-y"
                                 schema_type
                                 value=schem
-                                on_change=Callback::new(move |new_type_schema| {
-                                    type_schema_ws.set(new_type_schema)
-                                })
+                                on_change=move |new_type_schema| type_schema_ws.set(new_type_schema)
                                 r#type=InputType::Monaco(vec![])
                             />
                         </EditorProvider>
@@ -154,23 +147,20 @@ where
 
             </div>
 
-            <div class="form-control grid w-full mt-5 justify-start">
-                {move || {
-                    let loading = req_inprogess_rs.get();
-                    view! {
-                        <Button
-                            class="pl-[70px] pr-[70px] w-48 h-12".to_string()
-                            text="Submit".to_string()
-                            on_click=on_submit.clone()
-                            loading
-                        />
-                    }
-                }}
+            {move || {
+                let loading = req_inprogess_rs.get();
+                view! {
+                    <Button
+                        class="self-end h-12 w-48"
+                        text="Submit"
+                        icon_class="ri-send-plane-line"
+                        on_click=on_submit.clone()
+                        loading
+                    />
+                }
+            }}
+            <p class="text-red-500">{move || error_message.get()}</p>
 
-            </div>
-            <div>
-                <p class="text-red-500">{move || error_message.get()}</p>
-            </div>
         </form>
     }
 }

--- a/crates/frontend/src/components/type_template_form.rs
+++ b/crates/frontend/src/components/type_template_form.rs
@@ -92,7 +92,7 @@ where
         });
     };
     view! {
-        <form class="form-control w-full space-y-4 bg-white text-gray-700 font-mono">
+        <form class="form-control w-full space-y-4 bg-white text-gray-700">
             <div class="form-control">
                 <label class="label">
                     <span class="label-text">Type Name</span>

--- a/crates/frontend/src/components/variant_form.rs
+++ b/crates/frontend/src/components/variant_form.rs
@@ -500,8 +500,8 @@ where
     HC: Fn(Vec<(String, VariantFormT)>) + 'static + Clone,
 {
     let variants_rws = RwSignal::new(variants);
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
 
     let combined_resource = create_blocking_resource(
         move || {
@@ -509,8 +509,8 @@ where
                 context.clone(),
                 context_data.clone(),
                 default_config.clone(),
-                tenant_rws.get_untracked().0,
-                org_rws.get_untracked().0,
+                workspace.get_untracked().0,
+                org.get_untracked().0,
             )
         },
         |(context, context_data, default_config, tenant, org_id)| async move {

--- a/crates/frontend/src/components/webhook_form.rs
+++ b/crates/frontend/src/components/webhook_form.rs
@@ -13,6 +13,7 @@ use crate::{
         button::Button,
         change_form::ChangeForm,
         dropdown::{Dropdown, DropdownBtnType, DropdownDirection},
+        form::label::Label,
         input::{Input, InputType, Toggle},
     },
     providers::{alert_provider::enqueue_alert, editor_provider::EditorProvider},
@@ -139,11 +140,12 @@ where
     let events_options = WebhookEvent::iter().collect::<Vec<WebhookEvent>>();
 
     view! {
-        <form class="form-control w-full space-y-4 bg-white text-gray-700">
+        <form class="w-full flex flex-col gap-5 bg-white text-gray-700">
             <div class="form-control">
-                <label class="label">
-                    <span class="label-text">Name</span>
-                </label>
+                <Label
+                    title="Webhook Name"
+                    description="The name of the webhook. It should be unique within the workspace."
+                />
                 <Input
                     disabled=edit
                     r#type=InputType::Text
@@ -161,41 +163,25 @@ where
                 title="Description".to_string()
                 placeholder="Enter a description".to_string()
                 value=description_rs.get_untracked()
-                on_change=Callback::new(move |new_description| {
-                    description_ws.set(new_description)
-                })
+                on_change=move |new_description| description_ws.set(new_description)
             />
             <ChangeForm
                 title="Reason for Change".to_string()
                 placeholder="Enter a reason for this change".to_string()
                 value=change_reason_rs.get_untracked()
-                on_change=Callback::new(move |new_change_reason| {
-                    change_reason_ws.set(new_change_reason)
-                })
+                on_change=move |new_change_reason| change_reason_ws.set(new_change_reason)
             />
-
-            <div class="form-control">
-                <label class="label">
-                    <span class="label-text">Enable Webhook</span>
-                </label>
+            <div class="w-fit flex items-center gap-2">
                 <Toggle
                     name="Enable Webhook"
                     value=enabled_rs.get()
-                    on_change=Callback::new(move |flag: serde_json::Value| {
-                        let flag = flag.as_bool().unwrap();
-                        if flag {
-                            enabled_ws.set(true);
-                        } else {
-                            enabled_ws.set(false);
-                        }
-                    })
+                    on_change=move |_| enabled_ws.update(|v| *v = !*v)
                 />
+                <Label title="Enable Webhook" />
             </div>
 
             <div class="form-control">
-                <label class="label">
-                    <span class="label-text">URL</span>
-                </label>
+                <Label title="URL" description="The URL to which the webhook will send requests." />
                 <Input
                     placeholder="Enter the webhook URL"
                     class="textarea textarea-bordered w-full max-w-md"
@@ -209,9 +195,10 @@ where
             </div>
 
             <div class="form-control">
-                <label class="label">
-                    <span class="label-text">Method</span>
-                </label>
+                <Label
+                    title="Method"
+                    description="HTTP method to be used for the webhook request."
+                />
                 <Dropdown
                     dropdown_width="w-100"
                     dropdown_icon="".to_string()
@@ -227,9 +214,7 @@ where
             </div>
 
             <div class="form-control">
-                <label class="label">
-                    <span class="label-text">Payload Version</span>
-                </label>
+                <Label title="Paylaod Version" />
                 <Dropdown
                     dropdown_width="w-100"
                     dropdown_icon="".to_string()
@@ -245,9 +230,10 @@ where
             </div>
 
             <div class="form-control">
-                <label class="label">
-                    <span class="label-text">Events</span>
-                </label>
+                <Label
+                    title="Events"
+                    description="Events for which this webhook will be triggered."
+                />
                 <Dropdown
                     dropdown_text="Add Events".to_string()
                     dropdown_direction=DropdownDirection::Down
@@ -261,9 +247,10 @@ where
             </div>
 
             <div class="form-control">
-                <label class="label">
-                    <span class="label-text">Custom Headers</span>
-                </label>
+                <Label
+                    title="Custom Headers"
+                    description="Custom headers are optional and can be used to pass additional information with the webhook request."
+                />
                 <EditorProvider>
                     <Input
                         id="custom_headers"
@@ -280,20 +267,18 @@ where
                 </EditorProvider>
             </div>
 
-            <div class="form-control grid w-full justify-start">
-                {move || {
-                    let loading = req_inprogess_rs.get();
-                    view! {
-                        <Button
-                            class="pl-[70px] pr-[70px] w-48 h-12".to_string()
-                            text="Submit".to_string()
-                            on_click=on_submit.clone()
-                            loading
-                        />
-                    }
-                }}
-
-            </div>
+            {move || {
+                let loading = req_inprogess_rs.get();
+                view! {
+                    <Button
+                        class="self-end h-12 w-48"
+                        text="Submit"
+                        icon_class="ri-send-plane-line"
+                        on_click=on_submit.clone()
+                        loading
+                    />
+                }
+            }}
 
         </form>
     }

--- a/crates/frontend/src/components/webhook_form.rs
+++ b/crates/frontend/src/components/webhook_form.rs
@@ -133,6 +133,11 @@ where
             }
         });
     };
+
+    let method_options = HttpMethod::iter().collect::<Vec<HttpMethod>>();
+    let payload_version_options = PayloadVersion::iter().collect::<Vec<PayloadVersion>>();
+    let events_options = WebhookEvent::iter().collect::<Vec<WebhookEvent>>();
+
     view! {
         <form class="form-control w-full space-y-4 bg-white text-gray-700">
             <div class="form-control">
@@ -213,7 +218,7 @@ where
                     dropdown_text=method_rs.get_untracked().to_string()
                     dropdown_direction=DropdownDirection::Down
                     dropdown_btn_type=DropdownBtnType::Select
-                    dropdown_options={HttpMethod::iter().collect::<Vec<HttpMethod>>()}
+                    dropdown_options=method_options
                     on_select=Callback::new(move |selected_item: HttpMethod| {
                         logging::log!("selected item {:?}", selected_item);
                         method_ws.set(selected_item);
@@ -231,7 +236,7 @@ where
                     dropdown_text=payload_version_rs.get().to_string()
                     dropdown_direction=DropdownDirection::Down
                     dropdown_btn_type=DropdownBtnType::Select
-                    dropdown_options={PayloadVersion::iter().collect::<Vec<PayloadVersion>>()}
+                    dropdown_options=payload_version_options
                     on_select=Callback::new(move |selected_item: PayloadVersion| {
                         logging::log!("selected item {:?}", selected_item);
                         payload_version_ws.set(selected_item);
@@ -247,7 +252,7 @@ where
                     dropdown_text="Add Events".to_string()
                     dropdown_direction=DropdownDirection::Down
                     dropdown_btn_type=DropdownBtnType::Select
-                    dropdown_options={WebhookEvent::iter().collect::<Vec<WebhookEvent>>()}
+                    dropdown_options=events_options
                     selected=events_rs.get()
                     multi_select=true
                     on_select=handle_select_webhook_event_dropdown_option
@@ -266,11 +271,11 @@ where
                         value=Value::Object((*custom_headers_rs.get_untracked()).clone())
                         schema_type=Single(JsonSchemaType::Object)
                         r#type=InputType::Monaco(vec![])
-                        on_change=Callback::new(move |value: Value| {
-                            if let Some(val)= value.as_object() {
+                        on_change=move |value: Value| {
+                            if let Some(val) = value.as_object() {
                                 custom_headers_ws.set(CustomHeaders::from(val.clone()));
                             }
-                        })
+                        }
                     />
                 </EditorProvider>
             </div>

--- a/crates/frontend/src/components/webhook_form.rs
+++ b/crates/frontend/src/components/webhook_form.rs
@@ -36,8 +36,8 @@ pub fn webhook_form<NF>(
 where
     NF: Fn() + 'static + Clone,
 {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
 
     let (webhook_name_rs, webhook_name_ws) = create_signal(webhook_name);
     let (description_rs, description_ws) = create_signal(description);
@@ -90,8 +90,8 @@ where
                         events,
                         description,
                         change_reason,
-                        tenant_rws.get().0,
-                        org_rws.get().0,
+                        workspace.get().0,
+                        org.get().0,
                     )
                     .await
                 } else {
@@ -105,8 +105,8 @@ where
                         custom_headers,
                         events,
                         change_reason,
-                        tenant_rws.get().0,
-                        org_rws.get().0,
+                        workspace.get().0,
+                        org.get().0,
                     )
                     .await
                 };

--- a/crates/frontend/src/components/webhook_form.rs
+++ b/crates/frontend/src/components/webhook_form.rs
@@ -134,7 +134,7 @@ where
         });
     };
     view! {
-        <form class="form-control w-full space-y-4 bg-white text-gray-700 font-mono">
+        <form class="form-control w-full space-y-4 bg-white text-gray-700">
             <div class="form-control">
                 <label class="label">
                     <span class="label-text">Name</span>

--- a/crates/frontend/src/components/workspace_form.rs
+++ b/crates/frontend/src/components/workspace_form.rs
@@ -22,7 +22,7 @@ use crate::{
 
 #[component]
 pub fn workspace_form(
-    org_id: RwSignal<OrganisationId>,
+    org_id: Signal<OrganisationId>,
     #[prop(default = false)] edit: bool,
     #[prop(default = String::new())] workspace_admin_email: String,
     #[prop(default = String::new())] workspace_name: String,

--- a/crates/frontend/src/components/workspace_form.rs
+++ b/crates/frontend/src/components/workspace_form.rs
@@ -107,7 +107,7 @@ pub fn workspace_form(
 
     view! {
         <EditorProvider>
-            <form class="flex flex-col gap-2 form-control w-full space-y-4 bg-white text-gray-700 font-mono">
+            <form class="flex flex-col gap-2 form-control w-full space-y-4 bg-white text-gray-700">
                 <div class="form-control">
                     <label class="label">
                         <span class="label-text">Workspace Name</span>

--- a/crates/frontend/src/logic.rs
+++ b/crates/frontend/src/logic.rs
@@ -189,7 +189,7 @@ impl From<&Expression> for Operator {
 
 impl From<&Condition> for Operator {
     fn from(value: &Condition) -> Self {
-        (&value.expression).into()
+        Self::from(&value.expression)
     }
 }
 
@@ -204,13 +204,21 @@ impl Operator {
         }
     }
 
-    pub fn to_condition_json_operator(self) -> String {
+    pub fn to_condition_json_operator(&self) -> String {
         match self {
-            Self::Has => "in".to_owned(),
-            Self::Is => "==".to_owned(),
-            Self::In => "in".to_owned(),
-            Self::Between => "<=".to_owned(),
+            Self::Has => "in",
+            Self::Is => "==",
+            Self::In => "in",
+            Self::Between => "<=",
             Self::Other(o) => o,
+        }
+        .to_owned()
+    }
+
+    pub fn strict_mode_display(&self) -> String {
+        match self {
+            Self::Is => self.to_condition_json_operator(),
+            _ => self.to_string(),
         }
     }
 }

--- a/crates/frontend/src/pages/compare_overrides.rs
+++ b/crates/frontend/src/pages/compare_overrides.rs
@@ -81,20 +81,20 @@ fn table_columns(contexts_vector_rws: RwSignal<Vec<String>>) -> Vec<Column> {
 
 #[component]
 pub fn compare_overrides() -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let (context_rs, context_ws) = create_signal::<Conditions>(Conditions::default());
     let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
     // this vector stores the list of contexts the user is comparing
     let contexts_vector_rws = create_rw_signal(vec!["default_config".to_string()]);
     let source = move || {
-        let tenant = tenant_rws.get().0;
-        let org_id = org_rws.get().0;
+        let tenant = workspace.get().0;
+        let org_id = org.get().0;
         let contexts = contexts_vector_rws.get();
         (tenant, org_id, contexts)
     };
     let dimension_resource = create_blocking_resource(
-        move || (tenant_rws.get().0, org_rws.get().0),
+        move || (workspace.get().0, org.get().0),
         |(tenant, org)| async {
             fetch_dimensions(&PaginationParams::all_entries(), tenant, org)
                 .await

--- a/crates/frontend/src/pages/compare_overrides.rs
+++ b/crates/frontend/src/pages/compare_overrides.rs
@@ -202,9 +202,9 @@ pub fn compare_overrides() -> impl IntoView {
                                     let loading = req_inprogess_rs.get();
                                     view! {
                                         <Button
-                                            id="resolve_btn".to_string()
-                                            text="Submit".to_string()
-                                            class="my-4".into()
+                                            id="resolve_btn"
+                                            text="Submit"
+                                            icon_class="ri-send-plane-line"
                                             on_click=move |_| {
                                                 req_inprogress_ws.set(true);
                                                 let query = context_rs.get().as_query_string();

--- a/crates/frontend/src/pages/compare_overrides.rs
+++ b/crates/frontend/src/pages/compare_overrides.rs
@@ -164,7 +164,7 @@ pub fn compare_overrides() -> impl IntoView {
                         <div class="card rounded-xl w-full bg-base-100 shadow">
                             <div class="card-body">
                                 <div class="flex justify-between">
-                                    <h2 class="card-title">Compare Overrides</h2>
+                                    <h2 class="card-title">"Compare Overrides"</h2>
                                     <DrawerBtn drawer_id="add_comparison_drawer"
                                         .to_string()>
                                         Add Comparison <i class="ri-edit-2-line ml-2"></i>

--- a/crates/frontend/src/pages/compare_overrides.rs
+++ b/crates/frontend/src/pages/compare_overrides.rs
@@ -57,7 +57,7 @@ fn table_columns(
                                         })
                                 })
                         }
-                    ></i>
+                    />
                     <ConditionCollapseProvider>
                         <ConditionComponent
                             conditions
@@ -159,14 +159,12 @@ pub fn compare_overrides() -> impl IntoView {
                     );
                     let dimensions = dimension_resource.get().unwrap_or_default();
                     let data = resolved_config_map.into_values().collect();
-                    let (empty_context_rs, empty_context_ws) = create_signal(Conditions::default());
                     view! {
                         <div class="card rounded-xl w-full bg-base-100 shadow">
                             <div class="card-body">
                                 <div class="flex justify-between">
                                     <h2 class="card-title">"Compare Overrides"</h2>
-                                    <DrawerBtn drawer_id="add_comparison_drawer"
-                                        .to_string()>
+                                    <DrawerBtn drawer_id="add_comparison_drawer">
                                         Add Comparison <i class="ri-edit-2-line ml-2"></i>
                                     </DrawerBtn>
                                 </div>
@@ -188,8 +186,7 @@ pub fn compare_overrides() -> impl IntoView {
                             <EditorProvider>
                                 <ContextForm
                                     dimensions=dimensions.data
-                                    context_rs=empty_context_rs
-                                    context_ws=empty_context_ws
+                                    context=Conditions::default()
                                     heading_sub_text="Compare to...".to_string()
                                     dropdown_direction=DropdownDirection::Right
                                     resolve_mode=true
@@ -197,7 +194,9 @@ pub fn compare_overrides() -> impl IntoView {
                                         context_ws.update(|value| *value = new_context)
                                     }
                                     fn_environment
+                                    on_context_change=move |_| ()
                                 />
+
                                 {move || {
                                     let loading = req_inprogess_rs.get();
                                     view! {

--- a/crates/frontend/src/pages/config_version.rs
+++ b/crates/frontend/src/pages/config_version.rs
@@ -8,14 +8,16 @@ use leptos_router::use_params_map;
 
 #[component]
 pub fn config_version() -> impl IntoView {
-    let tenant = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_id = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org_id = use_context::<Signal<OrganisationId>>().unwrap();
     let params = use_params_map();
     let version = params.with(|p| p.get("version").cloned());
 
     let config_resource = create_blocking_resource(
-        move || (tenant.get().0, version.clone(), org_id.get().0),
-        |(tenant, version, org_id)| async move { fetch_config(tenant, version, org_id).await },
+        move || (workspace.get().0, version.clone(), org_id.get().0),
+        |(workspace, version, org_id)| async move {
+            fetch_config(workspace, version, org_id).await
+        },
     );
 
     view! {

--- a/crates/frontend/src/pages/config_version_list.rs
+++ b/crates/frontend/src/pages/config_version_list.rs
@@ -21,8 +21,8 @@ use crate::{api::fetch_snapshots, components::table::types::default_column_forma
 
 #[component]
 pub fn config_version_list() -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
 
     let pagination_params_rws = use_signal_from_query(move |query_string| {
         Query::<PaginationParams>::extract_non_empty(&query_string).into_inner()
@@ -31,7 +31,7 @@ pub fn config_version_list() -> impl IntoView {
     use_param_updater(move || box_params!(pagination_params_rws.get()));
 
     let table_columns =
-        create_memo(move |_| snapshot_table_columns(tenant_rws.get().0, org_rws.get().0));
+        create_memo(move |_| snapshot_table_columns(workspace.get().0, org.get().0));
 
     let snapshots_resource: Resource<
         (String, PaginationParams, String),
@@ -39,9 +39,9 @@ pub fn config_version_list() -> impl IntoView {
     > = create_blocking_resource(
         move || {
             (
-                tenant_rws.get().0,
+                workspace.get().0,
                 pagination_params_rws.get(),
-                org_rws.get().0,
+                org.get().0,
             )
         },
         |(current_tenant, pagination_params, org_id)| async move {

--- a/crates/frontend/src/pages/config_version_list.rs
+++ b/crates/frontend/src/pages/config_version_list.rs
@@ -37,13 +37,7 @@ pub fn config_version_list() -> impl IntoView {
         (String, PaginationParams, String),
         PaginatedResponse<ConfigVersion>,
     > = create_blocking_resource(
-        move || {
-            (
-                workspace.get().0,
-                pagination_params_rws.get(),
-                org.get().0,
-            )
-        },
+        move || (workspace.get().0, pagination_params_rws.get(), org.get().0),
         |(current_tenant, pagination_params, org_id)| async move {
             fetch_snapshots(&pagination_params, current_tenant.to_string(), org_id)
                 .await
@@ -51,12 +45,8 @@ pub fn config_version_list() -> impl IntoView {
         },
     );
 
-    let handle_next_click = Callback::new(move |next_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(next_page));
-    });
-
-    let handle_prev_click = Callback::new(move |prev_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(prev_page));
+    let handle_page_change = Callback::new(move |page: i64| {
+        pagination_params_rws.update(|f| f.page = Some(page));
     });
 
     view! {
@@ -115,8 +105,7 @@ pub fn config_version_list() -> impl IntoView {
                                             count,
                                             current_page: page,
                                             total_pages,
-                                            on_next: handle_next_click,
-                                            on_prev: handle_prev_click,
+                                            on_page_change: handle_page_change,
                                         };
                                         view! {
                                             <Table

--- a/crates/frontend/src/pages/config_version_list.rs
+++ b/crates/frontend/src/pages/config_version_list.rs
@@ -71,7 +71,7 @@ pub fn config_version_list() -> impl IntoView {
                 <div class="card rounded-xl w-full bg-base-100 shadow">
                     <div class="card-body">
                         <div class="flex justify-between">
-                            <h2 class="card-title">Config Versions</h2>
+                            <h2 class="card-title">"Config Versions"</h2>
                         </div>
                         <div>
                             {move || {

--- a/crates/frontend/src/pages/config_version_list.rs
+++ b/crates/frontend/src/pages/config_version_list.rs
@@ -1,6 +1,5 @@
 use leptos::*;
 
-use chrono::DateTime;
 use leptos_router::A;
 use serde_json::{json, Map, Value};
 use superposition_macros::box_params;
@@ -146,9 +145,7 @@ pub fn snapshot_table_columns(tenant: String, org_id: String) -> Vec<Column> {
                     id
                 );
                 view! {
-                    <div class="w-24">
-                        <A href=href class="btn-link">{id}</A>
-                    </div>
+                    <A href=href class="btn-link">{id}</A>
                 }
                 .into_view()
             },
@@ -156,27 +153,9 @@ pub fn snapshot_table_columns(tenant: String, org_id: String) -> Vec<Column> {
             Expandable::Disabled,
             default_column_formatter,
         ),
-        Column::new(
-            "created_at".to_string(),
-            false,
-            |value: &str, _row: &Map<String, Value>| {
-                let formatted_date =
-                    match DateTime::parse_from_str(value, "%Y-%m-%dT%H:%M:%S%.f") {
-                        Ok(dt) => dt.format("%d-%b-%Y").to_string(),
-                        Err(_) => {
-                            logging::log!("Failed to parse date: {}", value);
-                            value.to_string()
-                        }
-                    };
-                view! { <span class="w-24">{formatted_date}</span> }.into_view()
-            },
-            ColumnSortable::No,
-            Expandable::Enabled(100),
-            default_column_formatter,
-        ),
-        Column::new(
+        Column::default_no_collapse("created_at".to_string()),
+        Column::default_with_cell_formatter(
             "tags".to_string(),
-            false,
             |_value: &str, row: &Map<String, Value>| {
                 let tags = row.get("tags").and_then(|v| v.as_array());
                 match tags {
@@ -192,9 +171,6 @@ pub fn snapshot_table_columns(tenant: String, org_id: String) -> Vec<Column> {
                 }
                 .into_view()
             },
-            ColumnSortable::No,
-            Expandable::Enabled(100),
-            default_column_formatter,
         ),
     ]
 }

--- a/crates/frontend/src/pages/context_override.rs
+++ b/crates/frontend/src/pages/context_override.rs
@@ -170,8 +170,8 @@ fn form(
             <ContextForm
                 dimensions=dimensions.get_value()
                 resolve_mode=workspace_settings.get_value().strict_mode
-                context_rs
-                context_ws
+                context=context_rs.get_untracked()
+                on_context_change=move |new_context| context_ws.set(new_context)
                 fn_environment
                 handle_change=move |new_context| context_ws.set(new_context)
                 disabled=edit_id.get_value().is_some()
@@ -606,17 +606,17 @@ pub fn context_override() -> impl IntoView {
                                         />
                                     </div>
                                     <DrawerBtn
-                                        drawer_id="context_filter_drawer".into()
+                                        drawer_id="context_filter_drawer"
                                         style=DrawerButtonStyle::Outline
-                                        class="self-end".to_string()
+                                        class="self-end"
                                     >
                                         "Filters"
                                         <i class="ri-filter-3-line"></i>
                                     </DrawerBtn>
                                 </div>
                                 <DrawerBtn
-                                    class="self-end h-fit".to_string()
-                                    drawer_id="context_and_override_drawer".to_string()
+                                    class="self-end h-fit"
+                                    drawer_id="context_and_override_drawer"
                                     on_click=on_create_context_click
                                 >
                                     "Create Override"

--- a/crates/frontend/src/pages/context_override.rs
+++ b/crates/frontend/src/pages/context_override.rs
@@ -513,13 +513,9 @@ pub fn context_override() -> impl IntoView {
         set_delete_modal.set(true);
     };
 
-    let handle_next_click = Callback::new(move |next_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(next_page));
-    });
-
-    let handle_prev_click = Callback::new(move |prev_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(prev_page));
-    });
+    let handle_page_change = move |page: i64| {
+        pagination_params_rws.update(|f| f.page = Some(page));
+    };
 
     let on_delete_confirm = Callback::new(move |_| {
         if let Some(id) = delete_id.get().clone() {
@@ -701,8 +697,7 @@ pub fn context_override() -> impl IntoView {
                                 .map(|d| d.contexts)
                                 .unwrap_or_default()
                                 .total_pages
-                            next=handle_next_click
-                            previous=handle_prev_click
+                            on_change=handle_page_change
                         />
                     }
                 }}

--- a/crates/frontend/src/pages/context_override.rs
+++ b/crates/frontend/src/pages/context_override.rs
@@ -166,62 +166,49 @@ fn form(
         });
     };
     view! {
-        <ContextForm
-            dimensions=dimensions.get_value()
-            resolve_mode=workspace_settings.get_value().strict_mode
-            context_rs
-            context_ws
-            fn_environment
-            handle_change=move |new_context| {
+        <div class="flex flex-col gap-5">
+            <ContextForm
+                dimensions=dimensions.get_value()
+                resolve_mode=workspace_settings.get_value().strict_mode
+                context_rs
                 context_ws
-                    .update(|value| {
-                        *value = new_context;
-                    });
-            }
+                fn_environment
+                handle_change=move |new_context| context_ws.set(new_context)
+                disabled=edit_id.get_value().is_some()
+            />
 
-            disabled=edit_id.get_value().is_some()
-        />
+            <ChangeForm
+                title="Description".to_string()
+                placeholder="Enter a description".to_string()
+                value=description_rs.get_untracked()
+                on_change=move |new_description| description_ws.set(new_description)
+            />
+            <ChangeForm
+                title="Reason for Change".to_string()
+                placeholder="Enter a reason for this change".to_string()
+                value=change_reason_rs.get_untracked()
+                on_change=move |new_change_reason| change_reason_ws.set(new_change_reason)
+            />
 
-        <ChangeForm
-            title="Description".to_string()
-            placeholder="Enter a description".to_string()
-            value=description_rs.get_untracked()
-            on_change=Callback::new(move |new_description| { description_ws.set(new_description) })
-        />
-        <ChangeForm
-            title="Reason for Change".to_string()
-            placeholder="Enter a reason for this change".to_string()
-            value=change_reason_rs.get_untracked()
-            on_change=Callback::new(move |new_change_reason| {
-                change_reason_ws.set(new_change_reason)
-            })
-        />
+            <OverrideForm
+                overrides=overrides_rs.get_untracked()
+                default_config=default_config
+                handle_change=move |new_overrides| overrides_ws.set(new_overrides)
+                fn_environment
+            />
 
-        <OverrideForm
-            overrides=overrides_rs.get_untracked()
-            default_config=default_config
-            handle_change=move |new_overrides| {
-                overrides_ws
-                    .update(|value| {
-                        *value = new_overrides;
-                    });
-            }
-            fn_environment
-        />
-
-        <div class="flex justify-start w-full mt-10">
             {move || {
                 let loading = req_inprogess_rs.get();
                 view! {
                     <Button
-                        class="pl-[70px] pr-[70px] w-48 h-12".to_string()
-                        text="Submit".to_string()
+                        class="self-end h-12 w-48"
+                        text="Submit"
+                        icon_class="ri-send-plane-line"
                         on_click=on_submit
                         loading
                     />
                 }
             }}
-
         </div>
     }
 }
@@ -584,7 +571,7 @@ pub fn context_override() -> impl IntoView {
                                 SortBy::Asc => "ri-sort-asc",
                             };
                             view! {
-                                <div class="flex gap-2">
+                                <div class="flex justify-end gap-2">
                                     <Stat
                                         heading="Overrides"
                                         icon="ri-guide-fill"

--- a/crates/frontend/src/pages/context_override.rs
+++ b/crates/frontend/src/pages/context_override.rs
@@ -571,13 +571,13 @@ pub fn context_override() -> impl IntoView {
                                 SortBy::Asc => "ri-sort-asc",
                             };
                             view! {
-                                <div class="flex justify-end gap-2">
+                                <div class="flex items-center gap-2">
                                     <Stat
                                         heading="Overrides"
                                         icon="ri-guide-fill"
                                         number=total_items
                                     />
-                                    <div class="w-max flex flex-col justify-end">
+                                    <div class="w-max flex flex-col justify-center">
                                         <Dropdown
                                             class="!w-fit !h-fit".to_string()
                                             dropdown_width="w-max".to_string()
@@ -608,7 +608,7 @@ pub fn context_override() -> impl IntoView {
                                     <DrawerBtn
                                         drawer_id="context_filter_drawer"
                                         style=DrawerButtonStyle::Outline
-                                        class="self-end"
+                                        class="!h-9 !min-h-[32px] !w-fit px-2"
                                     >
                                         "Filters"
                                         <i class="ri-filter-3-line"></i>

--- a/crates/frontend/src/pages/context_override/filter.rs
+++ b/crates/frontend/src/pages/context_override/filter.rs
@@ -18,6 +18,7 @@ use crate::{
         context_form::ContextForm,
         drawer::{close_drawer, Drawer},
         dropdown::DropdownDirection,
+        form::label::Label,
     },
     logic::{Condition, Conditions, Expression},
     providers::condition_collapse_provider::ConditionCollapseProvider,
@@ -171,7 +172,7 @@ pub fn context_filter_summary(
                                 )
                                 .unwrap_or_else(|_| "[]".to_string());
                             view! {
-                                <div class="flex gap-2">
+                                <div class="flex justify-end gap-2">
                                     <div class="min-w-fit pt-1 text-xs">{"Context"}</div>
                                     <ConditionCollapseProvider>
                                         <Condition
@@ -291,7 +292,7 @@ pub fn context_filter_drawer(
             drawer_width="w-[50vw]"
             handle_close=move || close_drawer("context_filter_drawer")
         >
-            <div class="flex flex-col gap-4">
+            <div class="flex flex-col gap-5">
                 <ContextForm
                     dimensions
                     context_rs
@@ -317,14 +318,11 @@ pub fn context_filter_drawer(
                         .to_string()
                 />
                 <div class="form-control">
-                    <label class="label flex-col justify-center items-start">
-                        <span class="label-text font-semibold text-base">
-                            {"Free text search inside overrides"}
-                        </span>
-                        <span class="label-text text-slate-400">
-                            {"Searches both keys as well as the values"}
-                        </span>
-                    </label>
+                    <Label
+                        title="Free text search inside overrides"
+                        info="(any of)"
+                        description="Searches both keys as well as the values"
+                    />
                     {move || {
                         view! {
                             <textarea
@@ -346,15 +344,11 @@ pub fn context_filter_drawer(
                     }}
                 </div>
                 <div class="form-control">
-                    <label class="label flex flex-col items-start justify-center">
-                        <div class="flex items-center gap-1 label-text font-semibold text-base">
-                            {"Created By"}
-                            <span class="text-sm font-normal text-slate-400">"(any of)"</span>
-                        </div>
-                        <span class="label-text text-slate-400">
-                            {"Separate each user by a comma"}
-                        </span>
-                    </label>
+                    <Label
+                        title="Created By"
+                        info="(any of)"
+                        description="Separate each ID by a comma"
+                    />
                     <input
                         type="text"
                         id="context-creator-filter"
@@ -374,15 +368,11 @@ pub fn context_filter_drawer(
                     />
                 </div>
                 <div class="form-control">
-                    <label class="label flex flex-col items-start justify-center">
-                        <div class="flex items-center gap-1 label-text font-semibold text-base">
-                            "Last Modified By"
-                            <span class="text-sm font-normal text-slate-400">"(any of)"</span>
-                        </div>
-                        <span class="label-text text-slate-400">
-                            "Separate each user by a comma"
-                        </span>
-                    </label>
+                    <Label
+                        title="Last Modified By"
+                        info="(any of)"
+                        description="Separate each ID by a comma"
+                    />
                     <input
                         type="text"
                         id="context-modifier-filter"
@@ -402,10 +392,11 @@ pub fn context_filter_drawer(
                         }
                     />
                 </div>
-                <div class="flex justify-end">
+                <div class="flex justify-end gap-2">
                     <Button
-                        class="h-12 w-48".to_string()
-                        text="Submit".to_string()
+                        class="h-12 w-48"
+                        text="Submit"
+                        icon_class="ri-send-plane-line"
                         on_click=move |event| {
                             event.prevent_default();
                             pagination_params_rws
@@ -418,9 +409,9 @@ pub fn context_filter_drawer(
                         }
                     />
                     <Button
-                        class="h-12 w-48".to_string()
-                        text="Reset".to_string()
-                        icon_class="ri-restart-line".into()
+                        class="h-12 w-48"
+                        text="Reset"
+                        icon_class="ri-restart-line"
                         on_click=move |event| {
                             event.prevent_default();
                             pagination_params_rws

--- a/crates/frontend/src/pages/context_override/filter.rs
+++ b/crates/frontend/src/pages/context_override/filter.rs
@@ -3,7 +3,7 @@ use std::{fmt::Display, ops::Deref, str::FromStr};
 use leptos::*;
 use serde_json::{json, Map, Value};
 use superposition_types::{
-    api::context::ContextListFilters,
+    api::{context::ContextListFilters, workspace::WorkspaceResponse},
     custom_query::{
         CommaSeparatedQParams, CommaSeparatedStringQParams, CustomQuery, DimensionQuery,
         PaginationParams, QueryMap,
@@ -80,6 +80,7 @@ pub fn context_filter_summary(
     dimension_params_rws: RwSignal<DimensionQuery<QueryMap>>,
     filter_node_ref: NodeRef<html::Div>,
 ) -> impl IntoView {
+    let workspace_settings = use_context::<StoredValue<WorkspaceResponse>>().unwrap();
     let force_open_rws = RwSignal::new(true);
     // let force_open_rws = RwSignal::new(scrolled_to_top.get_untracked());
 
@@ -178,6 +179,7 @@ pub fn context_filter_summary(
                                             id=condition_id
                                             grouped_view=false
                                             class="xl:w-[400px] h-fit"
+                                            strict_mode=workspace_settings.with_value(|w| w.strict_mode)
                                         />
                                     </ConditionCollapseProvider>
                                 </div>

--- a/crates/frontend/src/pages/context_override/filter.rs
+++ b/crates/frontend/src/pages/context_override/filter.rs
@@ -313,7 +313,7 @@ pub fn context_filter_drawer(
                         .to_string()
                 />
                 <div class="form-control">
-                    <label class="label">
+                    <label class="label flex-col justify-center items-start">
                         <span class="label-text font-semibold text-base">
                             {"Free text search inside overrides"}
                         </span>
@@ -404,9 +404,11 @@ pub fn context_filter_drawer(
                         text="Submit".to_string()
                         on_click=move |event| {
                             event.prevent_default();
-                            context_filters_rws.set(filters_buffer_rws.get());
-                            dimension_params_rws.set(dimension_buffer_rws.get());
-                            pagination_params_rws.update(|f| f.reset_page());
+                            pagination_params_rws.update(|f| {
+                                context_filters_rws.set_untracked(filters_buffer_rws.get());
+                                dimension_params_rws.set_untracked(dimension_buffer_rws.get());
+                                f.reset_page()
+                            });
                             close_drawer("context_filter_drawer")
                         }
                     />
@@ -416,9 +418,11 @@ pub fn context_filter_drawer(
                         icon_class="ri-restart-line".into()
                         on_click=move |event| {
                             event.prevent_default();
-                            context_filters_rws.set(ContextListFilters::default());
-                            dimension_params_rws.set(DimensionQuery::default());
-                            pagination_params_rws.update(|f| f.reset_page());
+                            pagination_params_rws.update(|f| {
+                                context_filters_rws.set_untracked(ContextListFilters::default());
+                                dimension_params_rws.set_untracked(DimensionQuery::default());
+                                f.reset_page()
+                        });
                             close_drawer("context_filter_drawer")
                         }
                     />

--- a/crates/frontend/src/pages/context_override/filter.rs
+++ b/crates/frontend/src/pages/context_override/filter.rs
@@ -113,14 +113,16 @@ pub fn context_filter_summary(
                 }
             >
                 <div
-                    class=format!("h-max max-w-[1000px] pt-1 px-0.5 border-[1.5px] border-solid border-purple-400 rounded-[10px] ease-in-out duration-300 tranisition-[width] cursor-pointer {}", if scrolled_to_top.get() { "shadow-md" } else { "" })
+                    class=format!(
+                        "h-max max-w-[1000px] pt-1 px-0.5 border-[1.5px] border-solid border-purple-400 rounded-[10px] ease-in-out duration-300 tranisition-[width] cursor-pointer {}",
+                        if scrolled_to_top.get() { "shadow-md" } else { "" },
+                    )
                     // on:click=move |_| force_open_rws.set(!summary_expanded.get())
                     on:click=move |_| {
                         if scrolled_to_top.get() {
                             force_open_rws.update(|f| *f = !*f);
                         }
                     }
-
                 >
                     <i class=move || {
                         format!(
@@ -404,11 +406,12 @@ pub fn context_filter_drawer(
                         text="Submit".to_string()
                         on_click=move |event| {
                             event.prevent_default();
-                            pagination_params_rws.update(|f| {
-                                context_filters_rws.set_untracked(filters_buffer_rws.get());
-                                dimension_params_rws.set_untracked(dimension_buffer_rws.get());
-                                f.reset_page()
-                            });
+                            pagination_params_rws
+                                .update(|f| {
+                                    context_filters_rws.set_untracked(filters_buffer_rws.get());
+                                    dimension_params_rws.set_untracked(dimension_buffer_rws.get());
+                                    f.reset_page()
+                                });
                             close_drawer("context_filter_drawer")
                         }
                     />
@@ -418,11 +421,13 @@ pub fn context_filter_drawer(
                         icon_class="ri-restart-line".into()
                         on_click=move |event| {
                             event.prevent_default();
-                            pagination_params_rws.update(|f| {
-                                context_filters_rws.set_untracked(ContextListFilters::default());
-                                dimension_params_rws.set_untracked(DimensionQuery::default());
-                                f.reset_page()
-                        });
+                            pagination_params_rws
+                                .update(|f| {
+                                    context_filters_rws
+                                        .set_untracked(ContextListFilters::default());
+                                    dimension_params_rws.set_untracked(DimensionQuery::default());
+                                    f.reset_page()
+                                });
                             close_drawer("context_filter_drawer")
                         }
                     />

--- a/crates/frontend/src/pages/context_override/filter.rs
+++ b/crates/frontend/src/pages/context_override/filter.rs
@@ -51,8 +51,8 @@ where
 
     view! {
         <div class="flex gap-2 items-center">
-            <div class="min-w-fit flex gap-[2px] text-xs">
-                {label} <span class="text-[10px] text-slate-400">{"(any of)"}</span>
+            <div class="min-w-fit flex items-center gap-[2px] text-xs">
+                {label} <span class="text-[10px] text-slate-400">"(any of)"</span>
             </div>
             <div class="flex gap-[2px] items-center flex-wrap">
                 {items
@@ -345,7 +345,7 @@ pub fn context_filter_drawer(
                 </div>
                 <div class="form-control">
                     <label class="label flex flex-col items-start justify-center">
-                        <div class="flex gap-1 label-text font-semibold text-base">
+                        <div class="flex items-center gap-1 label-text font-semibold text-base">
                             {"Created By"}
                             <span class="text-sm font-normal text-slate-400">"(any of)"</span>
                         </div>
@@ -373,12 +373,12 @@ pub fn context_filter_drawer(
                 </div>
                 <div class="form-control">
                     <label class="label flex flex-col items-start justify-center">
-                        <div class="flex gap-1 label-text font-semibold text-base">
-                            {"Last Modified By"}
+                        <div class="flex items-center gap-1 label-text font-semibold text-base">
+                            "Last Modified By"
                             <span class="text-sm font-normal text-slate-400">"(any of)"</span>
                         </div>
                         <span class="label-text text-slate-400">
-                            {"Separate each user by a comma"}
+                            "Separate each user by a comma"
                         </span>
                     </label>
                     <input

--- a/crates/frontend/src/pages/custom_types.rs
+++ b/crates/frontend/src/pages/custom_types.rs
@@ -235,13 +235,11 @@ pub fn types_page() -> impl IntoView {
                             <div class="card rounded-xl w-full bg-base-100 shadow">
                                 <div class="card-body">
                                     <div class="flex justify-between">
-                                        <h2 class="card-title">Type Templates</h2>
-                                        <div>
-                                            <DrawerBtn drawer_id=TYPE_DRAWER_ID
-                                                .to_string()>
-                                                Create Type <i class="ri-add-fill ml-2"></i>
-                                            </DrawerBtn>
-                                        </div>
+                                        <h2 class="card-title">"Type Templates"</h2>
+                                        <DrawerBtn drawer_id=TYPE_DRAWER_ID
+                                            .to_string()>
+                                            Create Type <i class="ri-add-fill ml-2"></i>
+                                        </DrawerBtn>
                                     </div>
                                     <Table
                                         rows=data

--- a/crates/frontend/src/pages/custom_types.rs
+++ b/crates/frontend/src/pages/custom_types.rs
@@ -115,9 +115,8 @@ pub fn types_page() -> impl IntoView {
             Column::default("created_by".to_string()),
             Column::default("created_at".to_string()),
             Column::default("last_modified_at".to_string()),
-            Column::new(
+            Column::default_with_cell_formatter(
                 "actions".into(),
-                false,
                 move |_: &str, row: &Map<String, Value>| {
                     let edit_row_json = json!(row);
                     let delete_row_json = edit_row_json.clone();
@@ -149,9 +148,6 @@ pub fn types_page() -> impl IntoView {
                     }
                     .into_view()
                 },
-                ColumnSortable::No,
-                Expandable::Enabled(100),
-                default_column_formatter,
             ),
         ]
     });

--- a/crates/frontend/src/pages/custom_types.rs
+++ b/crates/frontend/src/pages/custom_types.rs
@@ -236,8 +236,7 @@ pub fn types_page() -> impl IntoView {
                                 <div class="card-body">
                                     <div class="flex justify-between">
                                         <h2 class="card-title">"Type Templates"</h2>
-                                        <DrawerBtn drawer_id=TYPE_DRAWER_ID
-                                            .to_string()>
+                                        <DrawerBtn drawer_id=TYPE_DRAWER_ID>
                                             Create Type <i class="ri-add-fill ml-2"></i>
                                         </DrawerBtn>
                                     </div>

--- a/crates/frontend/src/pages/custom_types.rs
+++ b/crates/frontend/src/pages/custom_types.rs
@@ -33,10 +33,10 @@ const TYPE_DRAWER_ID: &str = "type_template_drawer";
 
 #[component]
 pub fn types_page() -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let types_resource = create_blocking_resource(
-        move || (tenant_rws.get().0, org_rws.get().0),
+        move || (workspace.get().0, org.get().0),
         |(t, org_id)| async move {
             fetch_types(&PaginationParams::default(), t, org_id)
                 .await
@@ -56,8 +56,8 @@ pub fn types_page() -> impl IntoView {
     let confirm_delete = Callback::new(move |_| {
         if let Some(row_data) = delete_row_rs.get().clone() {
             spawn_local(async move {
-                let tenant = tenant_rws.get().0;
-                let org = org_rws.get().0;
+                let tenant = workspace.get().0;
+                let org = org.get().0;
                 let api_response =
                     delete_type(tenant, row_data.clone().type_name, org).await;
                 match api_response {

--- a/crates/frontend/src/pages/default_config.rs
+++ b/crates/frontend/src/pages/default_config.rs
@@ -420,7 +420,7 @@ pub fn default_config() -> impl IntoView {
                                             />
                                         </label>
                                         <DrawerBtn
-                                            drawer_id="default_config_drawer".to_string()
+                                            drawer_id="default_config_drawer"
                                             on_click=Callback::new(move |_| {
                                                 drawer_type.set(DrawerType::Create);
                                                 open_drawer("default_config_drawer");
@@ -535,7 +535,7 @@ fn default_config_filter_widget(
     let filters = filters_rws.get_untracked();
     let filters_buffer_rws = create_rw_signal(filters.clone());
     view! {
-        <DrawerBtn drawer_id="default_config_filter_drawer".into() style=DrawerButtonStyle::Outline>
+        <DrawerBtn drawer_id="default_config_filter_drawer" style=DrawerButtonStyle::Outline>
             Filters
             <i class="ri-filter-3-line"></i>
         </DrawerBtn>

--- a/crates/frontend/src/pages/default_config.rs
+++ b/crates/frontend/src/pages/default_config.rs
@@ -130,12 +130,8 @@ pub fn default_config() -> impl IntoView {
         delete_modal_visible_ws.set(false);
     });
 
-    let handle_next_click = Callback::new(move |next_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(next_page));
-    });
-
-    let handle_prev_click = Callback::new(move |prev_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(prev_page));
+    let handle_page_change = Callback::new(move |page: i64| {
+        pagination_params_rws.update(|f| f.page = Some(page));
     });
 
     let redirect_url = move |prefix: Option<String>| -> String {
@@ -384,8 +380,7 @@ pub fn default_config() -> impl IntoView {
                         count: pagination_params.count.unwrap_or_default(),
                         current_page,
                         total_pages,
-                        on_next: handle_next_click,
-                        on_prev: handle_prev_click,
+                        on_page_change: handle_page_change,
                     };
                     view! {
                         <div class="pb-4">

--- a/crates/frontend/src/pages/default_config.rs
+++ b/crates/frontend/src/pages/default_config.rs
@@ -12,7 +12,6 @@ use superposition_types::{
 };
 use types::PageParams;
 
-use crate::api::{delete_default_config, fetch_default_config};
 use crate::components::{
     alert::AlertType,
     button::Button,
@@ -34,6 +33,10 @@ use crate::providers::alert_provider::enqueue_alert;
 use crate::query_updater::{use_param_updater, use_signal_from_query};
 use crate::types::{BreadCrums, OrganisationId, Tenant};
 use crate::utils::{unwrap_option_or_default_with_error, use_url_base};
+use crate::{
+    api::{delete_default_config, fetch_default_config},
+    components::form::label::Label,
+};
 
 #[derive(Clone, Debug, Default)]
 pub struct RowData {
@@ -547,11 +550,9 @@ fn default_config_filter_widget(
                 close_drawer("default_config_filter_drawer");
             }
         >
-            <div class="card-body">
-                <div class="form-control flex flex-col gap-9 justify-between">
-                    <label class="label">
-                        <span class="label-text">Configuration Name</span>
-                    </label>
+            <div class="flex flex-col gap-5">
+                <div class="form-control">
+                    <Label title="Configuration Name" />
                     <input
                         type="text"
                         id="default-config-name-filter"
@@ -574,10 +575,11 @@ fn default_config_filter_widget(
                         }
                     />
                 </div>
-                <div class="flex justify-start">
+                <div class="flex justify-end gap-2">
                     <Button
-                        class="h-12 w-48 px-[70px]".to_string()
-                        text="Submit".to_string()
+                        class="h-12 w-48"
+                        text="Submit"
+                        icon_class="ri-send-plane-line"
                         on_click=move |event| {
                             event.prevent_default();
                             let filter = filters_buffer_rws.get();
@@ -587,8 +589,8 @@ fn default_config_filter_widget(
                         }
                     />
                     <Button
-                        class="h-12 w-48 px-[70px]".to_string()
-                        text="Reset".to_string()
+                        class="h-12 w-48"
+                        text="Reset"
                         on_click=move |event| {
                             event.prevent_default();
                             let filters = DefaultConfigFilters::default();

--- a/crates/frontend/src/pages/default_config.rs
+++ b/crates/frontend/src/pages/default_config.rs
@@ -395,7 +395,7 @@ pub fn default_config() -> impl IntoView {
                         </div>
                         <div class="card rounded-lg w-full bg-base-100 shadow">
                             <div class="card-body">
-                                <div class="flex justify-between pb-2">
+                                <div class="flex justify-between">
                                     <BreadCrums bread_crums=bread_crums.get() redirect_url />
                                     <div class="flex">
                                         <label
@@ -464,20 +464,17 @@ pub fn bread_crums(
     #[prop(into)] redirect_url: Callback<Option<String>, String>,
 ) -> impl IntoView {
     view! {
-        <div class="flex justify-between pt-3">
+        <div class="flex justify-between items-center gap-2">
             {bread_crums
                 .iter()
                 .map(|ele| {
                     view! {
-                        <h2 class="flex after:content-['>'] after:mx-4 after:last:hidden">
+                        <h2 class="first:card-title flex gap-2 after:content-['>'] after:font-normal after:text-base after:last:hidden">
                             {if ele.is_link {
                                 let href = redirect_url.call(ele.value.clone());
                                 let label = ele.key.clone();
                                 view! {
-                                    <A
-                                        class="flex after:content-['>'] after:mx-4 after:last:hidden placeholder:cursor-pointer text-blue-500 underline underline-offset-2"
-                                        href
-                                    >
+                                    <A class="text-blue-500 underline underline-offset-2" href>
                                         {label}
                                     </A>
                                 }

--- a/crates/frontend/src/pages/default_config.rs
+++ b/crates/frontend/src/pages/default_config.rs
@@ -54,8 +54,8 @@ pub enum DrawerType {
 
 #[component]
 pub fn default_config() -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let (delete_modal_visible_rs, delete_modal_visible_ws) = create_signal(false);
     let (delete_key_rs, delete_key_ws) = create_signal::<Option<String>>(None);
     let filters_rws = use_signal_from_query(move |query_string| {
@@ -86,9 +86,9 @@ pub fn default_config() -> impl IntoView {
     let default_config_resource = create_blocking_resource(
         move || {
             (
-                tenant_rws.get().0,
+                workspace.get().0,
                 pagination_params_rws.get(),
-                org_rws.get().0,
+                org.get().0,
                 filters_rws.get(),
             )
         },
@@ -100,8 +100,8 @@ pub fn default_config() -> impl IntoView {
     );
 
     let confirm_delete = Callback::new(move |_| {
-        let tenant = tenant_rws.get().0;
-        let org = org_rws.get().0;
+        let tenant = workspace.get().0;
+        let org = org.get().0;
         let prefix = page_params_rws.with(|p| p.prefix.clone().unwrap_or_default());
         if let Some(key_name) = delete_key_rs.get() {
             spawn_local({
@@ -140,8 +140,8 @@ pub fn default_config() -> impl IntoView {
 
     let redirect_url = move |prefix: Option<String>| -> String {
         let base = use_url_base();
-        let tenant = tenant_rws.get_untracked().0;
-        let org_id = org_rws.get_untracked().0;
+        let tenant = workspace.get_untracked().0;
+        let org_id = org.get_untracked().0;
         let mut redirect_url = format!("{base}/admin/{org_id}/{tenant}/default-config");
         if let Some(prefix) = prefix {
             redirect_url = format!("{redirect_url}?prefix={prefix}");

--- a/crates/frontend/src/pages/default_config/filter.rs
+++ b/crates/frontend/src/pages/default_config/filter.rs
@@ -1,0 +1,167 @@
+use std::{fmt::Display, str::FromStr};
+
+use leptos::*;
+use superposition_types::{
+    api::default_config::DefaultConfigFilters,
+    custom_query::{CommaSeparatedQParams, PaginationParams},
+};
+
+use crate::components::{
+    badge::GrayPill,
+    button::Button,
+    drawer::{close_drawer, Drawer, DrawerBtn, DrawerButtonStyle},
+    form::label::Label,
+};
+
+#[component]
+pub(super) fn filter_summary(
+    filters_rws: RwSignal<DefaultConfigFilters>,
+) -> impl IntoView {
+    let force_open_rws = RwSignal::new(true);
+    // let force_open_rws = RwSignal::new(scrolled_to_top.get_untracked());
+
+    fn filter_index<T: Display + FromStr + Clone>(
+        items: &Option<CommaSeparatedQParams<T>>,
+        index: usize,
+    ) -> Option<CommaSeparatedQParams<T>> {
+        items.clone().and_then(|mut items| {
+            items.0.remove(index);
+            (!items.is_empty()).then_some(items)
+        })
+    }
+
+    view! {
+        <Show when=move || {
+            let filters_empty = filters_rws.with(|f| f.name.is_none());
+            !filters_empty
+        }>
+            <div class="flex gap-2">
+                <div
+                    class="h-max max-w-[1000px] pt-1 px-0.5 border-[1.5px] border-solid border-purple-400 rounded-[10px] cursor-pointer"
+                    on:click=move |_| force_open_rws.update(|f| *f = !*f)
+                >
+                    <i class=move || {
+                        format!(
+                            "{} ri-xl text-purple-800",
+                            if force_open_rws.get() {
+                                "ri-filter-2-fill"
+                            } else {
+                                "ri-filter-2-line"
+                            },
+                        )
+                    } />
+                    <i class=move || {
+                        format!(
+                            "{} ri-xl text-gray-500",
+                            if force_open_rws.get() {
+                                "ri-arrow-up-s-line"
+                            } else {
+                                "ri-arrow-down-s-line"
+                            },
+                        )
+                    } />
+
+                </div>
+                <div class=move || {
+                    format!(
+                        "{} flex flex-col gap-1 overflow-hidden",
+                        if force_open_rws.get() { "max-h-[1000px]" } else { "max-h-0" },
+                    )
+                }>
+                    {move || {
+                        filters_rws
+                            .with(|f| f.name.clone())
+                            .map(|name| {
+                                view! {
+                                    <div class="flex gap-2 items-center">
+                                        <span class="text-xs">"Prefix"</span>
+                                        <GrayPill
+                                            text=name
+                                            on_delete=move |_| {
+                                                filters_rws.update(|f| f.name = None);
+                                            }
+                                        />
+                                    </div>
+                                }
+                            })
+                    }}
+                </div>
+            </div>
+        </Show>
+    }
+}
+#[component]
+pub(super) fn default_config_filter_widget(
+    pagination_params_rws: RwSignal<PaginationParams>,
+    filters_rws: RwSignal<DefaultConfigFilters>,
+    #[prop(into)] prefix: Option<String>,
+) -> impl IntoView {
+    let filters = filters_rws.get_untracked();
+    let filters_buffer_rws = create_rw_signal(filters.clone());
+    view! {
+        <DrawerBtn
+            drawer_id="default_config_filter_drawer"
+            class="!h-9 !min-h-[32px] !w-fit px-2"
+            style=DrawerButtonStyle::Outline
+        >
+            Filters
+            <i class="ri-filter-3-line"></i>
+        </DrawerBtn>
+        <Drawer
+            id="default_config_filter_drawer".to_string()
+            header="Default Config Filters"
+            drawer_width="w-[50vw]"
+            handle_close=move || close_drawer("default_config_filter_drawer")
+        >
+            <div class="flex flex-col gap-5">
+                <div class="form-control">
+                    <Label title="Configuration Prefix" />
+                    <input
+                        type="text"
+                        id="default-config-name-filter"
+                        placeholder="eg: city"
+                        class="input input-bordered rounded-md resize-y w-full max-w-md"
+                        value=if prefix.is_some()
+                            && filters_buffer_rws.get_untracked().name.is_none()
+                        {
+                            prefix
+                        } else {
+                            filters_buffer_rws.get_untracked().name
+                        }
+                        on:change=move |event| {
+                            let key_name = event_target_value(&event);
+                            let key_name = if key_name.is_empty() { None } else { Some(key_name) };
+                            filters_buffer_rws.update(|f| f.name = key_name);
+                        }
+                    />
+                </div>
+                <div class="flex justify-end gap-2">
+                    <Button
+                        class="h-12 w-48"
+                        text="Submit"
+                        icon_class="ri-send-plane-line"
+                        on_click=move |event| {
+                            event.prevent_default();
+                            let filter = filters_buffer_rws.get();
+                            pagination_params_rws.update(|f| f.reset_page());
+                            filters_rws.set(filter);
+                            close_drawer("default_config_filter_drawer")
+                        }
+                    />
+                    <Button
+                        class="h-12 w-48"
+                        text="Reset"
+                        on_click=move |event| {
+                            event.prevent_default();
+                            let filters = DefaultConfigFilters::default();
+                            pagination_params_rws.update(|f| f.reset_page());
+                            filters_rws.set(filters);
+                            close_drawer("default_config_filter_drawer")
+                        }
+                    />
+
+                </div>
+            </div>
+        </Drawer>
+    }
+}

--- a/crates/frontend/src/pages/default_config/types.rs
+++ b/crates/frontend/src/pages/default_config/types.rs
@@ -1,0 +1,52 @@
+use std::fmt::{self, Display};
+
+use serde::{Deserialize, Deserializer};
+use superposition_derives::IsEmpty;
+use superposition_types::IsEmpty;
+
+#[derive(PartialEq, Clone, IsEmpty)]
+pub struct PageParams {
+    pub grouped: bool,
+    pub prefix: Option<String>,
+}
+
+impl Display for PageParams {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut parts = vec![];
+
+        parts.push(format!("grouped={}", self.grouped));
+
+        if let Some(ref prefix) = self.prefix {
+            parts.push(format!("prefix={}", prefix));
+        }
+
+        write!(f, "{}", parts.join("&"))
+    }
+}
+
+impl Default for PageParams {
+    fn default() -> Self {
+        Self {
+            grouped: true,
+            prefix: None,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for PageParams {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct PageParamsHelper {
+            pub grouped: Option<bool>,
+            pub prefix: Option<String>,
+        }
+        let helper = PageParamsHelper::deserialize(deserializer)?;
+        Ok(Self {
+            grouped: helper.prefix.is_some() || helper.grouped.unwrap_or(true),
+            prefix: helper.prefix,
+        })
+    }
+}

--- a/crates/frontend/src/pages/dimensions.rs
+++ b/crates/frontend/src/pages/dimensions.rs
@@ -193,13 +193,9 @@ pub fn dimensions() -> impl IntoView {
             Column::default("autocomplete_function_name".to_string()),
             Column::default("created_by".to_string()),
             Column::default("created_at".to_string()),
-            Column::new(
+            Column::default_with_cell_formatter(
                 "actions".to_string(),
-                false,
                 action_col_formatter,
-                ColumnSortable::No,
-                Expandable::Enabled(100),
-                default_column_formatter,
             ),
         ]
     });

--- a/crates/frontend/src/pages/dimensions.rs
+++ b/crates/frontend/src/pages/dimensions.rs
@@ -288,8 +288,7 @@ pub fn dimensions() -> impl IntoView {
                             <div class="card-body">
                                 <div class="flex justify-between">
                                     <h2 class="card-title">"Dimensions"</h2>
-                                    <DrawerBtn drawer_id="dimension_drawer"
-                                        .to_string()>
+                                    <DrawerBtn drawer_id="dimension_drawer">
                                         Create Dimension <i class="ri-edit-2-line ml-2"></i>
                                     </DrawerBtn>
                                 </div>

--- a/crates/frontend/src/pages/dimensions.rs
+++ b/crates/frontend/src/pages/dimensions.rs
@@ -36,8 +36,8 @@ pub struct RowData {
 
 #[component]
 pub fn dimensions() -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let (delete_modal_visible_rs, delete_modal_visible_ws) = create_signal(false);
     let (delete_id_rs, delete_id_ws) = create_signal::<Option<String>>(None);
     let pagination_params_rws = use_signal_from_query(move |query_string| {
@@ -49,9 +49,9 @@ pub fn dimensions() -> impl IntoView {
     let dimensions_resource = create_blocking_resource(
         move || {
             (
-                tenant_rws.get().0,
+                workspace.get().0,
                 pagination_params_rws.get(),
-                org_rws.get().0,
+                org.get().0,
             )
         },
         |(current_tenant, pagination_params, org_id)| async move {
@@ -65,7 +65,7 @@ pub fn dimensions() -> impl IntoView {
         if let Some(id) = delete_id_rs.get().clone() {
             spawn_local(async move {
                 let result =
-                    delete_dimension(id, tenant_rws.get().0, org_rws.get().0).await;
+                    delete_dimension(id, workspace.get().0, org.get().0).await;
 
                 match result {
                     Ok(_) => {

--- a/crates/frontend/src/pages/dimensions.rs
+++ b/crates/frontend/src/pages/dimensions.rs
@@ -301,7 +301,7 @@ pub fn dimensions() -> impl IntoView {
                         <div class="card rounded-xl w-full bg-base-100 shadow">
                             <div class="card-body">
                                 <div class="flex justify-between">
-                                    <h2 class="card-title chat-bubble text-gray-800 dark:text-white bg-white font-mono">
+                                    <h2 class="card-title chat-bubble text-gray-800 dark:text-white bg-white">
                                         "Dimensions"
                                     </h2>
                                     <DrawerBtn drawer_id="dimension_drawer"

--- a/crates/frontend/src/pages/dimensions.rs
+++ b/crates/frontend/src/pages/dimensions.rs
@@ -287,9 +287,7 @@ pub fn dimensions() -> impl IntoView {
                         <div class="card rounded-xl w-full bg-base-100 shadow">
                             <div class="card-body">
                                 <div class="flex justify-between">
-                                    <h2 class="card-title chat-bubble text-gray-800 dark:text-white bg-white">
-                                        "Dimensions"
-                                    </h2>
+                                    <h2 class="card-title">"Dimensions"</h2>
                                     <DrawerBtn drawer_id="dimension_drawer"
                                         .to_string()>
                                         Create Dimension <i class="ri-edit-2-line ml-2"></i>

--- a/crates/frontend/src/pages/dimensions.rs
+++ b/crates/frontend/src/pages/dimensions.rs
@@ -239,8 +239,10 @@ pub fn dimensions() -> impl IntoView {
                                     dimension_name=selected_dimension_data.dimension
                                     dimension_schema=selected_dimension_data.schema
                                     dependencies=selected_dimension_data.dependencies
-                                    validation_function_name=selected_dimension_data.validation_function_name
-                                    autocomplete_function_name=selected_dimension_data.autocomplete_function_name
+                                    validation_function_name=selected_dimension_data
+                                        .validation_function_name
+                                    autocomplete_function_name=selected_dimension_data
+                                        .autocomplete_function_name
                                     dimensions
                                     handle_submit=move || {
                                         dimensions_resource.refetch();

--- a/crates/frontend/src/pages/dimensions.rs
+++ b/crates/frontend/src/pages/dimensions.rs
@@ -47,13 +47,7 @@ pub fn dimensions() -> impl IntoView {
     use_param_updater(move || box_params!(pagination_params_rws.get()));
 
     let dimensions_resource = create_blocking_resource(
-        move || {
-            (
-                workspace.get().0,
-                pagination_params_rws.get(),
-                org.get().0,
-            )
-        },
+        move || (workspace.get().0, pagination_params_rws.get(), org.get().0),
         |(current_tenant, pagination_params, org_id)| async move {
             fetch_dimensions(&pagination_params, current_tenant, org_id)
                 .await
@@ -64,8 +58,7 @@ pub fn dimensions() -> impl IntoView {
     let confirm_delete = Callback::new(move |_| {
         if let Some(id) = delete_id_rs.get().clone() {
             spawn_local(async move {
-                let result =
-                    delete_dimension(id, workspace.get().0, org.get().0).await;
+                let result = delete_dimension(id, workspace.get().0, org.get().0).await;
 
                 match result {
                     Ok(_) => {
@@ -81,12 +74,8 @@ pub fn dimensions() -> impl IntoView {
         delete_id_ws.set(None);
         delete_modal_visible_ws.set(false);
     });
-    let handle_next_click = Callback::new(move |next_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(next_page));
-    });
-
-    let handle_prev_click = Callback::new(move |prev_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(prev_page));
+    let handle_page_change = Callback::new(move |page: i64| {
+        pagination_params_rws.update(|f| f.page = Some(page));
     });
 
     let selected_dimension = create_rw_signal::<Option<RowData>>(None);
@@ -293,8 +282,7 @@ pub fn dimensions() -> impl IntoView {
                         count: pagination_params.count.unwrap_or_default(),
                         current_page: pagination_params.page.unwrap_or_default(),
                         total_pages: value.total_pages,
-                        on_next: handle_next_click,
-                        on_prev: handle_prev_click,
+                        on_page_change: handle_page_change,
                     };
                     view! {
                         <div class="pb-4">

--- a/crates/frontend/src/pages/experiment.rs
+++ b/crates/frontend/src/pages/experiment.rs
@@ -46,11 +46,11 @@ pub enum PopupType {
 #[component]
 pub fn experiment_page() -> impl IntoView {
     let exp_params = use_params_map();
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let source = move || {
-        let t = tenant_rws.get().0;
-        let org = org_rws.get().0;
+        let t = workspace.get().0;
+        let org = org.get().0;
         let exp_id =
             exp_params.with(|params| params.get("id").cloned().unwrap_or("1".into()));
         (exp_id, t, org)

--- a/crates/frontend/src/pages/experiment_group_listing.rs
+++ b/crates/frontend/src/pages/experiment_group_listing.rs
@@ -171,9 +171,8 @@ fn table_columns(
             Expandable::Disabled,
             default_column_formatter,
         ),
-        Column::new(
+        Column::default_with_cell_formatter(
             "traffic_percentage".to_string(),
-            false,
             |value: &str, _| {
                 let percentage = format!("{}%", value);
                 view! {
@@ -183,9 +182,6 @@ fn table_columns(
                 }
                 .into_view()
             },
-            ColumnSortable::No,
-            Expandable::Disabled,
-            default_column_formatter,
         ),
         Column::default_with_sort(
             "last_modified_at".to_string(),

--- a/crates/frontend/src/pages/experiment_group_listing.rs
+++ b/crates/frontend/src/pages/experiment_group_listing.rs
@@ -601,9 +601,7 @@ pub fn experiment_group_listing() -> impl IntoView {
                         spawn_local(async move {
                             let tenant = tenant_rws.get().0;
                             let org_id = org_rws.get().0;
-                            if let Err(e) = delete(&group_id, &tenant, &org_id)
-                                .await
-                            {
+                            if let Err(e) = delete(&group_id, &tenant, &org_id).await {
                                 logging::error!("Failed to delete experiment group: {}", e);
                                 enqueue_alert(
                                     format!(

--- a/crates/frontend/src/pages/experiment_group_listing.rs
+++ b/crates/frontend/src/pages/experiment_group_listing.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
 use superposition_macros::box_params;
 use superposition_types::{
-    api::experiment_groups::{ExpGroupFilters, SortOn},
+    api::{
+        experiment_groups::{ExpGroupFilters, SortOn},
+        workspace::WorkspaceResponse,
+    },
     custom_query::{CustomQuery, PaginationParams, Query},
     database::{models::experimentation::ExperimentGroup, types::DimensionWithMandatory},
     PaginatedResponse,
@@ -67,6 +70,7 @@ fn table_columns(
     selected_group_rws: RwSignal<Option<RowData>>,
     filters_rws: RwSignal<ExpGroupFilters>,
 ) -> Vec<Column> {
+    let workspace_settings = use_context::<StoredValue<WorkspaceResponse>>().unwrap();
     let current_filters = filters_rws.get();
     let current_sort_on = current_filters.sort_on.unwrap_or_default();
     let current_sort_by = current_filters.sort_by.unwrap_or_default();
@@ -158,7 +162,7 @@ fn table_columns(
                     Conditions::from_context_json(&context).unwrap_or_default();
 
                 view! {
-                    <ConditionComponent conditions grouped_view=false id class="w-[300px]" />
+                    <ConditionComponent conditions grouped_view=false id class="w-[300px]" strict_mode=workspace_settings.with_value(|w| w.strict_mode)  />
                 }
                 .into_view()
             },

--- a/crates/frontend/src/pages/experiment_group_listing.rs
+++ b/crates/frontend/src/pages/experiment_group_listing.rs
@@ -392,8 +392,8 @@ fn experiment_group_filter_widget(
 
 #[component]
 pub fn experiment_group_listing() -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
 
     let filters_rws = use_signal_from_query(move |query_string| {
         Query::<ExpGroupFilters>::extract_non_empty(&query_string).into_inner()
@@ -414,8 +414,8 @@ pub fn experiment_group_listing() -> impl IntoView {
         (
             filters_rws.get(),
             pagination_params_rws.get(),
-            tenant_rws.get().0,
-            org_rws.get().0,
+            workspace.get().0,
+            org.get().0,
         )
     };
 
@@ -599,8 +599,8 @@ pub fn experiment_group_listing() -> impl IntoView {
                             return;
                         }
                         spawn_local(async move {
-                            let tenant = tenant_rws.get().0;
-                            let org_id = org_rws.get().0;
+                            let tenant = workspace.get().0;
+                            let org_id = org.get().0;
                             if let Err(e) = delete(&group_id, &tenant, &org_id).await {
                                 logging::error!("Failed to delete experiment group: {}", e);
                                 enqueue_alert(

--- a/crates/frontend/src/pages/experiment_group_listing.rs
+++ b/crates/frontend/src/pages/experiment_group_listing.rs
@@ -480,13 +480,11 @@ pub fn experiment_group_listing() -> impl IntoView {
                 <div class="card rounded-xl w-full bg-base-100 shadow">
                     <div class="card-body">
                         <div class="flex justify-between">
-                            <h2 class="card-title">Experiment Groups</h2>
-                            <div>
-                                <DrawerBtn drawer_id="create_exp_group_drawer"
-                                    .to_string()>
-                                    Create Group <i class="ri-edit-2-line ml-2"></i>
-                                </DrawerBtn>
-                            </div>
+                            <h2 class="card-title">"Experiment Groups"</h2>
+                            <DrawerBtn drawer_id="create_exp_group_drawer"
+                                .to_string()>
+                                Create Group <i class="ri-edit-2-line ml-2"></i>
+                            </DrawerBtn>
                         </div>
                         {move || {
                             let value = experiment_groups_resource.get();

--- a/crates/frontend/src/pages/experiment_group_listing.rs
+++ b/crates/frontend/src/pages/experiment_group_listing.rs
@@ -448,12 +448,8 @@ pub fn experiment_group_listing() -> impl IntoView {
         close_drawer("create_exp_group_drawer");
     });
 
-    let handle_next_click = Callback::new(move |next_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(next_page));
-    });
-
-    let handle_prev_click = Callback::new(move |prev_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(prev_page));
+    let handle_page_change = Callback::new(move |page: i64| {
+        pagination_params_rws.update(|f| f.page = Some(page));
     });
 
     view! {
@@ -527,8 +523,7 @@ pub fn experiment_group_listing() -> impl IntoView {
                                         count: pagination_params.count.unwrap_or_default(),
                                         current_page: pagination_params.page.unwrap_or_default(),
                                         total_pages: v.experiment_groups.total_pages,
-                                        on_next: handle_next_click,
-                                        on_prev: handle_prev_click,
+                                        on_page_change: handle_page_change,
                                     };
                                     view! {
                                         <ConditionCollapseProvider>

--- a/crates/frontend/src/pages/experiment_group_listing.rs
+++ b/crates/frontend/src/pages/experiment_group_listing.rs
@@ -281,10 +281,7 @@ fn experiment_group_filter_widget(
     let filters_buffer_rws = create_rw_signal(filters.clone());
 
     view! {
-        <DrawerBtn
-            drawer_id="experiment_group_filter_drawer".into()
-            style=DrawerButtonStyle::Outline
-        >
+        <DrawerBtn drawer_id="experiment_group_filter_drawer" style=DrawerButtonStyle::Outline>
             Filters
             <i class="ri-filter-3-line"></i>
         </DrawerBtn>

--- a/crates/frontend/src/pages/experiment_group_listing.rs
+++ b/crates/frontend/src/pages/experiment_group_listing.rs
@@ -29,6 +29,7 @@ use crate::{
         description_icon::InfoDescription,
         drawer::{close_drawer, open_drawer, Drawer, DrawerBtn, DrawerButtonStyle},
         experiment_group_form::ExperimentGroupForm,
+        form::label::Label,
         skeleton::Skeleton,
         stat::Stat,
         table::{
@@ -277,6 +278,7 @@ fn table_columns(
 
 #[component]
 fn experiment_group_filter_widget(
+    pagination_params_rws: RwSignal<PaginationParams>,
     filters_rws: RwSignal<ExpGroupFilters>,
 ) -> impl IntoView {
     let filters = filters_rws.get_untracked();
@@ -296,12 +298,10 @@ fn experiment_group_filter_widget(
             drawer_width="w-[50vw]"
             handle_close=move || close_drawer("experiment_group_filter_drawer")
         >
-            <div class="card-body">
+            <div class="flex flex-col gap-5">
                 <div class="flex flex-col gap-5 justify-between">
                     <div class="form-control">
-                        <label class="label">
-                            <span class="label-text">Experiment Group Name</span>
-                        </label>
+                        <Label title="Experiment Group Name" />
                         <input
                             type="text"
                             id="experiment-group-name-filter"
@@ -320,9 +320,7 @@ fn experiment_group_filter_widget(
                         />
                     </div>
                     <div class="form-control">
-                        <label class="label">
-                            <span class="label-text">Created By</span>
-                        </label>
+                        <Label title="Created By" />
                         <input
                             type="text"
                             id="experiment-group-created-by-filter"
@@ -341,9 +339,7 @@ fn experiment_group_filter_widget(
                         />
                     </div>
                     <div class="form-control">
-                        <label class="label">
-                            <span class="label-text">Last Modified By</span>
-                        </label>
+                        <Label title="Last Modified By" />
                         <input
                             type="text"
                             id="experiment-last-modified-filter"
@@ -364,27 +360,35 @@ fn experiment_group_filter_widget(
 
                     </div>
                 </div>
-                <div class="flex justify-start mt-8">
+                <div class="flex justify-end gap-2">
                     <Button
-                        class="w-48 px-[70px] h-12".to_string()
-                        text="Sumit".to_string()
+                        class="h-12 w-48"
+                        text="Submit"
+                        icon_class="ri-send-plane-line"
                         on_click=move |event| {
                             event.prevent_default();
                             let filter = filters_buffer_rws.get();
-                            logging::log!("Submitting filters: {:?}", filter);
-                            filters_rws.set(filter);
+                            pagination_params_rws
+                                .update(|f| {
+                                    filters_rws.set_untracked(filter);
+                                    f.reset_page()
+                                });
                             close_drawer("experiment_group_filter_drawer")
                         }
                     />
                     <Button
-                        class="px-[70px] h-12 w-48".to_string()
-                        text="Reset".to_string()
-                        icon_class="ri-restart-line".into()
+                        class="h-12 w-48"
+                        text="Reset"
+                        icon_class="ri-restart-line"
                         on_click=move |event| {
                             event.prevent_default();
                             let filters = ExpGroupFilters::default();
                             filters_buffer_rws.set(filters.clone());
-                            filters_rws.set(filters);
+                            pagination_params_rws
+                                .update(|f| {
+                                    filters_rws.set_untracked(filters);
+                                    f.reset_page()
+                                });
                             close_drawer("experiment_group_filter_drawer")
                         }
                     />
@@ -531,7 +535,10 @@ pub fn experiment_group_listing() -> impl IntoView {
                                     };
                                     view! {
                                         <ConditionCollapseProvider>
-                                            <ExperimentGroupFilterWidget filters_rws />
+                                            <ExperimentGroupFilterWidget
+                                                filters_rws
+                                                pagination_params_rws
+                                            />
                                             <Table
                                                 rows=data
                                                 key_column="name".to_string()

--- a/crates/frontend/src/pages/experiment_group_listing/filter.rs
+++ b/crates/frontend/src/pages/experiment_group_listing/filter.rs
@@ -1,0 +1,239 @@
+use std::{fmt::Display, str::FromStr};
+
+use leptos::*;
+use superposition_types::{
+    api::experiment_groups::ExpGroupFilters,
+    custom_query::{CommaSeparatedQParams, PaginationParams},
+};
+
+use crate::components::{
+    badge::GrayPill,
+    button::Button,
+    drawer::{close_drawer, Drawer, DrawerBtn, DrawerButtonStyle},
+    form::label::Label,
+};
+
+#[component]
+pub(super) fn filter_summary(filters_rws: RwSignal<ExpGroupFilters>) -> impl IntoView {
+    let force_open_rws = RwSignal::new(true);
+    // let force_open_rws = RwSignal::new(scrolled_to_top.get_untracked());
+
+    fn filter_index<T: Display + FromStr + Clone>(
+        items: &Option<CommaSeparatedQParams<T>>,
+        index: usize,
+    ) -> Option<CommaSeparatedQParams<T>> {
+        items.clone().and_then(|mut items| {
+            items.0.remove(index);
+            (!items.is_empty()).then_some(items)
+        })
+    }
+
+    view! {
+        <Show when=move || {
+            let filters_empty = filters_rws
+                .with(|f| {
+                    f.created_by.is_none() && f.name.is_none() && f.last_modified_by.is_none()
+                });
+            !filters_empty
+        }>
+            <div class="flex gap-2">
+                <div
+                    class="h-max max-w-[1000px] pt-1 px-0.5 border-[1.5px] border-solid border-purple-400 rounded-[10px] cursor-pointer"
+                    on:click=move |_| force_open_rws.update(|f| *f = !*f)
+                >
+                    <i class=move || {
+                        format!(
+                            "{} ri-xl text-purple-800",
+                            if force_open_rws.get() {
+                                "ri-filter-2-fill"
+                            } else {
+                                "ri-filter-2-line"
+                            },
+                        )
+                    } />
+                    <i class=move || {
+                        format!(
+                            "{} ri-xl text-gray-500",
+                            if force_open_rws.get() {
+                                "ri-arrow-up-s-line"
+                            } else {
+                                "ri-arrow-down-s-line"
+                            },
+                        )
+                    } />
+
+                </div>
+                <div class=move || {
+                    format!(
+                        "{} flex flex-col gap-1 overflow-hidden",
+                        if force_open_rws.get() { "max-h-[1000px]" } else { "max-h-0" },
+                    )
+                }>
+                    {move || {
+                        filters_rws
+                            .with(|f| f.name.clone())
+                            .map(|name| {
+                                view! {
+                                    <div class="flex gap-2 items-center">
+                                        <span class="text-xs">"Name"</span>
+                                        <GrayPill
+                                            text=name
+                                            on_delete=move |_| {
+                                                filters_rws.update(|f| f.name = None);
+                                            }
+                                        />
+                                    </div>
+                                }
+                            })
+                    }}
+                    {move || {
+                        filters_rws
+                            .with(|f| f.created_by.clone())
+                            .map(|created_by| {
+                                view! {
+                                    <div class="flex gap-2 items-center">
+                                        <span class="text-xs">"Created By"</span>
+                                        <GrayPill
+                                            text=created_by
+                                            on_delete=move |_| {
+                                                filters_rws.update(|f| f.created_by = None);
+                                            }
+                                        />
+                                    </div>
+                                }
+                            })
+                    }}
+                    {move || {
+                        filters_rws
+                            .with(|f| f.last_modified_by.clone())
+                            .map(|last_modified_by| {
+                                view! {
+                                    <div class="flex gap-2 items-center">
+                                        <span class="text-xs">"Last Modified By"</span>
+                                        <GrayPill
+                                            text=last_modified_by
+                                            on_delete=move |_| {
+                                                filters_rws.update(|f| f.last_modified_by = None);
+                                            }
+                                        />
+                                    </div>
+                                }
+                            })
+                    }}
+                </div>
+            </div>
+        </Show>
+    }
+}
+
+#[component]
+pub(super) fn experiment_group_filter_widget(
+    pagination_params_rws: RwSignal<PaginationParams>,
+    filters_rws: RwSignal<ExpGroupFilters>,
+) -> impl IntoView {
+    let filters_buffer_rws = RwSignal::new(filters_rws.get_untracked());
+
+    view! {
+        <DrawerBtn
+            drawer_id="experiment_group_filter_drawer"
+            class="!h-9 !min-h-[32px] !w-fit px-2"
+            style=DrawerButtonStyle::Outline
+        >
+            Filters
+            <i class="ri-filter-3-line"></i>
+        </DrawerBtn>
+        <Drawer
+            id="experiment_group_filter_drawer".to_string()
+            header="Experiment Group Filters"
+            drawer_width="w-[50vw]"
+            handle_close=move || close_drawer("experiment_group_filter_drawer")
+        >
+            <div class="flex flex-col gap-5">
+                <div class="form-control">
+                    <Label title="Experiment Group Name" />
+                    <input
+                        type="text"
+                        id="experiment-group-name-filter"
+                        placeholder="eg: city experiment group"
+                        class="input input-bordered rounded-md resize-y w-full max-w-md"
+                        value=move || filters_buffer_rws.with(|f| f.name.clone())
+                        on:change=move |event| {
+                            let name = event_target_value(&event);
+                            let group_name = if name.trim().is_empty() { None } else { Some(name) };
+                            filters_buffer_rws.update(|f| f.name = group_name);
+                        }
+                    />
+                </div>
+                <div class="form-control">
+                    <Label title="Created By" />
+                    <input
+                        type="text"
+                        id="experiment-group-created-by-filter"
+                        class="input input-bordered rounded-md resize-y w-full max-w-md"
+                        value=move || filters_buffer_rws.with(|f| f.created_by.clone())
+                        placeholder="eg: user@superposition.io"
+                        on:change=move |event| {
+                            let created_by = event_target_value(&event);
+                            let created_by = if created_by.trim().is_empty() {
+                                None
+                            } else {
+                                Some(created_by)
+                            };
+                            filters_buffer_rws.update(|filter| filter.created_by = created_by);
+                        }
+                    />
+                </div>
+                <div class="form-control">
+                    <Label title="Last Modified By" />
+                    <input
+                        type="text"
+                        id="experiment-last-modified-filter"
+                        class="input input-bordered rounded-md resize-y w-full max-w-md"
+                        placeholder="eg: user@superposition.io"
+                        value=move || filters_buffer_rws.with(|f| f.last_modified_by.clone())
+                        on:change=move |event| {
+                            let last_modified = event_target_value(&event);
+                            let last_modified_by = if last_modified.trim().is_empty() {
+                                None
+                            } else {
+                                Some(last_modified)
+                            };
+                            filters_buffer_rws
+                                .update(|filter| filter.last_modified_by = last_modified_by);
+                        }
+                    />
+                </div>
+                <div class="flex justify-end gap-2">
+                    <Button
+                        class="h-12 w-48"
+                        text="Submit"
+                        icon_class="ri-send-plane-line"
+                        on_click=move |event| {
+                            event.prevent_default();
+                            let filter = filters_buffer_rws.get();
+                            close_drawer("experiment_group_filter_drawer");
+                            batch(|| {
+                                pagination_params_rws.update(|f| f.reset_page());
+                                filters_rws.set(filter);
+                            });
+                        }
+                    />
+                    <Button
+                        class="h-12 w-48"
+                        text="Reset"
+                        icon_class="ri-restart-line"
+                        on_click=move |event| {
+                            close_drawer("experiment_group_filter_drawer");
+                            event.prevent_default();
+                            batch(|| {
+                                filters_rws.set(ExpGroupFilters::default());
+                                pagination_params_rws.update(|f| f.reset_page());
+                                filters_buffer_rws.set(ExpGroupFilters::default());
+                            });
+                        }
+                    />
+                </div>
+            </div>
+        </Drawer>
+    }
+}

--- a/crates/frontend/src/pages/experiment_groups.rs
+++ b/crates/frontend/src/pages/experiment_groups.rs
@@ -180,15 +180,15 @@ fn experiment_group_info(group: StoredValue<ExperimentGroup>) -> impl IntoView {
 #[component]
 pub fn experiment_groups() -> impl IntoView {
     let group_params = use_params_map();
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
 
     let (delete_modal_rs, delete_modal_ws) = create_signal(false);
     let delete_group_rws = create_rw_signal(RemoveRequest::default());
 
     let source = move || {
-        let tenant_id = tenant_rws.get().0;
-        let org_id = org_rws.get().0;
+        let tenant_id = workspace.get().0;
+        let org_id = org.get().0;
         let group_id =
             group_params.with(|params| params.get("id").cloned().unwrap_or("1".into()));
         (group_id, tenant_id, org_id)
@@ -221,8 +221,8 @@ pub fn experiment_groups() -> impl IntoView {
     let confirm_delete = Callback::new(move |change_reason: String| {
         let delete_request = delete_group_rws.get();
         spawn_local(async move {
-            let tenant = tenant_rws.get().0;
-            let org_id = org_rws.get().0;
+            let tenant = workspace.get().0;
+            let org_id = org.get().0;
             let member_experiment_ids =
                 Vec::from([delete_request.experiment_id.parse().unwrap_or_default()]);
             let remove_request = ExpGroupMemberRequest {

--- a/crates/frontend/src/pages/experiment_groups.rs
+++ b/crates/frontend/src/pages/experiment_groups.rs
@@ -8,7 +8,7 @@ use superposition_types::{
         experiments::{ExperimentListFilters, ExperimentResponse},
         workspace::WorkspaceResponse,
     },
-    custom_query::{CommaSeparatedQParams, PaginationParams},
+    custom_query::{CommaSeparatedQParams, DimensionQuery, PaginationParams},
     database::models::{experimentation::ExperimentGroup, ChangeReason},
 };
 
@@ -206,16 +206,22 @@ pub fn experiment_groups() -> impl IntoView {
             .iter()
             .map(i64::to_string)
             .collect::<Vec<_>>();
-        let filters = ExperimentListFilters::default();
+
         let filters = ExperimentListFilters {
             experiment_ids: Some(CommaSeparatedQParams(members)),
-            ..filters
+            ..ExperimentListFilters::default()
         };
         let pagination = PaginationParams::all_entries();
-        let experiments = fetch_experiments(&filters, &pagination, tenant, org_id)
-            .await
-            .ok()?
-            .data;
+        let experiments = fetch_experiments(
+            &filters,
+            &pagination,
+            &DimensionQuery::default(),
+            tenant,
+            org_id,
+        )
+        .await
+        .ok()?
+        .data;
         Some(ExperimentGroupResource { group, experiments })
     });
 
@@ -298,8 +304,7 @@ pub fn experiment_groups() -> impl IntoView {
                                     <div class="card-body">
                                         <div class="flex justify-between">
                                             <h2 class="card-title">"Member Experiments"</h2>
-                                            <DrawerBtn drawer_id="add_members_group_drawer"
-                                                .to_string()>
+                                            <DrawerBtn drawer_id="add_members_group_drawer">
                                                 Add Members <i class="ri-add-large-fill ml-2"></i>
                                             </DrawerBtn>
                                         </div>

--- a/crates/frontend/src/pages/experiment_groups.rs
+++ b/crates/frontend/src/pages/experiment_groups.rs
@@ -297,7 +297,7 @@ pub fn experiment_groups() -> impl IntoView {
                                 <div class="card rounded-xl w-full bg-base-100 shadow">
                                     <div class="card-body">
                                         <div class="flex justify-between">
-                                            <h2 class="card-title">Member Experiments</h2>
+                                            <h2 class="card-title">"Member Experiments"</h2>
                                             <DrawerBtn drawer_id="add_members_group_drawer"
                                                 .to_string()>
                                                 Add Members <i class="ri-add-large-fill ml-2"></i>

--- a/crates/frontend/src/pages/experiment_groups.rs
+++ b/crates/frontend/src/pages/experiment_groups.rs
@@ -123,9 +123,8 @@ fn table_columns(
             Expandable::Disabled,
             default_column_formatter,
         ),
-        Column::new(
+        Column::default_with_cell_formatter(
             "actions".to_string(),
-            false,
             move |_, row: &Map<String, Value>| {
                 let id = row.get("id").map_or(String::from(""), |value| {
                     value.as_str().unwrap_or("").to_string()
@@ -144,9 +143,6 @@ fn table_columns(
                 }
                 .into_view()
             },
-            ColumnSortable::No,
-            Expandable::Disabled,
-            default_column_formatter,
         ),
     ]
 }

--- a/crates/frontend/src/pages/experiment_groups.rs
+++ b/crates/frontend/src/pages/experiment_groups.rs
@@ -156,7 +156,11 @@ fn experiment_group_info(group: StoredValue<ExperimentGroup>) -> impl IntoView {
     view! {
         <div class="card bg-base-100 max-w-screen shadow">
             <div class="card-body flex flex-row gap-2 flex-wrap">
-                <ConditionComponent conditions id="experiment-group-context" class="h-fit w-[300px]" />
+                <ConditionComponent
+                    conditions
+                    id="experiment-group-context"
+                    class="h-fit w-[300px]"
+                />
                 <div class="h-fit w-[300px]">
                     <div class="stat-title">Group ID</div>
                     <div class="stat-value text-sm">{group.id}</div>
@@ -309,7 +313,9 @@ pub fn experiment_groups() -> impl IntoView {
                                 <Drawer
                                     id="add_members_group_drawer".to_string()
                                     header="Add members to the group"
-                                    handle_close=move || { close_drawer("add_members_group_drawer") }
+                                    handle_close=move || {
+                                        close_drawer("add_members_group_drawer")
+                                    }
                                 >
                                     <AddExperimentToGroupForm
                                         experiment_group=resource_group

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -406,12 +406,8 @@ pub fn experiment_list() -> impl IntoView {
         close_drawer("create_exp_drawer");
     };
 
-    let handle_next_click = Callback::new(move |next_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(next_page));
-    });
-
-    let handle_prev_click = Callback::new(move |prev_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(prev_page));
+    let handle_page_change = Callback::new(move |page: i64| {
+        pagination_params_rws.update(|f| f.page = Some(page));
     });
 
     view! {
@@ -480,8 +476,7 @@ pub fn experiment_list() -> impl IntoView {
                                         count: pagination_params.count.unwrap_or_default(),
                                         current_page: pagination_params.page.unwrap_or_default(),
                                         total_pages: v.experiments.total_pages,
-                                        on_next: handle_next_click,
-                                        on_prev: handle_prev_click,
+                                        on_page_change: handle_page_change,
                                     };
                                     view! {
                                         <ConditionCollapseProvider>

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -336,8 +336,8 @@ fn experiment_table_filter_widget(
 #[component]
 pub fn experiment_list() -> impl IntoView {
     // acquire tenant
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let (reset_exp_form, set_exp_form) = create_signal(0);
     let filters_rws = use_signal_from_query(move |query_string| {
         Query::<ExperimentListFilters>::extract_non_empty(&query_string).into_inner()
@@ -355,10 +355,10 @@ pub fn experiment_list() -> impl IntoView {
     let combined_resource = create_blocking_resource(
         move || {
             (
-                tenant_rws.get().0,
+                workspace.get().0,
                 filters_rws.get(),
                 pagination_params_rws.get(),
-                org_rws.get().0,
+                org.get().0,
             )
         },
         |(current_tenant, filters, pagination_params, org_id)| async move {

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -199,38 +199,36 @@ fn experiment_table_filter_widget(
                     <div class="flex flex-row justify-start gap-10">
                         {ExperimentStatusType::iter()
                             .map(|status| {
-                                let current_status = status.to_string().to_lowercase();
                                 let label = status.to_string();
-                                let input_id = format!("{current_status}-checkbox");
-                                let input_peer_class = format!(
-                                    "hidden peer/{current_status}-checkbox",
-                                );
-                                let label_class = format!(
-                                    "px-6 h-[30px] py-2 badge peer-checked/{current_status}-checkbox:{} peer-checked/{current_status}-checkbox:text-white cursor-pointer transition duration-300 ease-in-out",
-                                    status.badge_color(),
-                                );
+                                let input_id = format!("{label}-checkbox");
+
                                 view! {
-                                    <input
-                                        type="checkbox"
-                                        id=&input_id
-                                        class=&input_peer_class
-                                        checked=move || {
-                                            filters_buffer_rws
-                                                .get()
-                                                .status
-                                                .is_some_and(|s| s.iter().any(|item| *item == status))
-                                        }
-                                        on:change=move |event| {
-                                            let checked = event_target_checked(&event);
-                                            status_filter_management(checked, status)
-                                        }
-                                    />
-                                    <label for=&input_id class=&label_class>
-                                        {label}
-                                    </label>
+                                    <div>
+                                        <input
+                                            type="checkbox"
+                                            id=&input_id
+                                            class="peer hidden"
+                                            checked=move || {
+                                                filters_buffer_rws
+                                                    .get()
+                                                    .status
+                                                    .is_some_and(|s| s.iter().any(|item| *item == status))
+                                            }
+                                            on:change=move |event| {
+                                                let checked = event_target_checked(&event);
+                                                status_filter_management(checked, status)
+                                            }
+                                        />
+                                        <label
+                                            for=&input_id
+                                            class="badge h-[30px] px-6 py-2 peer-checked:bg-purple-500 peer-checked:text-white cursor-pointer transition duration-300 ease-in-out"
+                                        >
+                                            {label}
+                                        </label>
+                                    </div>
                                 }
                             })
-                            .collect::<Vec<_>>()}
+                            .collect_view()}
                     </div>
                 </div>
                 <div class="flex flex-col gap-5 justify-between">

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -445,7 +445,10 @@ pub fn experiment_list() -> impl IntoView {
                         {move || {
                             let value = combined_resource.get();
                             let pagination_params = pagination_params_rws.get();
-                            let table_columns = experiment_table_columns(filters_rws);
+                            let table_columns = experiment_table_columns(
+                                filters_rws,
+                                workspace_settings.with_value(|ws| ws.strict_mode),
+                            );
                             match value {
                                 Some(v) => {
                                     let data = v

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -304,10 +304,11 @@ fn experiment_table_filter_widget(
                         on_click=move |event| {
                             event.prevent_default();
                             let filter = filters_buffer_rws.get();
-                            pagination_params_rws.update(|f| {
-                                filters_rws.set_untracked(filter);
-                                f.reset_page()
-                            });
+                            pagination_params_rws
+                                .update(|f| {
+                                    filters_rws.set_untracked(filter);
+                                    f.reset_page()
+                                });
                             close_drawer("experiment_filter_drawer")
                         }
                     />
@@ -317,10 +318,11 @@ fn experiment_table_filter_widget(
                         icon_class="ri-restart-line".into()
                         on_click=move |event| {
                             event.prevent_default();
-                            pagination_params_rws.update(|f| {
-                                filters_rws.set_untracked(ExperimentListFilters::default());
-                                f.reset_page()
-                            });
+                            pagination_params_rws
+                                .update(|f| {
+                                    filters_rws.set_untracked(ExperimentListFilters::default());
+                                    f.reset_page()
+                                });
                             close_drawer("experiment_filter_drawer")
                         }
                     />

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -421,13 +421,11 @@ pub fn experiment_list() -> impl IntoView {
                 <div class="card rounded-xl w-full bg-base-100 shadow">
                     <div class="card-body">
                         <div class="flex justify-between">
-                            <h2 class="card-title">Experiments</h2>
-                            <div>
-                                <DrawerBtn drawer_id="create_exp_drawer"
-                                    .to_string()>
-                                    Create Experiment <i class="ri-edit-2-line ml-2"></i>
-                                </DrawerBtn>
-                            </div>
+                            <h2 class="card-title">"Experiments"</h2>
+                            <DrawerBtn drawer_id="create_exp_drawer"
+                                .to_string()>
+                                Create Experiment <i class="ri-edit-2-line ml-2"></i>
+                            </DrawerBtn>
                         </div>
                         {move || {
                             let value = combined_resource.get();

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -55,6 +55,7 @@ struct CombinedResource {
 
 #[component]
 fn experiment_table_filter_widget(
+    pagination_params_rws: RwSignal<PaginationParams>,
     filters_rws: RwSignal<ExperimentListFilters>,
     combined_resource: CombinedResource,
 ) -> impl IntoView {
@@ -303,7 +304,10 @@ fn experiment_table_filter_widget(
                         on_click=move |event| {
                             event.prevent_default();
                             let filter = filters_buffer_rws.get();
-                            filters_rws.set(filter);
+                            pagination_params_rws.update(|f| {
+                                filters_rws.set_untracked(filter);
+                                f.reset_page()
+                            });
                             close_drawer("experiment_filter_drawer")
                         }
                     />
@@ -313,8 +317,10 @@ fn experiment_table_filter_widget(
                         icon_class="ri-restart-line".into()
                         on_click=move |event| {
                             event.prevent_default();
-                            let filters = ExperimentListFilters::default();
-                            filters_rws.set(filters);
+                            pagination_params_rws.update(|f| {
+                                filters_rws.set_untracked(ExperimentListFilters::default());
+                                f.reset_page()
+                            });
                             close_drawer("experiment_filter_drawer")
                         }
                     />
@@ -480,6 +486,7 @@ pub fn experiment_list() -> impl IntoView {
                                     view! {
                                         <ConditionCollapseProvider>
                                             <ExperimentTableFilterWidget
+                                                pagination_params_rws
                                                 filters_rws
                                                 combined_resource=v
                                             />

--- a/crates/frontend/src/pages/experiment_list/filter.rs
+++ b/crates/frontend/src/pages/experiment_list/filter.rs
@@ -30,7 +30,7 @@ use crate::{
 use super::CombinedResource;
 
 #[component]
-pub fn filter_summary(
+pub(super) fn filter_summary(
     filters_rws: RwSignal<ExperimentListFilters>,
     dimension_params_rws: RwSignal<DimensionQuery<QueryMap>>,
 ) -> impl IntoView {
@@ -50,13 +50,14 @@ pub fn filter_summary(
 
     view! {
         <Show when=move || {
-            let context_filters_empty = filters_rws
+            let filters_empty = filters_rws
                 .with(|f| {
                     f.created_by.is_none() && f.from_date.is_none() && f.to_date.is_none()
                         && f.status.is_none() && f.experiment_name.is_none()
                         && f.experiment_ids.is_none()
                 });
-            !context_filters_empty
+            let dimension_params_empty = dimension_params_rws.with(|f| f.is_empty());
+            !filters_empty || !dimension_params_empty
         }>
             <div class="flex gap-2">
                 <div
@@ -128,7 +129,7 @@ pub fn filter_summary(
                     }}
                     {move || {
                         filters_rws
-                            .with(|f| f.from_date.clone())
+                            .with(|f| f.from_date)
                             .map(|from_date| {
                                 view! {
                                     <div class="flex gap-2 items-center">
@@ -145,7 +146,7 @@ pub fn filter_summary(
                     }}
                     {move || {
                         filters_rws
-                            .with(|f| f.to_date.clone())
+                            .with(|f| f.to_date)
                             .map(|to_date| {
                                 view! {
                                     <div class="flex gap-2 items-center">
@@ -330,7 +331,7 @@ pub(super) fn experiment_table_filter_widget(
                             name="experiment_from_date"
                             min="2020-01-01"
                             value=filters_buffer_rws
-                                .with(|f| f.from_date.clone())
+                                .with(|f| f.from_date)
                                 .map(|s| s.format("%Y-%m-%d").to_string())
                                 .unwrap_or_default()
                             on_change=Callback::new(move |new_date: DateTime<Utc>| {
@@ -348,7 +349,7 @@ pub(super) fn experiment_table_filter_widget(
                             id="experiment_to_date_input"
                             name="experiment_to_date"
                             value=filters_buffer_rws
-                                .with(|f| f.to_date.clone())
+                                .with(|f| f.to_date)
                                 .map(|s| s.format("%Y-%m-%d").to_string())
                                 .unwrap_or_default()
                             on_change=Callback::new(move |new_date: DateTime<Utc>| {

--- a/crates/frontend/src/pages/experiment_list/filter.rs
+++ b/crates/frontend/src/pages/experiment_list/filter.rs
@@ -1,0 +1,504 @@
+use std::{collections::HashSet, fmt::Display, ops::Deref, str::FromStr};
+
+use chrono::{DateTime, Days, Duration, Utc};
+use leptos::*;
+use serde_json::{json, Map, Value};
+use strum::IntoEnumIterator;
+use superposition_types::{
+    api::{experiments::ExperimentListFilters, workspace::WorkspaceResponse},
+    custom_query::{
+        CommaSeparatedQParams, CustomQuery, DimensionQuery, PaginationParams, QueryMap,
+    },
+    database::models::experimentation::ExperimentStatusType,
+};
+
+use crate::{
+    components::{
+        badge::{GrayPill, ListPills},
+        button::Button,
+        condition_pills::Condition,
+        context_form::ContextForm,
+        drawer::{close_drawer, Drawer, DrawerBtn, DrawerButtonStyle},
+        dropdown::DropdownDirection,
+        form::label::Label,
+        input::DateInput,
+    },
+    logic::{Condition, Conditions, Expression},
+    providers::condition_collapse_provider::ConditionCollapseProvider,
+};
+
+use super::CombinedResource;
+
+#[component]
+pub fn filter_summary(
+    filters_rws: RwSignal<ExperimentListFilters>,
+    dimension_params_rws: RwSignal<DimensionQuery<QueryMap>>,
+) -> impl IntoView {
+    let workspace_settings = use_context::<StoredValue<WorkspaceResponse>>().unwrap();
+    let force_open_rws = RwSignal::new(true);
+    // let force_open_rws = RwSignal::new(scrolled_to_top.get_untracked());
+
+    fn filter_index<T: Display + FromStr + Clone>(
+        items: &Option<CommaSeparatedQParams<T>>,
+        index: usize,
+    ) -> Option<CommaSeparatedQParams<T>> {
+        items.clone().and_then(|mut items| {
+            items.0.remove(index);
+            (!items.is_empty()).then_some(items)
+        })
+    }
+
+    view! {
+        <Show when=move || {
+            let context_filters_empty = filters_rws
+                .with(|f| {
+                    f.created_by.is_none() && f.from_date.is_none() && f.to_date.is_none()
+                        && f.status.is_none() && f.experiment_name.is_none()
+                        && f.experiment_ids.is_none()
+                });
+            !context_filters_empty
+        }>
+            <div class="flex gap-2">
+                <div
+                    class="h-max max-w-[1000px] pt-1 px-0.5 border-[1.5px] border-solid border-purple-400 rounded-[10px] cursor-pointer"
+                    on:click=move |_| force_open_rws.update(|f| *f = !*f)
+                >
+                    <i class=move || {
+                        format!(
+                            "{} ri-xl text-purple-800",
+                            if force_open_rws.get() {
+                                "ri-filter-2-fill"
+                            } else {
+                                "ri-filter-2-line"
+                            },
+                        )
+                    } />
+                    <i class=move || {
+                        format!(
+                            "{} ri-xl text-gray-500",
+                            if force_open_rws.get() {
+                                "ri-arrow-up-s-line"
+                            } else {
+                                "ri-arrow-down-s-line"
+                            },
+                        )
+                    } />
+
+                </div>
+                <div class=move || {
+                    format!(
+                        "{} flex flex-col gap-1 overflow-hidden",
+                        if force_open_rws.get() { "max-h-[1000px]" } else { "max-h-0" },
+                    )
+                }>
+                    {move || {
+                        if !dimension_params_rws.with(|d| d.is_empty()) {
+                            let dimension_params = dimension_params_rws.get();
+                            let conditions = dimension_params
+                                .clone()
+                                .into_inner()
+                                .iter()
+                                .map(|(k, v)| Condition {
+                                    variable: k.clone(),
+                                    expression: Expression::Is(v.clone()),
+                                })
+                                .collect::<Conditions>();
+                            let condition_id = serde_json::to_string(
+                                    dimension_params.clone().into_inner().deref(),
+                                )
+                                .unwrap_or_else(|_| "[]".to_string());
+                            view! {
+                                <div class="flex justify-end gap-2">
+                                    <div class="min-w-fit pt-1 text-xs">"Context"</div>
+                                    <ConditionCollapseProvider>
+                                        <Condition
+                                            conditions
+                                            id=condition_id
+                                            grouped_view=false
+                                            class="xl:w-[400px] h-fit"
+                                            strict_mode=workspace_settings.with_value(|w| w.strict_mode)
+                                        />
+                                    </ConditionCollapseProvider>
+                                </div>
+                            }
+                                .into_view()
+                        } else {
+                            ().into_view()
+                        }
+                    }}
+                    {move || {
+                        filters_rws
+                            .with(|f| f.from_date.clone())
+                            .map(|from_date| {
+                                view! {
+                                    <div class="flex gap-2 items-center">
+                                        <span class="text-xs">"Last Modified From"</span>
+                                        <GrayPill
+                                            text=from_date.format("%Y-%m-%d").to_string()
+                                            on_delete=move |_| {
+                                                filters_rws.update(|f| f.from_date = None);
+                                            }
+                                        />
+                                    </div>
+                                }
+                            })
+                    }}
+                    {move || {
+                        filters_rws
+                            .with(|f| f.to_date.clone())
+                            .map(|to_date| {
+                                view! {
+                                    <div class="flex gap-2 items-center">
+                                        <span class="text-xs">"Last Modified To"</span>
+                                        <GrayPill
+                                            text=to_date.format("%Y-%m-%d").to_string()
+                                            on_delete=move |_| {
+                                                filters_rws.update(|f| f.to_date = None);
+                                            }
+                                        />
+                                    </div>
+                                }
+                            })
+                    }}
+                    {move || {
+                        view! {
+                            <ListPills
+                                label="Status"
+                                items=filters_rws
+                                    .with(|f| {
+                                        f.status.as_ref().map(|p| p.0.clone()).unwrap_or_default()
+                                    })
+                                on_delete=move |idx| {
+                                    filters_rws.update(|f| f.status = filter_index(&f.status, idx))
+                                }
+                            />
+                        }
+                    }}
+                    {move || {
+                        filters_rws
+                            .with(|f| f.experiment_name.clone())
+                            .map(|experiment_name| {
+                                view! {
+                                    <div class="flex gap-2 items-center">
+                                        <span class="text-xs">"Name"</span>
+                                        <GrayPill
+                                            text=experiment_name.clone()
+                                            on_delete=move |_| {
+                                                filters_rws.update(|f| f.experiment_name = None);
+                                            }
+                                        />
+                                    </div>
+                                }
+                            })
+                    }}
+                    {move || {
+                        view! {
+                            <ListPills
+                                label="Created by"
+                                items=filters_rws
+                                    .with(|f| {
+                                        f.created_by
+                                            .as_ref()
+                                            .map(|p| p.0.clone())
+                                            .unwrap_or_default()
+                                    })
+                                on_delete=move |idx| {
+                                    filters_rws
+                                        .update(|f| f.created_by = filter_index(&f.created_by, idx))
+                                }
+                            />
+                        }
+                    }}
+                    {move || {
+                        view! {
+                            <ListPills
+                                label="IDs"
+                                items=filters_rws
+                                    .with(|f| {
+                                        f.experiment_ids
+                                            .as_ref()
+                                            .map(|p| p.0.clone())
+                                            .unwrap_or_default()
+                                    })
+                                on_delete=move |idx| {
+                                    filters_rws
+                                        .update(|f| {
+                                            f.experiment_ids = filter_index(&f.experiment_ids, idx);
+                                        })
+                                }
+                            />
+                        }
+                    }}
+                </div>
+            </div>
+        </Show>
+    }
+}
+
+#[component]
+pub(super) fn experiment_table_filter_widget(
+    pagination_params_rws: RwSignal<PaginationParams>,
+    filters_rws: RwSignal<ExperimentListFilters>,
+    dimension_params_rws: RwSignal<DimensionQuery<QueryMap>>,
+    combined_resource: CombinedResource,
+) -> impl IntoView {
+    let filters_buffer_rws = RwSignal::new(filters_rws.get_untracked());
+    let dimension_buffer_rws = RwSignal::new(dimension_params_rws.get_untracked());
+    let context_rws = RwSignal::new(
+        dimension_params_rws
+            .get_untracked()
+            .into_inner()
+            .iter()
+            .map(|(k, v)| Condition {
+                variable: k.clone(),
+                expression: Expression::Is(v.clone()),
+            })
+            .collect::<Conditions>(),
+    );
+
+    let dim = combined_resource.dimensions;
+
+    let status_filter_management =
+        move |checked: bool, filter_status: ExperimentStatusType| {
+            filters_buffer_rws.update(|f| {
+                let status_types = f.status.clone().map(|s| s.0).unwrap_or_default();
+                let mut old_status_vector: HashSet<ExperimentStatusType> =
+                    HashSet::from_iter(status_types);
+
+                if checked {
+                    old_status_vector.insert(filter_status);
+                } else {
+                    old_status_vector.remove(&filter_status);
+                }
+                let new_status_vector = old_status_vector.into_iter().collect();
+                f.status = Some(CommaSeparatedQParams(new_status_vector))
+            })
+        };
+
+    let fn_environment = create_memo(move |_| {
+        let context = context_rws.get();
+        json!({
+            "context": context,
+            "overrides": [],
+        })
+    });
+
+    view! {
+        <DrawerBtn
+            drawer_id="experiment_filter_drawer"
+            class="!h-9 !min-h-[32px] !w-fit px-2"
+            style=DrawerButtonStyle::Outline
+        >
+            Filters
+            <i class="ri-filter-3-line"></i>
+        </DrawerBtn>
+        <Drawer
+            id="experiment_filter_drawer".to_string()
+            header="Experiment Filters"
+            drawer_width="w-[50vw]"
+            handle_close=move || close_drawer("experiment_filter_drawer")
+        >
+            <div class="flex flex-col gap-5">
+                <ContextForm
+                    dimensions=dim
+                    context=context_rws.get_untracked()
+                    on_context_change=move |new_context| context_rws.set(new_context)
+                    dropdown_direction=DropdownDirection::Down
+                    handle_change=move |context: Conditions| {
+                        let map = context
+                            .iter()
+                            .filter_map(|condition| {
+                                match condition.expression.clone() {
+                                    Expression::Is(value) => {
+                                        Some((condition.variable.clone(), value))
+                                    }
+                                    _ => None,
+                                }
+                            })
+                            .collect::<Map<_, _>>();
+                        dimension_buffer_rws.set(DimensionQuery::from(map));
+                    }
+                    heading_sub_text="Search By Context"
+                    resolve_mode=true
+                    fn_environment
+                />
+                <div class="w-full flex flex-row justify-start items-end gap-10">
+                    <div class="form-control">
+                        <Label title="Last Modified From" />
+                        <DateInput
+                            id="experiment_from_date_input"
+                            name="experiment_from_date"
+                            min="2020-01-01"
+                            value=filters_buffer_rws
+                                .with(|f| f.from_date.clone())
+                                .map(|s| s.format("%Y-%m-%d").to_string())
+                                .unwrap_or_default()
+                            on_change=Callback::new(move |new_date: DateTime<Utc>| {
+                                filters_buffer_rws.update(|f| f.from_date = Some(new_date));
+                            })
+                            on_clear=move |_| {
+                                filters_buffer_rws.update(|f| f.from_date = None);
+                            }
+                        />
+                    </div>
+                    <i class="ri-arrow-right-line pb-2.5 text-3xl" />
+                    <div class="form-control">
+                        <Label title="Last Modified To" />
+                        <DateInput
+                            id="experiment_to_date_input"
+                            name="experiment_to_date"
+                            value=filters_buffer_rws
+                                .with(|f| f.to_date.clone())
+                                .map(|s| s.format("%Y-%m-%d").to_string())
+                                .unwrap_or_default()
+                            on_change=Callback::new(move |new_date: DateTime<Utc>| {
+                                filters_buffer_rws
+                                    .update(|f| {
+                                        f.to_date = Some(
+                                            new_date + Days::new(1) - Duration::seconds(1),
+                                        );
+                                    });
+                            })
+                            on_clear=move |_| {
+                                filters_buffer_rws.update(|f| f.to_date = None);
+                            }
+                        />
+                    </div>
+                </div>
+
+                <div class="form-control w-full">
+                    <Label title="Experiment Status" />
+                    <div class="flex flex-row flex-wrap justify-start gap-5">
+                        {ExperimentStatusType::iter()
+                            .map(|status| {
+                                let label = status.to_string();
+                                let input_id = format!("{label}-checkbox");
+
+                                view! {
+                                    <div>
+                                        <input
+                                            type="checkbox"
+                                            id=&input_id
+                                            class="peer hidden"
+                                            checked=move || {
+                                                filters_buffer_rws
+                                                    .with(|f| f.status.clone())
+                                                    .is_some_and(|s| s.iter().any(|item| *item == status))
+                                            }
+                                            on:change=move |event| {
+                                                let checked = event_target_checked(&event);
+                                                status_filter_management(checked, status)
+                                            }
+                                        />
+                                        <label
+                                            for=&input_id
+                                            class="badge h-[30px] px-6 py-2 peer-checked:bg-purple-500 peer-checked:text-white cursor-pointer transition duration-300 ease-in-out"
+                                        >
+                                            {label}
+                                        </label>
+                                    </div>
+                                }
+                            })
+                            .collect_view()}
+                    </div>
+                </div>
+                <div class="form-control">
+                    <Label title="Experiment Name" />
+                    <input
+                        type="text"
+                        id="experiment-name-filter"
+                        placeholder="eg: city experiment"
+                        class="input input-bordered rounded-md resize-y w-full max-w-md"
+                        value=move || filters_buffer_rws.with(|f| f.experiment_name.clone())
+                        on:change=move |event| {
+                            let experiment_name = event_target_value(&event);
+                            let experiment_name = if experiment_name.is_empty() {
+                                None
+                            } else {
+                                Some(experiment_name)
+                            };
+                            filters_buffer_rws.update(|f| f.experiment_name = experiment_name);
+                        }
+                    />
+                </div>
+                <div class="form-control">
+                    <Label
+                        title="Experiment ID"
+                        info="(any of)"
+                        description="Separate each ID by a comma"
+                    />
+                    <input
+                        type="text"
+                        id="experiment-id-filter"
+                        class="input input-bordered rounded-md resize-y w-full max-w-md"
+                        value=move || {
+                            filters_buffer_rws
+                                .with(|f| f.experiment_ids.clone().map(|d| d.to_string()))
+                        }
+                        placeholder="eg: 7259558160762015744"
+                        on:change=move |event| {
+                            let ids = event_target_value(&event);
+                            let ids = (!ids.is_empty())
+                                .then(|| serde_json::from_value(Value::String(ids)).ok())
+                                .flatten();
+                            filters_buffer_rws.update(|filter| filter.experiment_ids = ids);
+                        }
+                    />
+                </div>
+                <div class="form-control">
+                    <Label
+                        title="Created By"
+                        info="(any of)"
+                        description="Separate each user by a comma"
+                    />
+                    <input
+                        type="text"
+                        id="experiment-user-filter"
+                        class="input input-bordered rounded-md resize-y w-full max-w-md"
+                        placeholder="eg: user@superposition.io"
+                        value=move || filters_buffer_rws.get().created_by.map(|d| d.to_string())
+                        on:change=move |event| {
+                            let user_names = event_target_value(&event);
+                            let user_names = (!user_names.is_empty())
+                                .then(|| serde_json::from_value(Value::String(user_names)).ok())
+                                .flatten();
+                            filters_buffer_rws.update(|filter| filter.created_by = user_names);
+                        }
+                    />
+                </div>
+                <div class="flex justify-end gap-2">
+                    <Button
+                        class="h-12 w-48"
+                        text="Submit"
+                        icon_class="ri-send-plane-line"
+                        on_click=move |event| {
+                            event.prevent_default();
+                            let filters = filters_buffer_rws.get();
+                            let dimension_params = dimension_buffer_rws.get();
+                            batch(|| {
+                                filters_rws.set(filters);
+                                dimension_params_rws.set(dimension_params);
+                                pagination_params_rws.update(|f| f.reset_page());
+                            });
+                            close_drawer("experiment_filter_drawer")
+                        }
+                    />
+                    <Button
+                        class="h-12 w-48"
+                        text="Reset"
+                        icon_class="ri-restart-line"
+                        on_click=move |event| {
+                            event.prevent_default();
+                            batch(|| {
+                                filters_rws.set(ExperimentListFilters::default());
+                                dimension_params_rws.set(DimensionQuery::default());
+                                pagination_params_rws.update(|f| f.reset_page());
+                            });
+                            close_drawer("experiment_filter_drawer")
+                        }
+                    />
+                </div>
+            </div>
+        </Drawer>
+    }
+}

--- a/crates/frontend/src/pages/experiment_list/utils.rs
+++ b/crates/frontend/src/pages/experiment_list/utils.rs
@@ -15,6 +15,7 @@ use web_sys::MouseEvent;
 
 pub fn experiment_table_columns(
     filters_rws: RwSignal<ExperimentListFilters>,
+    strict_mode: bool,
 ) -> Vec<Column> {
     let current_filters = filters_rws.get();
     let current_sort_on = current_filters.sort_on.unwrap_or_default();
@@ -116,7 +117,7 @@ pub fn experiment_table_columns(
         Column::new(
             "context".to_string(),
             false,
-            |_, row: &Map<String, Value>| {
+            move |_, row: &Map<String, Value>| {
                 let context = row
                     .get("context")
                     .and_then(|v| v.as_object().cloned())
@@ -129,7 +130,7 @@ pub fn experiment_table_columns(
 
                 view! {
                     <div class="w-[400px]">
-                        <ConditionComponent conditions grouped_view=false id />
+                        <ConditionComponent conditions grouped_view=false id strict_mode  />
                     </div>
                 }
                 .into_view()

--- a/crates/frontend/src/pages/experiment_list/utils.rs
+++ b/crates/frontend/src/pages/experiment_list/utils.rs
@@ -78,9 +78,8 @@ pub fn experiment_table_columns(
             Expandable::Disabled,
             default_column_formatter,
         ),
-        Column::new(
+        Column::default_with_cell_formatter(
             "status".to_string(),
-            false,
             |value: &str, row: &Map<String, Value>| {
                 let badge_color = match value {
                     "CREATED" => "badge-info",
@@ -110,9 +109,6 @@ pub fn experiment_table_columns(
                 }
                 .into_view()
             },
-            ColumnSortable::No,
-            Expandable::Enabled(100),
-            default_column_formatter,
         ),
         Column::new(
             "context".to_string(),
@@ -139,9 +135,8 @@ pub fn experiment_table_columns(
             Expandable::Disabled,
             default_column_formatter,
         ),
-        Column::new(
+        Column::default_with_cell_formatter(
             "chosen_variant".to_string(),
-            false,
             |value: &str, _| {
                 let label = match value {
                     "null" => "¯\\_(ツ)_/¯".to_string(),
@@ -153,13 +148,9 @@ pub fn experiment_table_columns(
                 }
                 .into_view()
             },
-            ColumnSortable::No,
-            Expandable::Enabled(100),
-            default_column_formatter,
         ),
-        Column::new(
+        Column::default_with_cell_formatter(
             "experiment_group_id".to_string(),
-            false,
             |value: &str, _| {
                 let label = match value {
                     "null" => "¯\\_(ツ)_/¯".to_string(),
@@ -171,9 +162,6 @@ pub fn experiment_table_columns(
                 }
                 .into_view()
             },
-            ColumnSortable::No,
-            Expandable::Disabled,
-            default_column_formatter,
         ),
         Column::default_with_sort(
             "created_at".to_string(),

--- a/crates/frontend/src/pages/function.rs
+++ b/crates/frontend/src/pages/function.rs
@@ -41,11 +41,11 @@ struct CombinedResource {
 #[component]
 pub fn function_page() -> impl IntoView {
     let function_params = use_params_map();
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let source = move || {
-        let t = tenant_rws.get().0;
-        let org = org_rws.get().0;
+        let t = workspace.get().0;
+        let org = org.get().0;
         let function_name = function_params
             .with(|params| params.get("function_name").cloned().unwrap_or("1".into()));
         (function_name, t, org)
@@ -95,8 +95,8 @@ pub fn function_page() -> impl IntoView {
                         let publish_click = move |event: MouseEvent| {
                             event.prevent_default();
                             logging::log!("Submitting function form");
-                            let tenant = tenant_rws.get().0;
-                            let org = org_rws.get().0;
+                            let tenant = workspace.get().0;
+                            let org = org.get().0;
                             let f_function_name = function_rs.get().function_name;
                             spawn_local({
                                 async move {

--- a/crates/frontend/src/pages/function/function_create.rs
+++ b/crates/frontend/src/pages/function/function_create.rs
@@ -15,8 +15,8 @@ struct CombinedResource {
 
 #[component]
 pub fn create_function_view() -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     view! {
         <div>
 
@@ -24,8 +24,8 @@ pub fn create_function_view() -> impl IntoView {
             <FunctionEditor
                 edit=false
                 handle_submit=move || {
-                    let tenant = tenant_rws.get().0;
-                    let org = org_rws.get().0;
+                    let tenant = workspace.get().0;
+                    let org = org.get().0;
                     let redirect_url = format!("admin/{org}/{tenant}/function");
                     let navigate = use_navigate();
                     navigate(redirect_url.as_str(), Default::default())

--- a/crates/frontend/src/pages/function/function_list.rs
+++ b/crates/frontend/src/pages/function/function_list.rs
@@ -62,12 +62,8 @@ pub fn function_list() -> impl IntoView {
         },
     );
 
-    let handle_next_click = Callback::new(move |next_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(next_page));
-    });
-
-    let handle_prev_click = Callback::new(move |prev_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(prev_page));
+    let handle_page_change = Callback::new(move |page: i64| {
+        pagination_params_rws.update(|f| f.page = Some(page));
     });
 
     view! {
@@ -138,8 +134,7 @@ pub fn function_list() -> impl IntoView {
                                             count: pagination_params.count.unwrap_or_default(),
                                             current_page: pagination_params.page.unwrap_or_default(),
                                             total_pages,
-                                            on_next: handle_next_click,
-                                            on_prev: handle_prev_click,
+                                            on_page_change: handle_page_change,
                                         };
                                         view! {
                                             <Table

--- a/crates/frontend/src/pages/function/function_list.rs
+++ b/crates/frontend/src/pages/function/function_list.rs
@@ -87,18 +87,13 @@ pub fn function_list() -> impl IntoView {
                 <div class="card rounded-xl w-full bg-base-100 shadow">
                     <div class="card-body">
                         <div class="flex justify-between">
-                            <h2 class="card-title">Functions</h2>
-                            <div>
-
-                                <A
-                                    href="create".to_string()
-                                    class="btn-purple font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 btn-link"
-                                >
-                                    <button>
-                                        Create Function <i class="ri-edit-2-line ml-2"></i>
-                                    </button>
-                                </A>
-                            </div>
+                            <h2 class="card-title">"Functions"</h2>
+                            <A
+                                href="create".to_string()
+                                class="btn-purple font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 btn-link"
+                            >
+                                <button>Create Function <i class="ri-edit-2-line ml-2"></i></button>
+                            </A>
                         </div>
                         <div>
 

--- a/crates/frontend/src/pages/function/function_list.rs
+++ b/crates/frontend/src/pages/function/function_list.rs
@@ -27,8 +27,8 @@ struct CombinedResource {
 
 #[component]
 pub fn function_list() -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let pagination_params_rws = use_signal_from_query(move |query_string| {
         Query::<PaginationParams>::extract_non_empty(&query_string).into_inner()
     });
@@ -45,10 +45,10 @@ pub fn function_list() -> impl IntoView {
     let combined_resource = create_blocking_resource(
         move || {
             (
-                tenant_rws.get().0,
+                workspace.get().0,
                 pagination_params_rws.get(),
                 filters_rws.get(),
-                org_rws.get().0,
+                org.get().0,
             )
         },
         |(current_tenant, pagination, filters, org)| async move {

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -335,8 +335,10 @@ pub fn home() -> impl IntoView {
 
                                                 <ContextForm
                                                     dimensions=dimension
-                                                    context_rs
-                                                    context_ws
+                                                    context=context_rs.get_untracked()
+                                                    on_context_change=move |new_context| {
+                                                        context_ws.set(new_context);
+                                                    }
                                                     heading_sub_text="Query your configs".to_string()
                                                     dropdown_direction=DropdownDirection::Right
                                                     resolve_mode=true

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -48,7 +48,7 @@ fn all_context_view(config: Config) -> impl IntoView {
                 let unique_name = gen_name_id(key, key, &value);
                 view! {
                     <tr>
-                        <td class="min-w-48 max-w-72 font-mono">
+                        <td class="min-w-48 max-w-72">
                             <span
                                 name=format!("{unique_name}-1")
                                 class="config-name"
@@ -59,7 +59,7 @@ fn all_context_view(config: Config) -> impl IntoView {
                                 {key}
                             </span>
                         </td>
-                        <td class="min-w-48 max-w-72 font-mono" style="word-break: break-word;">
+                        <td class="min-w-48 max-w-72" style="word-break: break-word;">
                             <span
                                 name=format!("{unique_name}-2")
                                 class="config-value"
@@ -72,7 +72,8 @@ fn all_context_view(config: Config) -> impl IntoView {
                         </td>
                     </tr>
                 }
-            }).collect_view()
+            })
+            .collect_view()
     };
 
     view! {
@@ -90,7 +91,7 @@ fn all_context_view(config: Config) -> impl IntoView {
                         let conditions: Conditions = context.try_into().unwrap_or_default();
                         view! {
                             <div class="card bg-base-100 shadow gap-4 p-6">
-                                <h3 class="card-title text-base timeline-box text-gray-800 bg-base-100 shadow-md font-mono m-0 w-max">
+                                <h3 class="card-title text-base timeline-box text-gray-800 bg-base-100 shadow-md m-0 w-max">
                                     "Condition"
                                 </h3>
                                 <div class="pl-5">

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -3,6 +3,7 @@ use std::time::Duration;
 use leptos::*;
 use serde_json::{json, Map, Value};
 use strum_macros::Display;
+use superposition_types::api::workspace::WorkspaceResponse;
 use superposition_types::{custom_query::PaginationParams, Config};
 use wasm_bindgen::JsCast;
 use web_sys::{HtmlButtonElement, HtmlSpanElement, MouseEvent};
@@ -32,7 +33,7 @@ fn gen_name_id(s0: &String, s1: &String, s2: &String) -> String {
 }
 
 #[component]
-fn all_context_view(config: Config) -> impl IntoView {
+fn all_context_view(config: Config, strict_mode: bool) -> impl IntoView {
     let Config {
         contexts,
         overrides,
@@ -99,6 +100,7 @@ fn all_context_view(config: Config) -> impl IntoView {
                                         conditions=conditions
                                         id=context.id.clone()
                                         class="xl:w-[400px] h-fit"
+                                        strict_mode
                                     />
                                     <div class="overflow-auto pt-5">
                                         <table class="table table-zebra">
@@ -145,6 +147,7 @@ fn all_context_view(config: Config) -> impl IntoView {
 pub fn home() -> impl IntoView {
     let workspace = use_context::<Signal<Tenant>>().unwrap();
     let org = use_context::<Signal<OrganisationId>>().unwrap();
+    let workspace_settings = use_context::<StoredValue<WorkspaceResponse>>().unwrap();
     let config_data = create_blocking_resource(
         move || (workspace.get().0, org.get().0),
         |(tenant, org)| fetch_config(tenant, None, org),
@@ -438,7 +441,12 @@ pub fn home() -> impl IntoView {
                                                 match result {
                                                     Some(Ok(config)) => {
                                                         vec![
-                                                            view! { <AllContextView config=config.clone() /> }
+                                                            view! {
+                                                                <AllContextView
+                                                                    config=config.clone()
+                                                                    strict_mode=workspace_settings.with_value(|w| w.strict_mode)
+                                                                />
+                                                            }
                                                                 .into_view(),
                                                         ]
                                                     }

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -123,7 +123,7 @@ fn all_context_view(config: Config, strict_mode: bool) -> impl IntoView {
             </ConditionCollapseProvider>
             <div class="card bg-base-100 shadow m-6">
                 <div class="card-body">
-                    <h2 class="card-title">Default Configuration</h2>
+                    <h2 class="card-title">"Default Configuration"</h2>
                     <table class="table table-zebra">
                         <thead>
                             <tr>
@@ -331,7 +331,7 @@ pub fn home() -> impl IntoView {
                                     <div class="card h-4/5 shadow bg-base-100">
                                         <div class="card flex flex-row m-2 bg-base-100">
                                             <div class="card-body">
-                                                <h2 class="card-title">Resolve Configs</h2>
+                                                <h2 class="card-title">"Resolve Configs"</h2>
 
                                                 <ContextForm
                                                     dimensions=dimension
@@ -490,7 +490,7 @@ pub fn home() -> impl IntoView {
                                                         view! {
                                                             <div class="card m-6 shadow bg-base-100">
                                                                 <div class="card-body">
-                                                                    <h2 class="card-title">Resolved Config</h2>
+                                                                    <h2 class="card-title">"Resolved Config"</h2>
                                                                     <table class="table table-zebra">
                                                                         <thead>
                                                                             <tr>

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -143,14 +143,14 @@ fn all_context_view(config: Config) -> impl IntoView {
 
 #[component]
 pub fn home() -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let config_data = create_blocking_resource(
-        move || (tenant_rws.get().0, org_rws.get().0),
+        move || (workspace.get().0, org.get().0),
         |(tenant, org)| fetch_config(tenant, None, org),
     );
     let dimension_resource = create_blocking_resource(
-        move || (tenant_rws.get().0, org_rws.get().0),
+        move || (workspace.get().0, org.get().0),
         |(tenant, org)| async {
             fetch_dimensions(&PaginationParams::all_entries(), tenant, org)
                 .await
@@ -253,9 +253,9 @@ pub fn home() -> impl IntoView {
         spawn_local(async move {
             let context = context_updated.as_query_string();
             let mut config = resolve_config(
-                &tenant_rws.get_untracked().0,
+                &workspace.get_untracked().0,
                 &context,
-                &org_rws.get_untracked().0,
+                &org.get_untracked().0,
                 true,
                 None,
             )

--- a/crates/frontend/src/pages/webhooks.rs
+++ b/crates/frontend/src/pages/webhooks.rs
@@ -53,13 +53,7 @@ pub fn webhooks() -> impl IntoView {
     use_param_updater(move || box_params!(pagination_params_rws.get()));
 
     let webhooks_resource = create_blocking_resource(
-        move || {
-            (
-                workspace.get().0,
-                pagination_params_rws.get(),
-                org.get().0,
-            )
-        },
+        move || (workspace.get().0, pagination_params_rws.get(), org.get().0),
         |(current_tenant, pagination_params, org_id)| async move {
             fetch_webhooks(&pagination_params, current_tenant, org_id)
                 .await
@@ -70,8 +64,7 @@ pub fn webhooks() -> impl IntoView {
     let confirm_delete = Callback::new(move |_| {
         if let Some(id) = delete_id_rs.get().clone() {
             spawn_local(async move {
-                let result =
-                    delete_webhooks(id, workspace.get().0, org.get().0).await;
+                let result = delete_webhooks(id, workspace.get().0, org.get().0).await;
 
                 match result {
                     Ok(_) => {
@@ -87,12 +80,8 @@ pub fn webhooks() -> impl IntoView {
         delete_id_ws.set(None);
         delete_modal_visible_ws.set(false);
     });
-    let handle_next_click = Callback::new(move |next_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(next_page));
-    });
-
-    let handle_prev_click = Callback::new(move |prev_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(prev_page));
+    let handle_page_change = Callback::new(move |page: i64| {
+        pagination_params_rws.update(|f| f.page = Some(page));
     });
 
     let selected_webhook = create_rw_signal::<Option<RowData>>(None);
@@ -312,8 +301,7 @@ pub fn webhooks() -> impl IntoView {
                         count: pagination_params.count.unwrap_or_default(),
                         current_page: pagination_params.page.unwrap_or_default(),
                         total_pages: value.total_pages,
-                        on_next: handle_next_click,
-                        on_prev: handle_prev_click,
+                        on_page_change: handle_page_change,
                     };
                     view! {
                         <div class="pb-4">

--- a/crates/frontend/src/pages/webhooks.rs
+++ b/crates/frontend/src/pages/webhooks.rs
@@ -307,8 +307,7 @@ pub fn webhooks() -> impl IntoView {
                             <div class="card-body">
                                 <div class="flex justify-between">
                                     <h2 class="card-title">"Webhooks"</h2>
-                                    <DrawerBtn drawer_id="webhook_drawer"
-                                        .to_string()>
+                                    <DrawerBtn drawer_id="webhook_drawer">
                                         Create Webhook <i class="ri-edit-2-line ml-2"></i>
                                     </DrawerBtn>
                                 </div>

--- a/crates/frontend/src/pages/webhooks.rs
+++ b/crates/frontend/src/pages/webhooks.rs
@@ -213,7 +213,7 @@ pub fn webhooks() -> impl IntoView {
                     let options = RwSignal::new(events);
 
                     view! {
-                        <Badge options=options.read_only() />
+                        <Badge options />
                     }
                 },
                 ColumnSortable::No,

--- a/crates/frontend/src/pages/webhooks.rs
+++ b/crates/frontend/src/pages/webhooks.rs
@@ -322,7 +322,7 @@ pub fn webhooks() -> impl IntoView {
                         <div class="card rounded-xl w-full bg-base-100 shadow">
                             <div class="card-body">
                                 <div class="flex justify-between">
-                                    <h2 class="card-title chat-bubble text-gray-800 dark:text-white bg-white font-mono">
+                                    <h2 class="card-title chat-bubble text-gray-800 dark:text-white bg-white">
                                         "Webhooks"
                                     </h2>
                                     <DrawerBtn drawer_id="webhook_drawer"

--- a/crates/frontend/src/pages/webhooks.rs
+++ b/crates/frontend/src/pages/webhooks.rs
@@ -42,8 +42,8 @@ pub struct RowData {
 
 #[component]
 pub fn webhooks() -> impl IntoView {
-    let tenant_rws = use_context::<RwSignal<Tenant>>().unwrap();
-    let org_rws = use_context::<RwSignal<OrganisationId>>().unwrap();
+    let workspace = use_context::<Signal<Tenant>>().unwrap();
+    let org = use_context::<Signal<OrganisationId>>().unwrap();
     let (delete_modal_visible_rs, delete_modal_visible_ws) = create_signal(false);
     let (delete_id_rs, delete_id_ws) = create_signal::<Option<String>>(None);
     let pagination_params_rws = use_signal_from_query(move |query_string| {
@@ -55,9 +55,9 @@ pub fn webhooks() -> impl IntoView {
     let webhooks_resource = create_blocking_resource(
         move || {
             (
-                tenant_rws.get().0,
+                workspace.get().0,
                 pagination_params_rws.get(),
-                org_rws.get().0,
+                org.get().0,
             )
         },
         |(current_tenant, pagination_params, org_id)| async move {
@@ -71,7 +71,7 @@ pub fn webhooks() -> impl IntoView {
         if let Some(id) = delete_id_rs.get().clone() {
             spawn_local(async move {
                 let result =
-                    delete_webhooks(id, tenant_rws.get().0, org_rws.get().0).await;
+                    delete_webhooks(id, workspace.get().0, org.get().0).await;
 
                 match result {
                     Ok(_) => {

--- a/crates/frontend/src/pages/webhooks.rs
+++ b/crates/frontend/src/pages/webhooks.rs
@@ -306,9 +306,7 @@ pub fn webhooks() -> impl IntoView {
                         <div class="card rounded-xl w-full bg-base-100 shadow">
                             <div class="card-body">
                                 <div class="flex justify-between">
-                                    <h2 class="card-title chat-bubble text-gray-800 dark:text-white bg-white">
-                                        "Webhooks"
-                                    </h2>
+                                    <h2 class="card-title">"Webhooks"</h2>
                                     <DrawerBtn drawer_id="webhook_drawer"
                                         .to_string()>
                                         Create Webhook <i class="ri-edit-2-line ml-2"></i>

--- a/crates/frontend/src/pages/webhooks.rs
+++ b/crates/frontend/src/pages/webhooks.rs
@@ -215,13 +215,9 @@ pub fn webhooks() -> impl IntoView {
             Column::default("created_at".to_string()),
             Column::default("last_modified_by".to_string()),
             Column::default("last_modified_at".to_string()),
-            Column::new(
+            Column::default_with_cell_formatter(
                 "actions".to_string(),
-                false,
                 action_col_formatter,
-                ColumnSortable::No,
-                Expandable::Enabled(100),
-                default_column_formatter,
             ),
         ]
     });

--- a/crates/frontend/src/pages/workspace.rs
+++ b/crates/frontend/src/pages/workspace.rs
@@ -247,8 +247,7 @@ pub fn workspace() -> impl IntoView {
                             <div class="card-body">
                                 <div class="flex justify-between">
                                     <h2 class="card-title">"Workspaces"</h2>
-                                    <DrawerBtn drawer_id="workspace_drawer"
-                                        .to_string()>
+                                    <DrawerBtn drawer_id="workspace_drawer">
                                         Create Workspace <i class="ri-edit-2-line ml-2"></i>
                                     </DrawerBtn>
                                 </div>

--- a/crates/frontend/src/pages/workspace.rs
+++ b/crates/frontend/src/pages/workspace.rs
@@ -245,13 +245,12 @@ pub fn workspace() -> impl IntoView {
                         </div>
                         <div class="card rounded-lg w-full bg-base-100 shadow">
                             <div class="card-body">
-                                <div class="flex justify-end pb-2">
-                                    <div class="flex">
-                                        <DrawerBtn drawer_id="workspace_drawer"
-                                            .to_string()>
-                                            Create Workspace <i class="ri-edit-2-line ml-2"></i>
-                                        </DrawerBtn>
-                                    </div>
+                                <div class="flex justify-between">
+                                    <h2 class="card-title">"Workspaces"</h2>
+                                    <DrawerBtn drawer_id="workspace_drawer"
+                                        .to_string()>
+                                        Create Workspace <i class="ri-edit-2-line ml-2"></i>
+                                    </DrawerBtn>
                                 </div>
                                 <Table
                                     rows=table_rows

--- a/crates/frontend/src/pages/workspace.rs
+++ b/crates/frontend/src/pages/workspace.rs
@@ -140,13 +140,9 @@ pub fn workspace() -> impl IntoView {
             Column::default("strict_mode".to_string()),
             Column::default("created_by".to_string()),
             Column::default("created_at".to_string()),
-            Column::new(
+            Column::default_with_cell_formatter(
                 "actions".to_string(),
-                false,
                 actions_col_formatter,
-                ColumnSortable::No,
-                Expandable::Disabled,
-                default_column_formatter,
             ),
         ]
     });

--- a/crates/frontend/src/pages/workspace.rs
+++ b/crates/frontend/src/pages/workspace.rs
@@ -40,13 +40,10 @@ pub fn workspace() -> impl IntoView {
     );
     let selected_workspace = create_rw_signal::<Option<RowData>>(None);
 
-    let handle_next_click = Callback::new(move |next_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(next_page));
+    let handle_page_change = Callback::new(move |page: i64| {
+        pagination_params_rws.update(|f| f.page = Some(page));
     });
 
-    let handle_prev_click = Callback::new(move |prev_page: i64| {
-        pagination_params_rws.update(|f| f.page = Some(prev_page));
-    });
     let handle_close = move || {
         selected_workspace.set(None);
         close_drawer("workspace_drawer");
@@ -240,8 +237,7 @@ pub fn workspace() -> impl IntoView {
                         count: pagination_params.count.unwrap_or_default(),
                         current_page,
                         total_pages,
-                        on_next: handle_next_click,
-                        on_prev: handle_prev_click,
+                        on_page_change: handle_page_change,
                     };
                     view! {
                         <div class="pb-4">

--- a/crates/frontend/src/pages/workspace.rs
+++ b/crates/frontend/src/pages/workspace.rs
@@ -1,5 +1,5 @@
 use leptos::*;
-use leptos_router::use_navigate;
+use leptos_router::A;
 use serde_json::{json, Map, Value};
 use superposition_macros::box_params;
 use superposition_types::{
@@ -23,8 +23,7 @@ use crate::{api::fetch_workspaces, components::table::types::default_column_form
 
 #[component]
 pub fn workspace() -> impl IntoView {
-    let org_id: RwSignal<OrganisationId> =
-        use_context::<RwSignal<OrganisationId>>().unwrap();
+    let org_id = use_context::<Signal<OrganisationId>>().unwrap();
     let pagination_params_rws = use_signal_from_query(move |query_string| {
         Query::<PaginationParams>::extract_non_empty(&query_string).into_inner()
     });
@@ -114,27 +113,17 @@ pub fn workspace() -> impl IntoView {
             .into_view()
         };
 
-        let navigate_to_workspace = move |org_id: String, workspace_name: String| {
-            let redirect_url = format!("admin/{org_id}/{workspace_name}/default-config");
-            logging::log!("redirecting to {:?}", redirect_url.clone());
-            let navigate = use_navigate();
-            navigate(redirect_url.as_str(), Default::default());
-        };
-
         let navigate = move |_: &str, row: &Map<String, Value>| {
             let org_id = org_id.get().0;
             let workspace_name = row["workspace_name"].to_string().replace('"', "");
-            let navigated_workspace_name = workspace_name.clone();
-            view! {
-                <span
-                    class="cursor-pointer text-blue-500"
-                    on:click=move |_| {
-                        navigate_to_workspace(org_id.clone(), navigated_workspace_name.clone())
-                    }
-                >
 
+            view! {
+                <A
+                    class="cursor-pointer text-blue-500"
+                    href=format!("/admin/{org_id}/{workspace_name}/default-config")
+                >
                     {workspace_name}
-                </span>
+                </A>
             }
             .into_view()
         };

--- a/crates/frontend/src/utils.rs
+++ b/crates/frontend/src/utils.rs
@@ -1,6 +1,5 @@
 use std::{env, str::FromStr};
 
-use cfg_if::cfg_if;
 use leptos::*;
 use reqwest::{
     header::{HeaderMap, HeaderName, HeaderValue},
@@ -288,39 +287,6 @@ pub fn unwrap_option_or_default_with_error<T>(option: Option<T>, default: T) -> 
         );
         default
     })
-}
-
-pub fn get_local_storage<T>(_key: &str) -> Option<T>
-where
-    T: serde::de::DeserializeOwned,
-{
-    cfg_if! {
-        if #[cfg(target_arch = "wasm32")] {
-            web_sys::window()
-                .and_then(|win| win.local_storage().ok().flatten())
-                .and_then(|storage| {
-                    storage
-                        .get_item(_key)
-                        .ok()
-                        .flatten()
-                        .and_then(|value: String| serde_json::from_str::<T>(value.as_str()).ok())
-                })
-        } else {
-            None
-        }
-    }
-}
-
-pub fn set_local_storage(_key: &str, _value: &str) -> Option<()> {
-    cfg_if! {
-        if #[cfg(target_arch = "wasm32")] {
-            web_sys::window()
-                .and_then(|win| win.local_storage().ok().flatten())
-                .and_then(|storage| storage.set_item(_key, _value).ok())
-        } else {
-            None
-        }
-    }
 }
 
 pub fn set_function(selected_function: FunctionsName, value: &mut Option<String>) {

--- a/crates/frontend/styles/tailwind.css
+++ b/crates/frontend/styles/tailwind.css
@@ -161,7 +161,6 @@
 }
 
 .condition-value {
-    @apply font-mono;
 	@apply font-semibold;
 	@apply context_condition;
 	@apply w-full;
@@ -171,7 +170,6 @@
 
 
 .condition-value-collapsed {
-    @apply font-mono;
 	@apply font-semibold;
 	@apply context_condition;
 	@apply w-full;

--- a/crates/frontend/styles/tailwind.css
+++ b/crates/frontend/styles/tailwind.css
@@ -8,10 +8,6 @@
     src: url("/assets/codicon.ttf") format("truetype");
 }
 
-.h-sidenav {
-  height: calc(100vh - 370px);
-}
-
 .disable-click {
     pointer-events: none;
     cursor: not-allowed;

--- a/crates/frontend/tailwind.config.js
+++ b/crates/frontend/tailwind.config.js
@@ -1,27 +1,11 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
     content: [
-        '*.html',
-        './src/app.rs',
-        './src/pages/**/*.rs',
-        './src/components/**/*.rs',
-        './src/hoc/**/*.rs',
-    ],
-    safelist: [
-        "peer/concluded-checkbox",
-        "peer/created-checkbox",
-        "peer/inprogress-checkbox",
-        "peer/discarded-checkbox",
-        "peer-checked/discarded-checkbox:badge-neutral",
-        "peer-checked/concluded-checkbox:badge-success",
-        "peer-checked/created-checkbox:badge-info",
-        "peer-checked/inprogress-checkbox:badge-warning",
-        "peer-checked/paused-checkbox:badge-error",
-        "peer-checked/discarded-checkbox:text-white",
-        "peer-checked/concluded-checkbox:text-white",
-        "peer-checked/created-checkbox:text-white",
-        "peer-checked/inprogress-checkbox:text-white",
-        "peer-checked/paused-checkbox:text-white",
+        "*.html",
+        "./src/app.rs",
+        "./src/pages/**/*.rs",
+        "./src/components/**/*.rs",
+        "./src/hoc/**/*.rs",
     ],
     theme: {
         extend: {

--- a/crates/superposition/src/main.rs
+++ b/crates/superposition/src/main.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<()> {
     let conf = get_configuration(Some("Cargo.toml")).await.unwrap();
     // Generate the list of routes in your Leptos App
     let routes = generate_route_list(move || {
-        view! { <App app_envs=routes_ui_envs.clone()/> }
+        view! { <App app_envs=routes_ui_envs.clone() /> }
     });
 
     let app_env = get_from_env_unsafe("APP_ENV").expect("APP_ENV is not set");
@@ -121,7 +121,7 @@ async fn main() -> Result<()> {
             .leptos_routes(
                 leptos_options.to_owned(),
                 routes.to_owned(),
-                move || view! { <App app_envs=leptos_envs.clone()/> },
+                move || view! { <App app_envs=leptos_envs.clone() /> },
             )
             .service(
                 scope(&base)

--- a/crates/superposition_types/Cargo.toml
+++ b/crates/superposition_types/Cargo.toml
@@ -49,4 +49,3 @@ api = []
 
 [lints]
 workspace = true
-

--- a/crates/superposition_types/src/api/context.rs
+++ b/crates/superposition_types/src/api/context.rs
@@ -51,7 +51,9 @@ impl Display for ContextListFilters {
         let mut parts = vec![];
 
         if let Some(prefix) = &self.prefix {
-            parts.push(format!("prefix={prefix}"));
+            if !prefix.is_empty() {
+                parts.push(format!("prefix={prefix}"));
+            }
         }
 
         if let Some(sort_on) = &self.sort_on {
@@ -63,11 +65,15 @@ impl Display for ContextListFilters {
         }
 
         if let Some(created_by) = &self.created_by {
-            parts.push(format!("created_by={created_by}"));
+            if !created_by.is_empty() {
+                parts.push(format!("created_by={created_by}"));
+            }
         }
 
         if let Some(last_modified_by) = &self.last_modified_by {
-            parts.push(format!("last_modified_by={last_modified_by}"));
+            if !last_modified_by.is_empty() {
+                parts.push(format!("last_modified_by={last_modified_by}"));
+            }
         }
 
         if let Some(plaintext) = &self.plaintext {

--- a/crates/superposition_types/src/api/default_config.rs
+++ b/crates/superposition_types/src/api/default_config.rs
@@ -6,15 +6,16 @@ use derive_more::{AsRef, Deref, DerefMut, Into};
 use diesel::AsChangeset;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::{Map, Value};
+use superposition_derives::IsEmpty;
 
 #[cfg(feature = "diesel_derives")]
 use crate::database::schema::default_configs;
 use crate::{
     database::models::{cac::deserialize_function_name, ChangeReason, Description},
-    RegexEnum,
+    IsEmpty, RegexEnum,
 };
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Default, IsEmpty)]
 pub struct DefaultConfigFilters {
     pub name: Option<String>,
 }

--- a/crates/superposition_types/src/api/experiments.rs
+++ b/crates/superposition_types/src/api/experiments.rs
@@ -240,7 +240,6 @@ pub struct ExperimentListFilters {
     pub experiment_name: Option<String>,
     pub experiment_ids: Option<CommaSeparatedStringQParams>,
     pub created_by: Option<CommaSeparatedStringQParams>,
-    pub context: Option<CommaSeparatedStringQParams>,
     pub sort_on: Option<ExperimentSortOn>,
     pub sort_by: Option<SortBy>,
 }
@@ -272,11 +271,6 @@ impl Display for ExperimentListFilters {
                 query_params.push(format!("created_by={}", created_by));
             }
         }
-        if let Some(context) = &self.context {
-            if !context.is_empty() {
-                query_params.push(format!("context={}", context));
-            }
-        }
         if let Some(sort_on) = self.sort_on {
             query_params.push(format!("sort_on={}", sort_on));
         }
@@ -305,7 +299,6 @@ impl Default for ExperimentListFilters {
             experiment_name: None,
             experiment_ids: None,
             created_by: None,
-            context: None,
             sort_on: None,
             sort_by: Some(SortBy::Desc),
         }

--- a/crates/superposition_types/src/api/experiments.rs
+++ b/crates/superposition_types/src/api/experiments.rs
@@ -249,9 +249,9 @@ impl Display for ExperimentListFilters {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut query_params = vec![];
         if let Some(status) = &self.status {
-            let status: Vec<String> =
-                status.0.iter().map(|val| val.to_string()).collect();
-            query_params.push(format!("status={}", status.join(",")));
+            if !status.is_empty() {
+                query_params.push(format!("status={}", status));
+            }
         }
         if let Some(from_date) = self.from_date {
             query_params.push(format!("from_date={}", from_date));
@@ -263,13 +263,19 @@ impl Display for ExperimentListFilters {
             query_params.push(format!("experiment_name={}", experiment_name));
         }
         if let Some(experiment_ids) = &self.experiment_ids {
-            query_params.push(format!("experiment_ids={}", experiment_ids));
+            if !experiment_ids.is_empty() {
+                query_params.push(format!("experiment_ids={}", experiment_ids));
+            }
         }
         if let Some(created_by) = &self.created_by {
-            query_params.push(format!("created_by={}", created_by));
+            if !created_by.is_empty() {
+                query_params.push(format!("created_by={}", created_by));
+            }
         }
         if let Some(context) = &self.context {
-            query_params.push(format!("context={}", context));
+            if !context.is_empty() {
+                query_params.push(format!("context={}", context));
+            }
         }
         if let Some(sort_on) = self.sort_on {
             query_params.push(format!("sort_on={}", sort_on));

--- a/crates/superposition_types/src/api/functions.rs
+++ b/crates/superposition_types/src/api/functions.rs
@@ -133,7 +133,9 @@ impl Display for ListFunctionFilters {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut query_params = vec![];
         if let Some(fntype) = &self.function_type {
-            query_params.push(format!("function_type={}", fntype));
+            if !fntype.is_empty() {
+                query_params.push(format!("function_type={}", fntype));
+            }
         }
         write!(f, "{}", query_params.join("&"))
     }

--- a/docker-compose/postgres/db_init.sql
+++ b/docker-compose/postgres/db_init.sql
@@ -1323,7 +1323,7 @@ CREATE TABLE localorg_dev.webhooks (
 CREATE TRIGGER webhooks_audit AFTER INSERT OR DELETE OR UPDATE ON localorg_dev.webhooks FOR EACH ROW EXECUTE FUNCTION localorg_dev.event_logger();
 
 ALTER TABLE superposition.workspaces
-ADD COLUMN IF NOT EXISTS strict_mode BOOLEAN DEFAULT FALSE;
+ADD COLUMN IF NOT EXISTS strict_mode BOOLEAN DEFAULT TRUE;
 
 ALTER TABLE superposition.workspaces ADD COLUMN IF NOT EXISTS metrics JSON DEFAULT '{"enabled": false}'::json NOT NULL;
 

--- a/smithy/models/experiments.smithy
+++ b/smithy/models/experiments.smithy
@@ -354,10 +354,6 @@ operation ListExperiment {
         @notProperty
         created_by: String
 
-        @httpQuery("context")
-        @notProperty
-        context_query: String
-
         @httpQuery("sort_on")
         @notProperty        
         sort_on: ExperimentSortOn,


### PR DESCRIPTION
# Note
Other than UI fixes, had to chip in a fix for `experiment/list` endpoint
while taking context in `experiment/list` as comma separated objects as string, it cause deserialization issues

example:
required context:
```
{
   "and": [
      {
         "==": [
            {"var": "test"},
            0
         ]
      },
      {
         "==": [
            {"var": "test2"},
            1
         ]
      }
   ]
}
```

is sent as :
```
context={"==":[{"var":"test"},0]},{"==":[{"var":"test2"},1]}
```

ideally this should have been split as:
1. `{"==":[{"var":"test"},0]}`
2. `{"==":[{"var":"test2"},1]}`

but instead it is being split as:
1. `{"==":[{"var":"test"}`
2. `0]}`
3. `{"==":[{"var":"test2"}`
4. `1]}`

### Fix
moved it to DimensionQuery params just like `context/list` endpoint, so that it is sent as:
```
dimension[test]=0&dimension[test2]=1
```
the logic the endpoint to fetch data still remains the same

### NB
Smithy changes not pushed in this, just updated the model file
Probably this feature was never tested and it just existed