### PR TITLE
chore(logs): enable access log for each actix request

### DIFF
--- a/crates/superposition/src/main.rs
+++ b/crates/superposition/src/main.rs
@@ -9,7 +9,7 @@ use std::{io::Result, time::Duration};
 
 use actix_files::Files;
 use actix_web::{
-    middleware::Compress,
+    middleware::{Compress, Logger},
     web::{self, get, scope, Data, PathConfig},
     App, HttpResponse, HttpServer,
 };
@@ -106,6 +106,7 @@ async fn main() -> Result<()> {
         let leptos_envs = ui_envs.clone();
         App::new()
             .wrap(Compress::default())
+            .wrap(Logger::default())
             .app_data(app_state.clone())
             .app_data(PathConfig::default().error_handler(|err, _| {
                 actix_web::error::ErrorBadRequest(err)


### PR DESCRIPTION
## Problem
The Superposition server logs do not print a single log line for requests.

## Solution
This can be enabled by include the default implementation of the Logger middleware supplied by actix.

## Environment variable changes
None

## Pre-deployment activity
None

## Post-deployment activity
None

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
None

## Testing stdout sample
```log
[2025-07-08T16:47:50Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET /workspaces?all=true HTTP/1.1" 200 1066 "-" "-" 0.025802
[2025-07-08T16:47:50Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET /default-config?all=true& HTTP/1.1" 200 2045 "-" "-" 0.006340
[2025-07-08T16:47:50Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET /admin/localorg/test/default-config?all=true&grouped=true HTTP/1.1" 200 8576 "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" 0.079910
[2025-07-08T16:47:50Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET /pkg/frontend.js HTTP/1.1" 200 12064 "http://localhost:8080/admin/localorg/test/default-config?all=true&grouped=true" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" 0.011693
[2025-07-08T16:47:50Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET /pkg/style.css HTTP/1.1" 200 23817 "http://localhost:8080/admin/localorg/test/default-config?all=true&grouped=true" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" 0.028702
[2025-07-08T16:47:50Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET /pkg/snippets/frontend-5bb326d1b691a430/src-js/utils.js HTTP/1.1" 200 769 "http://localhost:8080/pkg/frontend.js" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" 0.001738
[2025-07-08T16:47:51Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET /pkg/snippets/monaco-bd8b36bfd9ad4127/js/debug/editor.js HTTP/1.1" 200 1363611 "http://localhost:8080/pkg/frontend.js" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" 1.000168
[2025-07-08T16:47:58Z INFO  actix_web::middleware::logger] 127.0.0.1 "GET /pkg/frontend_bg.wasm HTTP/1.1" 200 12363264 "http://localhost:8080/admin/localorg/test/default-config?all=true&grouped=true" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36" 8.115882
```
