### PR TITLE
build: fix gradle/python/npm publish

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -423,6 +423,11 @@ jobs:
               with:
                   version: "latest"
 
+            - name: install twine
+              run: |
+                  python -m pip install --upgrade pip
+                  pip install twine
+
             - name: Download all rust binary artifacts
               uses: actions/download-artifact@v4
               with:
@@ -535,6 +540,7 @@ jobs:
             AWS_REGION: ${{ vars.AWS_REGION }}
             CODEARTIFACT_DOMAIN: ${{ vars.CODEARTIFACT_DOMAIN }}
             CODEARTIFACT_REPOSITORY: ${{ vars.CODEARTIFACT_REPOSITORY }}
+            NODE_AUTH_TOKEN: ${{ env.CODEARTIFACT_AUTH_TOKEN }}
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4

--- a/clients/java/build.gradle.kts
+++ b/clients/java/build.gradle.kts
@@ -6,13 +6,18 @@ allprojects {
         google()
         gradlePluginPortal()
     }
-    repositories {
-        maven {
-            name = "CodeArtifact"
-            url = uri(System.getenv("CODEARTIFACT_REPOSITORY_ENDPOINT") ?: "")
-            credentials {
-                username = "aws"
-                password = System.getenv("CODEARTIFACT_AUTH_TOKEN")
+
+    apply(plugin = "maven-publish")
+
+    configure<PublishingExtension> {
+        repositories {
+            maven {
+                name = "CodeArtifact"
+                url = uri(System.getenv("CODEARTIFACT_REPOSITORY_ENDPOINT") ?: "")
+                credentials {
+                    username = "aws"
+                    password = System.getenv("CODEARTIFACT_AUTH_TOKEN")
+                }
             }
         }
     }

--- a/clients/java/build.gradle.kts
+++ b/clients/java/build.gradle.kts
@@ -13,7 +13,7 @@ allprojects {
         repositories {
             maven {
                 name = "CodeArtifact"
-                url = uri(System.getenv("CODEARTIFACT_REPOSITORY_ENDPOINT") ?: "")
+                url = uri(System.getenv("CODEARTIFACT_REPOSITORY_ENDPOINT") ?: "https://non.existent.site.here")
                 credentials {
                     username = "aws"
                     password = System.getenv("CODEARTIFACT_AUTH_TOKEN")


### PR DESCRIPTION
## Problem
Gradle/npm/twine is broken in the build - https://github.com/juspay/superposition/actions/runs/16373708049/job/46269070025

## Solution
Fix gradle publishing reference by including the plugin

## Environment variable changes
NA

## Pre-deployment activity
NA

## Post-deployment activity
NA

## API changes
NA

## Possible Issues in the future
NA