### PR TITLE
build: fix npm issue

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -540,7 +540,7 @@ jobs:
             AWS_REGION: ${{ vars.AWS_REGION }}
             CODEARTIFACT_DOMAIN: ${{ vars.CODEARTIFACT_DOMAIN }}
             CODEARTIFACT_REPOSITORY: ${{ vars.CODEARTIFACT_REPOSITORY }}
-            NODE_AUTH_TOKEN: ${{ env.CODEARTIFACT_AUTH_TOKEN }}
+
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -555,6 +555,27 @@ jobs:
                   role-session-name: superposition-release
                   role-to-assume: ${{ secrets.AWS_ARTIFACT_ROLE }}
 
+            - name: Configure CodeArtifact for npm
+              run: |
+                  # Get CodeArtifact authorization token
+                  export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
+                      --domain $CODEARTIFACT_DOMAIN \
+                      --query authorizationToken --output text)
+
+                  # Get repository endpoint
+                  export CODEARTIFACT_REPOSITORY_ENDPOINT=$(aws codeartifact get-repository-endpoint \
+                      --domain $CODEARTIFACT_DOMAIN \
+                      --repository $CODEARTIFACT_REPOSITORY \
+                      --format npm --query repositoryEndpoint --output text)
+
+                  echo "CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN" >> $GITHUB_ENV
+                  echo "CODEARTIFACT_REPOSITORY_ENDPOINT=$CODEARTIFACT_REPOSITORY_ENDPOINT" >> $GITHUB_ENV
+                  echo "NODE_AUTH_TOKEN=$CODEARTIFACT_REPOSITORY_ENDPOINT" >> $GITHUB_ENV
+
+                  # Configure npm to use CodeArtifact
+                  npm config set registry $CODEARTIFACT_REPOSITORY_ENDPOINT
+                  npm config set //$CODEARTIFACT_REPOSITORY_ENDPOINT:_authToken=$CODEARTIFACT_AUTH_TOKEN
+
             - uses: actions/setup-node@v4
               with:
                   node-version: "20.0.0"
@@ -598,26 +619,6 @@ jobs:
                   # List what we have
                   echo "Native libraries in bindings package:"
                   ls -la clients/javascript/bindings
-
-            - name: Configure CodeArtifact for npm
-              run: |
-                  # Get CodeArtifact authorization token
-                  export CODEARTIFACT_AUTH_TOKEN=$(aws codeartifact get-authorization-token \
-                      --domain $CODEARTIFACT_DOMAIN \
-                      --query authorizationToken --output text)
-
-                  # Get repository endpoint
-                  export CODEARTIFACT_REPOSITORY_ENDPOINT=$(aws codeartifact get-repository-endpoint \
-                      --domain $CODEARTIFACT_DOMAIN \
-                      --repository $CODEARTIFACT_REPOSITORY \
-                      --format npm --query repositoryEndpoint --output text)
-
-                  echo "CODEARTIFACT_AUTH_TOKEN=$CODEARTIFACT_AUTH_TOKEN" >> $GITHUB_ENV
-                  echo "CODEARTIFACT_REPOSITORY_ENDPOINT=$CODEARTIFACT_REPOSITORY_ENDPOINT" >> $GITHUB_ENV
-
-                  # Configure npm to use CodeArtifact
-                  npm config set registry $CODEARTIFACT_REPOSITORY_ENDPOINT
-                  npm config set //$CODEARTIFACT_REPOSITORY_ENDPOINT:_authToken $CODEARTIFACT_AUTH_TOKEN
 
             - run: |
                   cd clients/javascript/bindings

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -574,7 +574,7 @@ jobs:
 
                   # Configure npm to use CodeArtifact
                   npm config set registry $CODEARTIFACT_REPOSITORY_ENDPOINT
-                  npm config set //$CODEARTIFACT_REPOSITORY_ENDPOINT:_authToken=$CODEARTIFACT_AUTH_TOKEN
+                  npm config set //$CODEARTIFACT_REPOSITORY_ENDPOINT:_authToken $CODEARTIFACT_AUTH_TOKEN
 
             - uses: actions/setup-node@v4
               with:


### PR DESCRIPTION
## Problem
The auth for private npm registry needs to be setup before the setup-node action.

## Solution
This moves the aws auth stuff before the setup-node action

## Environment variable changes
NA

## Pre-deployment activity
NA

## Post-deployment activity
NA

## API changes
NA

## Possible Issues in the future
NA