### PR TITLE
fix: Dependent dimensions UI while creating context in strict mode

### DIFF
--- a/crates/frontend/src/components/context_form.rs
+++ b/crates/frontend/src/components/context_form.rs
@@ -106,7 +106,7 @@ pub fn condition_input(
                 </label>
 
                 <select
-                    disabled=disabled || resolve_mode
+                    disabled=disabled || resolve_mode || strict_mode
                     value=operator.to_string()
                     on:input=move |event| {
                         on_operator_change
@@ -118,7 +118,7 @@ pub fn condition_input(
                 >
                     <option
                         value="=="
-                        selected={ matches!(operator, Operator::Is) } || resolve_mode
+                        selected={ matches!(operator, Operator::Is) } || resolve_mode || strict_mode
                     >
                         {if strict_mode {
                             { Operator::Is.strict_mode_display().to_uppercase() }

--- a/crates/frontend/src/components/experiment_form.rs
+++ b/crates/frontend/src/components/experiment_form.rs
@@ -10,7 +10,6 @@ use superposition_types::{
         dimension::DimensionResponse,
         experiment_groups::ExpGroupFilters,
         experiments::{ExperimentResponse, OverrideKeysUpdateRequest},
-        workspace::WorkspaceResponse,
     },
     custom_query::PaginationParams,
     database::models::{
@@ -97,7 +96,6 @@ pub fn experiment_form(
     let experiment_form_type = StoredValue::new(experiment_form_type);
     let workspace = use_context::<Signal<Tenant>>().unwrap();
     let org = use_context::<Signal<OrganisationId>>().unwrap();
-    let workspace_settings = use_context::<StoredValue<WorkspaceResponse>>().unwrap();
 
     let (experiment_name, set_experiment_name) = create_signal(name);
     let (context_rs, context_ws) = create_signal(context.clone());
@@ -305,7 +303,6 @@ pub fn experiment_form(
                         dimensions=dimensions.get_value()
                         context=context_rs.get_untracked()
                         on_context_change=move |new_context| context_ws.set(new_context)
-                        resolve_mode=workspace_settings.get_value().strict_mode
                         disabled=edit_id.get_value().is_some()
                             || (experiment_form_type.get_value() != ExperimentFormType::Default)
                         heading_sub_text=String::from(

--- a/crates/frontend/src/components/experiment_group_form.rs
+++ b/crates/frontend/src/components/experiment_group_form.rs
@@ -6,7 +6,6 @@ use superposition_types::{
     api::{
         dimension::DimensionResponse,
         experiment_groups::{ExpGroupMemberRequest, ExpGroupUpdateRequest},
-        workspace::WorkspaceResponse,
     },
     database::models::{experimentation::ExperimentGroup, ChangeReason},
 };
@@ -181,7 +180,6 @@ pub fn experiment_group_form(
     let workspace = use_context::<Signal<Tenant>>().unwrap();
     let org = use_context::<Signal<OrganisationId>>().unwrap();
     let experiment_group_id = StoredValue::new(group_id);
-    let workspace_settings = use_context::<StoredValue<WorkspaceResponse>>().unwrap();
     let (context_rs, context_ws) = create_signal(context);
     let group_name_rws = create_rw_signal(group_name);
     let group_description_rws = create_rw_signal(group_description);
@@ -302,7 +300,6 @@ pub fn experiment_group_form(
                     dimensions=dimensions
                     context=context_rs.get_untracked()
                     on_context_change=move |new_context| context_ws.set(new_context)
-                    resolve_mode=workspace_settings.get_value().strict_mode
                     disabled=is_edit
                     heading_sub_text="Define rules under which this experiment group would function"
                     fn_environment

--- a/crates/frontend/src/pages/context_override.rs
+++ b/crates/frontend/src/pages/context_override.rs
@@ -100,7 +100,6 @@ fn form(
 ) -> impl IntoView {
     let workspace = use_context::<Signal<Tenant>>().unwrap();
     let org = use_context::<Signal<OrganisationId>>().unwrap();
-    let workspace_settings = use_context::<StoredValue<WorkspaceResponse>>().unwrap();
     let (context_rs, context_ws) = create_signal(context);
     let (overrides_rs, overrides_ws) = create_signal(overrides);
     let dimensions = StoredValue::new(dimensions);
@@ -192,7 +191,6 @@ fn form(
         <div class="flex flex-col gap-5">
             <ContextForm
                 dimensions=dimensions.get_value()
-                resolve_mode=workspace_settings.with_value(|w| w.strict_mode)
                 context=context_rs.get_untracked()
                 on_context_change=move |new_context| context_ws.set(new_context)
                 fn_environment


### PR DESCRIPTION
## Problem
On selecting a dimension, the dependent dimensions were not coming up in the UI

## Solution
Fix the usage of resolve_mode with respect to strict_mode
