### PR TITLE
[WIP] fix(hs-sdk): Content-type header missing in hs-sdk.

### DIFF
--- a/clients/generated/smithy/haskell/Io/Superposition/Command/AddMembersToGroup.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/AddMembersToGroup.hs
@@ -68,9 +68,11 @@ serAddMembersToGroupHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/ApplicableVariants.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/ApplicableVariants.hs
@@ -63,9 +63,11 @@ serApplicableVariantsHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/BulkOperation.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/BulkOperation.hs
@@ -65,10 +65,12 @@ serBulkOperationHEADER input =
         
                     Data.Functor.<&> \x -> [("x-config-tags", Data.Text.Encoding.encodeUtf8 x)]
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
             org_idHeader,
-            config_tagsHeader
+            config_tagsHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/ConcludeExperiment.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/ConcludeExperiment.hs
@@ -68,9 +68,11 @@ serConcludeExperimentHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/CreateContext.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/CreateContext.hs
@@ -71,10 +71,12 @@ serCreateContextHEADER input =
         
                     Data.Functor.<&> \x -> [("x-config-tags", Data.Text.Encoding.encodeUtf8 x)]
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
             org_idHeader,
-            config_tagsHeader
+            config_tagsHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/CreateDefaultConfig.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/CreateDefaultConfig.hs
@@ -68,9 +68,11 @@ serCreateDefaultConfigHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/CreateDimension.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/CreateDimension.hs
@@ -70,9 +70,11 @@ serCreateDimensionHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/CreateExperiment.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/CreateExperiment.hs
@@ -73,9 +73,11 @@ serCreateExperimentHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/CreateExperimentGroup.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/CreateExperimentGroup.hs
@@ -70,9 +70,11 @@ serCreateExperimentGroupHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/CreateFunction.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/CreateFunction.hs
@@ -68,9 +68,11 @@ serCreateFunctionHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/CreateTypeTemplates.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/CreateTypeTemplates.hs
@@ -65,9 +65,11 @@ serCreateTypeTemplatesHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/CreateWebhook.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/CreateWebhook.hs
@@ -73,9 +73,11 @@ serCreateWebhookHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/CreateWorkspace.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/CreateWorkspace.hs
@@ -63,8 +63,10 @@ serCreateWorkspaceHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/DiscardExperiment.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/DiscardExperiment.hs
@@ -66,9 +66,11 @@ serDiscardExperimentHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/GetConfig.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/GetConfig.hs
@@ -91,9 +91,11 @@ serGetConfigHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/GetContextFromCondition.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/GetContextFromCondition.hs
@@ -64,9 +64,11 @@ serGetContextFromConditionHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/GetResolvedConfig.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/GetResolvedConfig.hs
@@ -105,10 +105,12 @@ serGetResolvedConfigHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
             merge_strategyHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/MoveContext.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/MoveContext.hs
@@ -67,9 +67,11 @@ serMoveContextHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/PauseExperiment.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/PauseExperiment.hs
@@ -66,9 +66,11 @@ serPauseExperimentHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/Publish.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/Publish.hs
@@ -65,9 +65,11 @@ serPublishHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/RampExperiment.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/RampExperiment.hs
@@ -67,9 +67,11 @@ serRampExperimentHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/RemoveMembersFromGroup.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/RemoveMembersFromGroup.hs
@@ -68,9 +68,11 @@ serRemoveMembersFromGroupHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/ResumeExperiment.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/ResumeExperiment.hs
@@ -66,9 +66,11 @@ serResumeExperimentHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/Test.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/Test.hs
@@ -63,9 +63,11 @@ serTestHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateDefaultConfig.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateDefaultConfig.hs
@@ -69,9 +69,11 @@ serUpdateDefaultConfigHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateDimension.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateDimension.hs
@@ -71,9 +71,11 @@ serUpdateDimensionHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateExperimentGroup.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateExperimentGroup.hs
@@ -69,9 +69,11 @@ serUpdateExperimentGroupHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateFunction.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateFunction.hs
@@ -68,9 +68,11 @@ serUpdateFunctionHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateOverride.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateOverride.hs
@@ -69,10 +69,12 @@ serUpdateOverrideHEADER input =
         
                     Data.Functor.<&> \x -> [("x-config-tags", Data.Text.Encoding.encodeUtf8 x)]
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
             org_idHeader,
-            config_tagsHeader
+            config_tagsHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateOverridesExperiment.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateOverridesExperiment.hs
@@ -70,9 +70,11 @@ serUpdateOverridesExperimentHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateTypeTemplates.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateTypeTemplates.hs
@@ -66,9 +66,11 @@ serUpdateTypeTemplatesHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateWebhook.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateWebhook.hs
@@ -74,9 +74,11 @@ serUpdateWebhookHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
             workspace_idHeader,
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateWorkspace.hs
+++ b/clients/generated/smithy/haskell/Io/Superposition/Command/UpdateWorkspace.hs
@@ -65,8 +65,10 @@ serUpdateWorkspaceHEADER input =
                     Data.Function.& \x -> [("x-org-id", Data.Text.Encoding.encodeUtf8 x)]
                     Data.Function.& Data.Maybe.Just
         
+        contentType = Just [("content-type", "application/json")]
         in Data.List.concat $ Data.Maybe.catMaybes [
-            org_idHeader
+            org_idHeader,
+            contentType
             ]
         
     

--- a/smithy/smithy-build.json
+++ b/smithy/smithy-build.json
@@ -15,7 +15,7 @@
       "software.amazon.smithy.python.codegen:core:0.0.1",
       "software.amazon.smithy.java:client-core:0.0.1",
       "software.amazon.smithy.java.codegen:plugins:0.0.1",
-      "in.juspay.smithy.haskell:client-codegen:0.0.2-dev",
+      "in.juspay.smithy.haskell:client-codegen:0.0.3-dev",
       "software.amazon.smithy.java:aws-client-restjson:0.0.1"
     ]
   },


### PR DESCRIPTION
Content-type header missing in hs-sdk, used patched generator & re-generated it.