### PR TITLE
feat: Move jsonlogic behind compile time flag

### DIFF
--- a/.github/workflows/ci_check_pr.yaml
+++ b/.github/workflows/ci_check_pr.yaml
@@ -2,9 +2,9 @@ name: CI Checks on PRs
 
 on:
     pull_request:
-        branches: [ main ]
+        branches: [main]
     push:
-        branches: [ main ]
+        branches: [main]
 
 concurrency:
     group: ${{ github.workflow }}-${{ github.ref }}
@@ -141,6 +141,12 @@ jobs:
                   make test CI=1
               env:
                   APP_ENV: "TEST"
+            - name: run jsonlogic tests
+              shell: bash
+              run: |
+                  make test_jsonlogic CI=1
+              env:
+                  APP_ENV: "TEST"
 
     java-build:
         name: Java build
@@ -156,8 +162,8 @@ jobs:
             - name: Set up JDK 17
               uses: actions/setup-java@v4
               with:
-                  java-version: '17'
-                  distribution: 'temurin'
+                  java-version: "17"
+                  distribution: "temurin"
 
             - name: Make gradlew executable
               run: chmod +x gradlew

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ version = "0.87.0"
 dependencies = [
  "actix-web",
  "cbindgen",
+ "cfg-if",
  "chrono",
  "derive_more",
  "itertools 0.10.5",
@@ -2184,6 +2185,7 @@ name = "experimentation_client"
 version = "0.87.0"
 dependencies = [
  "cbindgen",
+ "cfg-if",
  "chrono",
  "derive_more",
  "juspay_jsonlogic",
@@ -2213,6 +2215,7 @@ dependencies = [
  "anyhow",
  "blake3",
  "cac_client",
+ "cfg-if",
  "chrono",
  "experimentation_client",
  "juspay_diesel",
@@ -5412,7 +5415,6 @@ dependencies = [
  "actix-web",
  "anyhow",
  "aws-sdk-kms",
- "cfg-if",
  "chrono",
  "context_aware_config",
  "dotenv",
@@ -5452,6 +5454,7 @@ version = "0.87.0"
 dependencies = [
  "actix-web",
  "anyhow",
+ "cfg-if",
  "chrono",
  "derive_more",
  "itertools 0.10.5",

--- a/crates/cac_client/Cargo.toml
+++ b/crates/cac_client/Cargo.toml
@@ -8,10 +8,11 @@ build = "build.rs"
 
 [dependencies]
 actix-web = { workspace = true }
+cfg-if = { workspace = true }
 chrono = { workspace = true }
 derive_more = { workspace = true }
 itertools = { workspace = true }
-jsonlogic = { workspace = true }
+jsonlogic = { workspace = true, optional = true }
 log = { workspace = true }
 mini-moka = { version = "0.10.3" }
 once_cell = { workspace = true }
@@ -21,6 +22,9 @@ strum = { workspace = true }
 strum_macros = { workspace = true }
 superposition_types = { workspace = true }
 tokio = { version = "1.29.1", features = ["full"] }
+
+[features]
+jsonlogic = ["dep:jsonlogic", "superposition_types/jsonlogic"]
 
 [lib]
 name = "cac_client"

--- a/crates/context_aware_config/Cargo.toml
+++ b/crates/context_aware_config/Cargo.toml
@@ -18,7 +18,7 @@ chrono = { workspace = true }
 diesel = { workspace = true, features = ["numeric"] }
 fred = { workspace = true, optional = true, features = ["metrics"] }
 itertools = { workspace = true }
-jsonlogic = { workspace = true }
+jsonlogic = { workspace = true, optional = true }
 jsonschema = { workspace = true }
 log = { workspace = true }
 num-bigint = "0.4"
@@ -37,6 +37,12 @@ uuid = { workspace = true }
 [features]
 disable_db_data_validation = ["superposition_types/disable_db_data_validation"]
 high-performance-mode = ["dep:fred"]
+jsonlogic = [
+    "dep:jsonlogic",
+    "cac_client/jsonlogic",
+    "service_utils/jsonlogic",
+    "superposition_types/jsonlogic",
+]
 
 [lints]
 workspace = true

--- a/crates/context_aware_config/src/api/context/handlers.rs
+++ b/crates/context_aware_config/src/api/context/handlers.rs
@@ -119,12 +119,13 @@ async fn put_handler(
         AppHeader::XConfigVersion.to_string(),
         version_id.to_string(),
     ));
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "high-performance-mode")] {
-            let DbConnection(mut conn) = db_conn;
-            put_config_in_redis(version_id, state, &schema_name, &mut conn).await?;
-        }
+
+    #[cfg(feature = "high-performance-mode")]
+    {
+        let DbConnection(mut conn) = db_conn;
+        put_config_in_redis(version_id, state, &schema_name, &mut conn).await?;
     }
+
     Ok(http_resp.json(put_response))
 }
 
@@ -166,12 +167,13 @@ async fn update_override_handler(
         AppHeader::XConfigVersion.to_string(),
         version_id.to_string(),
     ));
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "high-performance-mode")] {
-            let DbConnection(mut conn) = db_conn;
-            put_config_in_redis(version_id, state, &schema_name, &mut conn).await?;
-        }
+
+    #[cfg(feature = "high-performance-mode")]
+    {
+        let DbConnection(mut conn) = db_conn;
+        put_config_in_redis(version_id, state, &schema_name, &mut conn).await?;
     }
+
     Ok(http_resp.json(override_resp))
 }
 
@@ -228,12 +230,13 @@ async fn move_handler(
         AppHeader::XConfigVersion.to_string(),
         version_id.to_string(),
     ));
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "high-performance-mode")] {
-            let DbConnection(mut conn) = db_conn;
-            put_config_in_redis(version_id, state, &schema_name, &mut conn).await?;
-        }
+
+    #[cfg(feature = "high-performance-mode")]
+    {
+        let DbConnection(mut conn) = db_conn;
+        put_config_in_redis(version_id, state, &schema_name, &mut conn).await?;
     }
+
     Ok(http_resp.json(move_response))
 }
 
@@ -424,12 +427,13 @@ async fn delete_context_handler(
             )?;
             Ok(version_id)
         })?;
-    cfg_if::cfg_if! {
-        if #[cfg(feature = "high-performance-mode")] {
-            let DbConnection(mut conn) = db_conn;
-            put_config_in_redis(version_id, state, &schema_name, &mut conn).await?;
-        }
+
+    #[cfg(feature = "high-performance-mode")]
+    {
+        let DbConnection(mut conn) = db_conn;
+        put_config_in_redis(version_id, state, &schema_name, &mut conn).await?;
     }
+
     Ok(HttpResponse::NoContent()
         .insert_header((
             AppHeader::XConfigVersion.to_string().as_str(),

--- a/crates/context_aware_config/src/api/context/types.rs
+++ b/crates/context_aware_config/src/api/context/types.rs
@@ -1,6 +1,8 @@
 use chrono::{DateTime, Utc};
 use diesel::prelude::AsChangeset;
-use serde::{Deserialize, Serialize};
+#[cfg(feature = "jsonlogic")]
+use serde::Deserialize;
+use serde::Serialize;
 use superposition_types::{
     database::{
         models::{cac::FunctionCode, ChangeReason, Description},
@@ -21,6 +23,7 @@ pub(crate) struct UpdateContextOverridesChangeset {
     pub change_reason: ChangeReason,
 }
 
+#[cfg(feature = "jsonlogic")]
 #[derive(Deserialize, Clone)]
 pub struct DimensionCondition {
     pub var: String,

--- a/crates/context_aware_config/src/api/dimension/handlers.rs
+++ b/crates/context_aware_config/src/api/dimension/handlers.rs
@@ -24,6 +24,8 @@ use superposition_types::{
     result as superposition, PaginatedResponse, User,
 };
 
+#[cfg(not(feature = "jsonlogic"))]
+use crate::helpers::allow_primitive_types;
 use crate::{
     api::dimension::utils::{
         get_dimension_usage_context_ids, validate_and_update_dimension_hierarchy,
@@ -69,6 +71,8 @@ async fn create(
         create_req.position,
         num_rows,
     )?;
+    #[cfg(not(feature = "jsonlogic"))]
+    allow_primitive_types(&schema_value)?;
     validate_jsonschema(&state.meta_schema, &schema_value)?;
 
     let mut dimension_data = Dimension {
@@ -197,6 +201,8 @@ async fn update(
     let update_req = req.into_inner();
 
     if let Some(schema_value) = update_req.schema.clone() {
+        #[cfg(not(feature = "jsonlogic"))]
+        allow_primitive_types(&schema_value)?;
         validate_jsonschema(&state.meta_schema, &schema_value)?;
     }
 

--- a/crates/experimentation_client/Cargo.toml
+++ b/crates/experimentation_client/Cargo.toml
@@ -4,9 +4,10 @@ version.workspace = true
 edition = "2021"
 
 [dependencies]
+cfg-if = { workspace = true }
 chrono = { workspace = true }
 derive_more = { workspace = true }
-jsonlogic = { workspace = true }
+jsonlogic = { workspace = true, optional = true }
 log = { workspace = true }
 once_cell = { workspace = true }
 reqwest = { workspace = true }
@@ -16,6 +17,9 @@ superposition_types = { workspace = true, features = [
     "api",
 ] }
 tokio = { version = "1.29.1", features = ["full"] }
+
+[features]
+jsonlogic = ["dep:jsonlogic", "superposition_types/jsonlogic"]
 
 [lib]
 name = "experimentation_client"

--- a/crates/experimentation_platform/Cargo.toml
+++ b/crates/experimentation_platform/Cargo.toml
@@ -11,6 +11,7 @@ actix-http = "3.3.1"
 anyhow = { workspace = true }
 blake3 = "1.3.3"
 cac_client = { path = "../cac_client" }
+cfg-if = { workspace = true }
 chrono = { workspace = true }
 diesel = { workspace = true }
 experimentation_client = { path = "../experimentation_client" }
@@ -30,6 +31,12 @@ superposition_types = { workspace = true, features = [
 
 [features]
 disable_db_data_validation = ["superposition_types/disable_db_data_validation"]
+jsonlogic = [
+    "cac_client/jsonlogic",
+    "experimentation_client/jsonlogic",
+    "service_utils/jsonlogic",
+    "superposition_types/jsonlogic",
+]
 
 [lints]
 workspace = true

--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -31,7 +31,7 @@ superposition_macros = { workspace = true }
 superposition_types = { workspace = true, features = [
     "experimentation",
     "api",
-], default-features = false }
+] }
 url = { workspace = true }
 wasm-bindgen = "0.2.100"
 web-sys = { version = "0.3.64", features = [
@@ -58,6 +58,7 @@ hydrate = [
     "console_error_panic_hook",
 ]
 ssr = ["leptos/ssr", "leptos_meta/ssr", "leptos_router/ssr"]
+jsonlogic = ["superposition_types/jsonlogic"]
 
 [lints]
 workspace = true

--- a/crates/frontend/src/components/condition_pills.rs
+++ b/crates/frontend/src/components/condition_pills.rs
@@ -1,5 +1,5 @@
 use crate::{
-    logic::{Condition, Conditions, Expression, Operator},
+    logic::{Condition, Conditions, Operator},
     schema::HtmlDisplay,
 };
 
@@ -92,7 +92,8 @@ pub fn condition_expression(
                     </span>
 
                     {match condition.get_value().expression {
-                        Expression::Between(c1, c2) => {
+                        #[cfg(feature = "jsonlogic")]
+                        crate::logic::Expression::Between(c1, c2) => {
                             view! {
                                 <>
                                     <span class="font-semibold context_condition">

--- a/crates/frontend/src/components/context_card.rs
+++ b/crates/frontend/src/components/context_card.rs
@@ -12,7 +12,7 @@ use crate::{
         description_icon::InfoDescription,
         table::{types::Column, Table},
     },
-    logic::{Conditions, Expression},
+    logic::Conditions,
 };
 
 #[component]
@@ -128,10 +128,16 @@ pub fn context_card(
     let actions_supported =
         show_actions && !conditions.0.iter().any(|c| c.variable == "variantIds");
 
-    let edit_unsupported = conditions
-        .0
-        .iter()
-        .any(|c| matches!(c.expression, Expression::Other(_, _)));
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "jsonlogic")] {
+            let edit_unsupported = conditions
+                .0
+                .iter()
+                .any(|c| matches!(c.expression, crate::logic::Expression::Other(_, _)));
+        } else {
+            let edit_unsupported = false;
+        }
+    }
 
     view! {
         <div class="rounded-lg shadow bg-base-100 p-6 flex flex-col gap-4">

--- a/crates/frontend/src/components/input.rs
+++ b/crates/frontend/src/components/input.rs
@@ -72,9 +72,10 @@ impl From<(SchemaType, EnumVariants)> for InputType {
 
 impl From<(SchemaType, EnumVariants, Operator)> for InputType {
     fn from(
-        (schema_type, enum_variants, operator): (SchemaType, EnumVariants, Operator),
+        (schema_type, enum_variants, _operator): (SchemaType, EnumVariants, Operator),
     ) -> Self {
-        if operator == Operator::In {
+        #[cfg(feature = "jsonlogic")]
+        if _operator == Operator::In {
             let EnumVariants(ev) = enum_variants;
             return InputType::Monaco(ev);
         }
@@ -116,6 +117,7 @@ fn parse_with_operator(
     op: &Operator,
 ) -> Result<Value, String> {
     match op {
+        #[cfg(feature = "jsonlogic")]
         Operator::In => match type_ {
             JsonSchemaType::String => serde_json::from_str::<Vec<String>>(s)
                 .map(|v| json!(v))

--- a/crates/frontend/src/components/workspace_form.rs
+++ b/crates/frontend/src/components/workspace_form.rs
@@ -41,6 +41,7 @@ pub fn workspace_form(
     let (mandatory_dimensions_rs, mandatory_dimensions_ws) =
         create_signal(mandatory_dimensions);
     let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
+    #[cfg(feature = "jsonlogic")]
     let (strict_mode_rs, strict_mode_ws) = create_signal(true);
     let metrics_rws = RwSignal::new(metrics);
     let allow_experiment_self_approval_rs = RwSignal::new(allow_experiment_self_approval);
@@ -80,6 +81,7 @@ pub fn workspace_form(
                         workspace_admin_email: workspace_admin_email_rs.get_untracked(),
                         workspace_name: workspace_name_rs.get_untracked(),
                         workspace_status: Some(workspace_status_rs.get_untracked()),
+                        #[cfg(feature = "jsonlogic")]
                         strict_mode: strict_mode_rs.get_untracked(),
                         metrics: Some(metrics_rws.get_untracked()),
                         allow_experiment_self_approval: allow_experiment_self_approval_rs
@@ -115,6 +117,29 @@ pub fn workspace_form(
                 }
             }
         });
+    };
+
+    cfg_if::cfg_if! {
+        if #[cfg(feature = "jsonlogic")] {
+            let strict_mode =
+                view! {
+                    <Show when=move || !edit>
+                        <div class="w-fit flex items-center gap-2">
+                            <Toggle
+                                name="workspace-strict-mode"
+                                value=strict_mode_rs.get_untracked()
+                                on_change=move |_| strict_mode_ws.update(|v| *v = !*v)
+                            />
+                            <Label
+                                title="Strict Mode"
+                                extra_info="Strict Mode limits the operators available to just ==. This is the recommended mode for production environments"
+                            />
+                        </div>
+                    </Show>
+                }.into_view();
+        } else {
+            let strict_mode = ().into_view();
+        }
     };
 
     view! {
@@ -214,19 +239,7 @@ pub fn workspace_form(
                     <Label title="Allow self approval for Experiments" />
                 </div>
 
-                <Show when=move || !edit>
-                    <div class="w-fit flex items-center gap-2">
-                        <Toggle
-                            name="workspace-strict-mode"
-                            value=strict_mode_rs.get_untracked()
-                            on_change=move |_| strict_mode_ws.update(|v| *v = !*v)
-                        />
-                        <Label
-                            title="Strict Mode"
-                            extra_info="Strict Mode limits the operators available to just ==. This is the recommended mode for production environments"
-                        />
-                    </div>
-                </Show>
+                {strict_mode}
 
                 <div class="w-fit flex items-center gap-2">
                     <Toggle

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -32,6 +32,7 @@ urlencoding = "~2.1.2"
 
 [features]
 high-performance-mode = ["dep:fred"]
+jsonlogic = ["superposition_types/jsonlogic"]
 
 [lints]
 workspace = true

--- a/crates/service_utils/src/helpers.rs
+++ b/crates/service_utils/src/helpers.rs
@@ -15,12 +15,14 @@ use reqwest::{
     StatusCode,
 };
 use serde::Serialize;
+#[cfg(feature = "jsonlogic")]
 use serde_json::{Map, Value};
+#[cfg(feature = "jsonlogic")]
+use superposition_types::Condition;
 use superposition_types::{
     api::webhook::{HeadersEnum, WebhookEventInfo, WebhookResponse},
     database::models::others::{HttpMethod, Webhook, WebhookEvent},
     result::{self},
-    Condition,
 };
 
 use crate::service::types::{AppState, WorkspaceContext};
@@ -103,6 +105,7 @@ pub fn get_pod_info() -> (String, String) {
     (pod_id, deployment_id)
 }
 
+#[cfg(feature = "jsonlogic")]
 pub fn extract_dimensions(context: &Condition) -> result::Result<Map<String, Value>> {
     // Assuming max 2-level nesting in context json logic
 
@@ -139,6 +142,7 @@ pub fn extract_dimensions(context: &Condition) -> result::Result<Map<String, Val
     Ok(Map::from_iter(dimension_tuples))
 }
 
+#[cfg(feature = "jsonlogic")]
 pub fn get_variable_name_and_value(operands: &[Value]) -> result::Result<(&str, &Value)> {
     let (obj_pos, variable_obj) = operands
         .iter()

--- a/crates/superposition/Cargo.toml
+++ b/crates/superposition/Cargo.toml
@@ -10,7 +10,6 @@ actix-files = { version = "0.6" }
 actix-web = { workspace = true }
 anyhow = { workspace = true }
 aws-sdk-kms = { workspace = true }
-cfg-if = { workspace = true }
 chrono = { workspace = true }
 context_aware_config = { path = "../context_aware_config" }
 diesel = { workspace = true }
@@ -41,6 +40,13 @@ high-performance-mode = [
     "context_aware_config/high-performance-mode",
     "service_utils/high-performance-mode",
     "dep:fred",
+]
+jsonlogic = [
+    "context_aware_config/jsonlogic",
+    "experimentation_platform/jsonlogic",
+    "frontend/jsonlogic",
+    "service_utils/jsonlogic",
+    "superposition_types/jsonlogic",
 ]
 
 [lints]

--- a/crates/superposition/src/workspace/handlers.rs
+++ b/crates/superposition/src/workspace/handlers.rs
@@ -112,7 +112,10 @@ async fn create_workspace(
         last_modified_at: timestamp,
         created_at: timestamp,
         mandatory_dimensions: None,
+        #[cfg(feature = "jsonlogic")]
         strict_mode: request.strict_mode,
+        #[cfg(not(feature = "jsonlogic"))]
+        strict_mode: true,
         metrics: request.metrics.unwrap_or_default(),
         allow_experiment_self_approval: request.allow_experiment_self_approval,
         auto_populate_control: request.auto_populate_control,

--- a/crates/superposition_core/Cargo.toml
+++ b/crates/superposition_core/Cargo.toml
@@ -10,24 +10,31 @@ readme = "README.md"
 
 [dependencies]
 actix-web = { workspace = true }
+anyhow = { workspace = true }
+cfg-if = { workspace = true }
 chrono = { workspace = true }
 derive_more = { workspace = true }
 itertools = { workspace = true }
-jsonlogic = { workspace = true }
+jsonlogic = { workspace = true, optional = true }
 log = { workspace = true }
 mini-moka = { version = "0.10.3" }
 once_cell = { workspace = true }
+rand = "0.9.1"
 reqwest = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 strum = { workspace = true }
 strum_macros = { workspace = true }
-superposition_types = { workspace = true, features = ["experimentation", "api"] }
-tokio = { version = "1.29.1", features = ["full"] }
-serde = { workspace = true }
-uniffi = { workspace = true }
-anyhow = { workspace = true }
+superposition_types = { workspace = true, features = [
+    "experimentation",
+    "api",
+] }
 thiserror = { version = "1.0.57" }
-rand = "0.9.1"
+tokio = { version = "1.29.1", features = ["full"] }
+uniffi = { workspace = true }
+
+[features]
+jsonlogic = ["dep:jsonlogic", "superposition_types/jsonlogic"]
 
 [dev-dependencies]
 uniffi = { workspace = true }

--- a/crates/superposition_core/src/ffi.rs
+++ b/crates/superposition_core/src/ffi.rs
@@ -27,8 +27,17 @@ fn json_from_map(m: HashMap<String, String>) -> serde_json::Result<Map<String, V
         .collect::<serde_json::Result<Map<String, Value>>>()
 }
 
+type EvalFn = fn(
+    Map<String, Value>,
+    &[Context],
+    &HashMap<String, Overrides>,
+    &Map<String, Value>,
+    MergeStrategy,
+    Option<Vec<String>>,
+) -> Result<Map<String, Value>, String>;
+
 #[allow(clippy::too_many_arguments)]
-fn ffi_eval_logic<F>(
+fn ffi_eval_logic(
     default_config: HashMap<String, String>,
     contexts: &[Context],
     overrides: HashMap<String, Overrides>,
@@ -36,18 +45,8 @@ fn ffi_eval_logic<F>(
     merge_strategy: MergeStrategy,
     filter_prefixes: Option<Vec<String>>,
     experimentation: Option<ExperimentationArgs>,
-    eval_fn: F,
-) -> Result<HashMap<String, String>, OperationError>
-where
-    F: FnOnce(
-        Map<String, Value>,
-        &[Context],
-        &HashMap<String, Overrides>,
-        &Map<String, Value>,
-        MergeStrategy,
-        Option<Vec<String>>,
-    ) -> Result<Map<String, Value>, String>,
-{
+    eval_fn: EvalFn,
+) -> Result<HashMap<String, String>, OperationError> {
     let _d = json_from_map(default_config)
         .map_err(|err| OperationError::Unexpected(err.to_string()))?;
     let mut _q = json_from_map(query_data)

--- a/crates/superposition_types/Cargo.toml
+++ b/crates/superposition_types/Cargo.toml
@@ -22,7 +22,7 @@ diesel = { workspace = true, optional = true }
 diesel-derive-enum = { version = "2.0.1", features = [
     "postgres",
 ], optional = true }
-jsonlogic = { workspace = true }
+jsonlogic = { workspace = true, optional = true }
 log = { workspace = true }
 regex = { workspace = true }
 serde = { workspace = true }
@@ -46,6 +46,7 @@ diesel_derives = [
     "dep:base64",
 ]
 disable_db_data_validation = []
+jsonlogic = ["dep:jsonlogic"]
 result = ["dep:diesel", "dep:anyhow", "dep:thiserror", "dep:actix-web"]
 server = ["dep:actix-web"]
 experimentation = []

--- a/crates/superposition_types/src/api/workspace.rs
+++ b/crates/superposition_types/src/api/workspace.rs
@@ -43,7 +43,10 @@ impl From<Workspace> for WorkspaceResponse {
             last_modified_at: workspace.last_modified_at,
             created_at: workspace.created_at,
             mandatory_dimensions: workspace.mandatory_dimensions,
+            #[cfg(feature = "jsonlogic")]
             strict_mode: workspace.strict_mode,
+            #[cfg(not(feature = "jsonlogic"))]
+            strict_mode: true,
             metrics: workspace.metrics,
             allow_experiment_self_approval: workspace.allow_experiment_self_approval,
             auto_populate_control: workspace.auto_populate_control,
@@ -56,6 +59,7 @@ pub struct CreateWorkspaceRequest {
     pub workspace_admin_email: String,
     pub workspace_name: String,
     pub workspace_status: Option<WorkspaceStatus>,
+    #[cfg(feature = "jsonlogic")]
     #[serde(alias = "workspace_strict_mode")]
     pub strict_mode: bool,
     pub metrics: Option<Metrics>,

--- a/crates/superposition_types/src/logic.rs
+++ b/crates/superposition_types/src/logic.rs
@@ -1,0 +1,39 @@
+use serde_json::{Map, Value};
+
+fn apply_logic(
+    condition: &Map<String, Value>,
+    context: &Map<String, Value>,
+    partial: bool,
+) -> bool {
+    for (dimension, value) in condition {
+        if let Some(context_value) = context.get(dimension) {
+            if dimension == "variantIds" {
+                if let Value::Array(ref context_values) = context_value {
+                    if !context_values.contains(value) {
+                        return false;
+                    }
+                } else {
+                    return false;
+                }
+            } else if *context_value != *value {
+                return false;
+            }
+        } else if partial {
+            continue;
+        } else {
+            return false;
+        }
+    }
+    true
+}
+
+pub fn apply(condition: &Map<String, Value>, context: &Map<String, Value>) -> bool {
+    apply_logic(condition, context, false)
+}
+
+pub fn partial_apply(
+    condition: &Map<String, Value>,
+    context: &Map<String, Value>,
+) -> bool {
+    apply_logic(condition, context, true)
+}

--- a/makefile
+++ b/makefile
@@ -5,6 +5,7 @@ DOCKER_DNS ?= localhost
 TENANT ?= dev
 SHELL := /usr/bin/env bash
 FEATURES ?= ssr
+FE_FEATURES ?= hydrate
 CARGO_FLAGS := --color always --no-default-features
 EXCLUDE_PACKAGES := experimentation_client_integration_example superposition_sdk
 FMT_EXCLUDE_PACKAGES_REGEX := $(shell echo "$(EXCLUDE_PACKAGES)" | sed "s/ /|/g")
@@ -146,7 +147,7 @@ kill:
 get-password:
 	export DB_PASSWORD=`./docker-compose/localstack/get_db_password.sh` && echo $$DB_PASSWORD
 
-superposition: CARGO_FLAGS += --features=$(FEATURES)
+superposition: CARGO_FLAGS += --features='$(FEATURES)'
 superposition:
 	cargo build $(CARGO_FLAGS) --bin superposition
 	@cd target && ln -s ../node_modules node_modules || true
@@ -161,7 +162,11 @@ superposition_legacy: CARGO_FLAGS += experimentation_platform/disable_db_data_va
 superposition_legacy:
 	cargo build $(CARGO_FLAGS) --bin superposition
 
-superposition_dev: CARGO_FLAGS += --features=$(FEATURES)
+superposition_jsonlogic: CARGO_FLAGS += --features='$(FEATURES) jsonlogic'
+superposition_jsonlogic:
+	cargo build $(CARGO_FLAGS) --bin superposition
+
+superposition_dev: CARGO_FLAGS += --features='$(FEATURES)'
 superposition_dev:
 	# export DB_PASSWORD=`./docker-compose/localstack/get_db_password.sh`
 	cargo watch -x 'run $(CARGO_FLAGS) --bin superposition'
@@ -169,7 +174,7 @@ superposition_dev:
 
 frontend:
 	cd crates/frontend && \
-		wasm-pack build --target web $(WASM_PACK_MODE) --no-default-features --features hydrate
+		wasm-pack build --target web $(WASM_PACK_MODE) --no-default-features --features '$(FE_FEATURES)'
 	cd crates/frontend && \
 		npx tailwindcss -i ./styles/tailwind.css -o ./pkg/style.css
 	-rm -rf target/site
@@ -191,6 +196,10 @@ run: kill db localstack frontend superposition
 run_legacy: kill build db localstack superposition_legacy
 	@./target/debug/superposition
 
+run_jsonlogic: FE_FEATURES += jsonlogic
+run_jsonlogic: kill build db localstack superposition_jsonlogic
+	@./target/debug/superposition
+
 test: WASM_PACK_MODE=--profiling
 test: setup frontend superposition
 	cargo test
@@ -203,6 +212,21 @@ test: setup frontend superposition
 				--retry-all-errors \
 				'http://localhost:8080/health' 2>&1 > /dev/null
 	cd tests && bun test
+	-@pkill -f target/debug/superposition &
+
+test_jsonlogic: WASM_PACK_MODE=--profiling
+test_jsonlogic: FE_FEATURES += jsonlogic
+test_jsonlogic: setup frontend superposition_jsonlogic
+	cargo test --features=jsonlogic
+	@echo "Running superposition"
+	@./target/debug/superposition &
+	@echo "Awaiting superposition boot..."
+## FIXME Curl doesn't retry.
+	@curl	--silent --retry 10 \
+				--connect-timeout 2 \
+				--retry-all-errors \
+				'http://localhost:8080/health' 2>&1 > /dev/null
+	cd tests && export JSONLOGIC_ENABLED=true && bun test
 	-@pkill -f target/debug/superposition &
 
 ## npm run test

--- a/tests/env.ts
+++ b/tests/env.ts
@@ -4,6 +4,7 @@ export let ENV: any = {
     baseUrl: "http://127.0.0.1:8080",
     org_id: undefined,
     workspace_id: undefined,
+    jsonlogic_enabled: process.env.JSONLOGIC_ENABLED === "true" ? true : false,
 };
 
 const config: any = {

--- a/tests/src/dimension.test.ts
+++ b/tests/src/dimension.test.ts
@@ -194,6 +194,29 @@ describe("Dimension API", () => {
         }
     });
 
+    test("CreateDimension: should reject non primitive type for dimension", async () => {
+        if (ENV.jsonlogic_enabled) {
+            console.log(
+                "Skipping non primitive type update test because JSONLogic is enabled"
+            );
+            return;
+        }
+        const invalidPositionInput = {
+            workspace_id: ENV.workspace_id,
+            org_id: ENV.org_id,
+            dimension: `test-dimension-non-primitive-${Date.now()}`,
+            position: 1,
+            schema: { type: "object" },
+            description: "Test dimension with non primitive type",
+            change_reason: "Testing non primitive validation",
+        };
+
+        const cmd = new CreateDimensionCommand(invalidPositionInput);
+        expect(superpositionClient.send(cmd)).rejects.toThrow(
+            /Invalid schema: expected a primitive type or an array of primitive types/i
+        );
+    });
+
     test("CreateDimension: should reject duplicate position", async () => {
         // Fail if dimension wasn't created
         if (!createdDimension) {
@@ -357,6 +380,27 @@ describe("Dimension API", () => {
             console.error(e["$response"]);
             throw e;
         }
+    });
+
+    test("UpdateDimension: should reject updating to non primitive type", async () => {
+        if (ENV.jsonlogic_enabled) {
+            console.log(
+                "Skipping non primitive type update test because JSONLogic is enabled"
+            );
+            return;
+        }
+        const input = {
+            workspace_id: ENV.workspace_id,
+            org_id: ENV.org_id,
+            dimension: createdDimension.dimension,
+            schema: { type: "object" }, // Non primitive type
+            change_reason: "Testing error handling",
+        };
+
+        const cmd = new UpdateDimensionCommand(input);
+        expect(superpositionClient.send(cmd)).rejects.toThrow(
+            /Invalid schema: expected a primitive type or an array of primitive types/i
+        );
     });
 
     test("UpdateDimension: should handle non-existent dimension", async () => {

--- a/tests/src/experiments.test.ts
+++ b/tests/src/experiments.test.ts
@@ -47,12 +47,17 @@ describe("Experiments API", () => {
     const defaultChangeReason = "Automated Test";
     const defaultDescription = "Created by automated test";
 
-    const experiment1Context = {
-        and: [
-            { "==": [{ var: "os" }, "ios"] },
-            { "==": [{ var: "clientId" }, "testClientCac1"] },
-        ],
-    };
+    const experiment1Context = ENV.jsonlogic_enabled
+        ? {
+              and: [
+                  { "==": [{ var: "os" }, "ios"] },
+                  { "==": [{ var: "clientId" }, "testClientCac1"] },
+              ],
+          }
+        : {
+              os: "ios",
+              clientId: "testClientCac1",
+          };
     const experiment1InitialVariants: Omit<
         Variant,
         "id" | "context_id" | "override_id"
@@ -70,12 +75,17 @@ describe("Experiments API", () => {
         },
     ];
 
-    const experiment2Context = {
-        and: [
-            { "==": [{ var: "os" }, "ios"] },
-            { "==": [{ var: "clientId" }, "testClientCac02"] },
-        ],
-    };
+    const experiment2Context = ENV.jsonlogic_enabled
+        ? {
+              and: [
+                  { "==": [{ var: "os" }, "ios"] },
+                  { "==": [{ var: "clientId" }, "testClientCac02"] },
+              ],
+          }
+        : {
+              os: "ios",
+              clientId: "testClientCac02",
+          };
     const experiment2InitialVariants: Omit<
         Variant,
         "id" | "context_id" | "override_id"
@@ -94,12 +104,17 @@ describe("Experiments API", () => {
     ];
 
     // Experiment group context (common base for both experiments)
-    const experimentGroupContext = {
-        and: [
-            { "==": [{ var: "os" }, "ios"] },
-            { "==": [{ var: "clientId" }, "testClientCac1"] },
-        ],
-    };
+    const experimentGroupContext = ENV.jsonlogic_enabled
+        ? {
+              and: [
+                  { "==": [{ var: "os" }, "ios"] },
+                  { "==": [{ var: "clientId" }, "testClientCac1"] },
+              ],
+          }
+        : {
+              os: "ios",
+              clientId: "testClientCac1",
+          };
 
     const auto_populate_test_workspace = `temptestexp${Date.now() % 10000}`;
 


### PR DESCRIPTION
Crate wise summary of changes for removing `jsonlogic`:
1. cac_client:
a. use custom logic for evaluation
2. context_aware_config
a. context validation logic - removal of strict mode checks
b. changes in places requiring the list of dimensions used in the condition of the override context
c. change in logic to validate the dimensions used in the condition of the override context
d. dimension schema restricted to primitive types only (rejecting `array` and `object` types)
3. experimentation_client
a. use of custom `apply` and `partial_apply` logic for evaluation and filtering
4. experimentation_platform
a. changes in places requiring the list of dimensions used in the context of the experiment
b. change in logic of adding `variantIds` while creating override contexts for experiments
5. frontend
a. `strict_mode` option and details totally made hidden
b. relies on the fact that backend is returning `strict_mode` as `true` for all workspaces, in case, strict mode is forcibly made true, other operator options are also removed from UI
c. `variantIds` in context even though is a simple string, retained `has` syntactic sugar in the UI
d. change in context parsing logic (not to expect `jsonlogic`, but just a simple map)
6. service_utils
a. disabled `jsonlogic` related functions
7. superposition
a. `strict_mode` option is not unavailable to the APIs and is forced to `true` while creating workspaces
8. superposition_core
a. use of custom `apply` and `partial_apply` logic for evaluation and filtering
9. superposition_types
a. addition of custom `apply` and `partial_apply` logics
i. `variantIds` has special evaluation logic, it checks if the given value of `variantIds` in the context condition is part of the `array` provided in context for evaluation, for rest of the dimensions of the context condition it does a direct `!=` check for failure
b. Changes in logic related to:
i. check if a condition is a superset of another or not
ii. validating experiment context - empty object allowed, `variantIds` not allowed
iii. validating CAC context - empty object not allowed

Note:
The context condition has been made into a simple key value pair, where even the value for `variantIds` is expected to be simple string value
key (dimension) is validated if it is a valid dimension or not
value (value for the dimension) is validated if it follows the `jsonschema` provided for the dimension