### PR TITLE
build: use make functions instead of inline commands for wider compat…

### DIFF
--- a/makefile
+++ b/makefile
@@ -6,7 +6,7 @@ TENANT ?= dev
 SHELL := /usr/bin/env bash
 FEATURES ?= ssr
 CARGO_FLAGS := --color always --no-default-features
-EXCLUDE_PACKAGES := superposition_core cac_toml experimentation_client_integration_example superposition_sdk
+EXCLUDE_PACKAGES := experimentation_client_integration_example superposition_sdk
 FMT_EXCLUDE_PACKAGES_REGEX := $(shell echo "$(EXCLUDE_PACKAGES)" | sed "s/ /|/g")
 LINT_FLAGS := --workspace --all-targets $(addprefix --exclude ,$(EXCLUDE_PACKAGES)) --no-deps
 


### PR DESCRIPTION
## Problem
Current makefile execution fails because we use features not supported by GNU Make 3.81 which is typically available in our Mac books.

## Solution
Use a primitive that works across both versions - moving them to a Makefile function solves the problem.

## Environment variable changes
NA

## Pre-deployment activity
NA

## Post-deployment activity
NA

## API changes
NA

## Possible Issues in the future
NA