### PR TITLE
docs: add README.md for examples

### DIFF
--- a/examples/cac_redis_module/README.md
+++ b/examples/cac_redis_module/README.md
@@ -1,0 +1,311 @@
+# CAC Redis Module
+
+A Redis module that integrates Superposition's Context-Aware Configuration (CAC) system directly into Redis, enabling configuration resolution through Redis commands with context-based logic evaluation.
+
+## Overview
+
+The `cac_redis_module` extends Redis with custom commands that allow clients to resolve configurations based on contextual data using Superposition's configuration engine. This module brings the power of context-aware configuration directly to Redis, making it accessible through standard Redis protocols.
+
+## Features
+
+- **Context-Aware Configuration**: Resolve configurations based on dynamic context conditions using JSONLogic
+- **Redis Integration**: Access configuration resolution through Redis commands
+- **Real-time Configuration**: Load and evaluate configurations from local JSON files
+- **Multiple Merge Strategies**: Support for MERGE and REPLACE strategies when applying overrides
+- **Error Handling**: Comprehensive error reporting with timestamps and detailed messages
+
+## Architecture
+
+The module consists of several key components:
+
+- **Core Module** (`lib.rs`): Main Redis module implementation with custom commands
+- **Configuration Engine** (`config.rs`): Local implementation of Superposition's configuration evaluation logic
+- **Configuration Data** (`cac_config.json`): JSON file containing contexts, overrides, and default configurations
+
+## Installation
+
+### Prerequisites
+
+- Rust 1.70 or later
+- Redis server 6.0 or later
+- Git (for dependencies)
+
+### Building the Module
+
+1. Clone the Superposition repository:
+```bash
+git clone https://github.com/juspay/superposition.git
+cd superposition/examples/cac_redis_module
+```
+
+2. Build the Redis module:
+```bash
+cargo build --release
+```
+
+3. The compiled module will be available at `target/release/libredis_module_cac.so` (Linux) or `target/release/libredis_module_cac.dylib` (macOS).
+
+### Loading the Module
+
+Start Redis with the module loaded:
+
+```bash
+redis-server --loadmodule ./target/release/libredis_module_cac.so
+```
+
+Or load the module into a running Redis instance:
+```bash
+redis-cli> MODULE LOAD /path/to/libredis_module_cac.so
+```
+
+## Configuration
+
+The module reads configuration from `src/cac_config.json`. This file contains:
+
+### Structure
+
+```json
+{
+  "contexts": [
+    {
+      "id": "context_id",
+      "condition": {
+        "and": [
+          {
+            "==": [
+              {"var": "variable_name"},
+              "expected_value"
+            ]
+          }
+        ]
+      },
+      "priority": 0,
+      "weight": 0,
+      "override_with_keys": ["override_key_id"]
+    }
+  ],
+  "overrides": {
+    "override_key_id": {
+      "config_key": "config_value"
+    }
+  },
+  "default_configs": {
+    "config_key": "default_value",
+    "numeric_config": 123,
+    "boolean_config": true
+  }
+}
+```
+
+### Configuration Elements
+
+- **Contexts**: Define conditions using JSONLogic that determine when overrides should be applied
+- **Overrides**: Key-value pairs that override default configurations when their associated contexts match
+- **Default Configs**: Base configuration values used when no overrides apply
+
+## Usage
+
+### Available Commands
+
+#### 1. CAC.HELLO
+A simple greeting command for testing module functionality.
+
+```bash
+redis-cli> CAC.HELLO "World"
+"Hello from CAC module, World!"
+```
+
+#### 2. CAC.EVAL
+Evaluates configuration based on provided context data.
+
+```bash
+redis-cli> CAC.EVAL '{"newd": "hi", "d1": "d1"}'
+```
+
+**Response Format:**
+```json
+{
+  "status": "success",
+  "result": {
+    "abcd": 2,
+    "bool": true,
+    "bool_key": false,
+    "double": 1.2,
+    "integer": 1,
+    "new": "help",
+    "new2": "hithere",
+    "object": {
+      "k1": {
+        "k2": "v1"
+      }
+    },
+    "string": "something"
+  },
+  "query_data": {
+    "newd": "hi",
+    "d1": "d1"
+  },
+  "timestamp": 1703123456,
+  "eval_type": "config_evaluation_with_file"
+}
+```
+
+#### 3. HELLO.MUL
+A utility command that multiplies numbers (example from Redis module template).
+
+```bash
+redis-cli> HELLO.MUL 2 3 4
+1) (integer) 2
+2) (integer) 3
+3) (integer) 4
+4) (integer) 24
+```
+
+### Example Usage Scenarios
+
+#### Basic Configuration Resolution
+
+```bash
+# Query with context that matches a condition
+redis-cli> CAC.EVAL '{"d1": "d1"}'
+
+# Query with context that doesn't match any condition
+redis-cli> CAC.EVAL '{"unknown": "value"}'
+```
+
+#### Experiment Variant Selection
+
+```bash
+# Query with variant context for A/B testing
+redis-cli> CAC.EVAL '{"d1": "d1", "variantIds": ["7346449145428840448-experimental"]}'
+```
+
+#### Numeric Context Evaluation
+
+```bash
+# Query with numeric conditions
+redis-cli> CAC.EVAL '{"new104": 5}'
+```
+
+## Error Handling
+
+The module provides detailed error messages for various scenarios:
+
+### Invalid JSON Input
+```json
+{
+  "status": "error",
+  "message": "Invalid JSON: expected value at line 1 column 1",
+  "input": "invalid_json",
+  "timestamp": 1703123456
+}
+```
+
+### Configuration Load Errors
+```json
+{
+  "status": "error",
+  "message": "Failed to load configuration: No such file or directory (os error 2)",
+  "timestamp": 1703123456
+}
+```
+
+### Invalid Query Data Type
+```json
+{
+  "status": "error",
+  "message": "Query data must be a JSON object",
+  "received_type": "string",
+  "timestamp": 1703123456
+}
+```
+
+## Performance Considerations
+
+- **File I/O**: Configuration is loaded from disk on each evaluation. For production use, consider caching mechanisms
+- **JSON Parsing**: JSONLogic evaluation is performed for each context condition
+- **Memory Usage**: Module keeps minimal state; most data is processed per request
+
+## Development
+
+### Dependencies
+
+The module uses these key dependencies:
+
+- `redis-module`: Redis module SDK for Rust
+- `serde_json`: JSON serialization/deserialization
+- `jsonlogic`: JSONLogic rule evaluation engine
+- `superposition_types`: Superposition's type definitions
+
+### Extending the Module
+
+To add new commands:
+
+1. Define the command function in `lib.rs`:
+```rust
+fn my_command(_: &Context, args: Vec<RedisString>) -> RedisResult {
+    // Command implementation
+    Ok("response".into())
+}
+```
+
+2. Register the command in the `redis_module!` macro:
+```rust
+redis_module! {
+    name: "cac",
+    version: 1,
+    commands: [
+        ["my.command", my_command, "", 0, 0, 0],
+    ],
+}
+```
+
+### Testing
+
+Test the module using Redis CLI:
+
+```bash
+# Test module loading
+redis-cli> MODULE LIST
+
+# Test basic functionality
+redis-cli> CAC.HELLO "Test"
+
+# Test configuration evaluation
+redis-cli> CAC.EVAL '{"test": "value"}'
+```
+
+## Troubleshooting
+
+### Module Won't Load
+- Verify Redis version compatibility (6.0+)
+- Check file permissions on the compiled module
+- Ensure all dependencies are properly linked
+
+### Configuration Errors
+- Verify `cac_config.json` exists in the `src/` directory
+- Validate JSON syntax in the configuration file
+- Check file permissions for reading the configuration
+
+### Evaluation Errors
+- Ensure query data is valid JSON
+- Verify context conditions use proper JSONLogic syntax
+- Check that override keys referenced in contexts exist in the overrides section
+
+## Use Cases
+
+1. **Feature Flags**: Enable/disable features based on user attributes
+2. **A/B Testing**: Route traffic to different configurations based on experiment variants
+3. **Environment-Specific Configs**: Different settings for dev/staging/production
+4. **User Personalization**: Customize application behavior based on user context
+5. **Geographic Configuration**: Different settings based on user location
+
+## Security Considerations
+
+- The module reads configuration files from the local filesystem
+- No authentication is performed on Redis commands (use Redis AUTH if needed)
+- JSONLogic evaluation should be considered when exposing user-controllable context data
+
+## License
+
+This module is part of the Superposition project. Please refer to the main project's license terms.

--- a/examples/k8s-staggered-releaser/README.md
+++ b/examples/k8s-staggered-releaser/README.md
@@ -1,0 +1,454 @@
+# Kubernetes Staggered Releaser (Mayday)
+
+A Kubernetes deployment automation tool that leverages Superposition's experimentation features to perform safe, gradual rollouts with automatic traffic management and rollback capabilities.
+
+## Overview
+
+The `k8s-staggered-releaser` (internally named "Mayday") is a webhook-driven deployment orchestrator that integrates with Superposition's experimentation system to manage Kubernetes deployments. It automatically creates, updates, and manages Kubernetes resources (Deployments, Services, Ingresses) based on experiment lifecycle events from Superposition.
+
+## Features
+
+- **Webhook-Driven Automation**: Responds to Superposition experiment events via webhooks
+- **Graduated Rollouts**: Implements canary deployments with configurable traffic splitting
+- **Automatic Resource Management**: Creates and manages Kubernetes Deployments, Services, and Ingresses
+- **Multi-Namespace Support**: Deploy to different Kubernetes namespaces based on context
+- **Traffic Management**: Uses NGINX Ingress Controller for weighted traffic distribution
+- **Rollback Capability**: Automatic cleanup and rollback when experiments conclude
+- **Configuration Integration**: Fetches deployment configurations from Superposition
+
+## Architecture
+
+### Components
+
+- **Main Server** (`main.rs`): HTTP server that receives webhook events from Superposition
+- **Experiment Handler** (`experiment.rs`): Processes different experiment lifecycle events
+- **Deployment Manager** (`deployment.rs`): Creates and configures Kubernetes Deployments
+- **Service Manager** (`service.rs`): Manages Kubernetes Services for deployments
+- **Ingress Manager** (`ingress.rs`): Handles NGINX Ingress resources for traffic routing
+- **Utilities** (`utils.rs`): Common utilities and configuration constants
+
+### Workflow
+
+1. **Experiment Started**: Creates new Deployment, Service, and Ingress resources
+2. **Experiment In Progress**: Updates traffic weights for gradual rollout
+3. **Experiment Concluded**: Promotes winning variant and cleans up resources
+
+## Installation
+
+### Prerequisites
+
+- Kubernetes cluster with NGINX Ingress Controller
+- Superposition server running and accessible
+- Rust 1.70 or later for building
+- Valid Kubernetes API access token
+
+### Setup
+
+1. Clone the Superposition repository:
+```bash
+git clone https://github.com/juspay/superposition.git
+cd superposition/examples/k8s-staggered-releaser
+```
+
+2. Configure the application by editing `src/utils.rs`:
+```rust
+pub const K8S_API_SERVER: &str = "https://your-k8s-api-server:6443";
+pub const TOKEN: &str = "your-k8s-api-token";
+```
+
+3. Build the application:
+```bash
+cargo build --release
+```
+
+4. Run the webhook server:
+```bash
+cargo run
+```
+
+The server will start on `127.0.0.1:8090` and listen for webhook events at `/hi`.
+
+## Configuration
+
+### Environment Variables
+
+You can configure the following constants in `src/utils.rs`:
+
+- `K8S_API_SERVER`: Kubernetes API server URL
+- `TOKEN`: Kubernetes API authentication token
+- `NAMESPACE`: Default namespace for deployments
+
+### Superposition Integration
+
+Configure Superposition to send webhook events to this service:
+
+1. Set up a webhook in Superposition pointing to `http://your-server:8090/hi`
+2. Configure experiments with appropriate context conditions
+3. Ensure your Superposition instance can resolve configurations for deployment variants
+
+### Kubernetes RBAC
+
+The service requires the following Kubernetes permissions:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: mayday-deployer
+rules:
+- apiGroups: ["apps"]
+  resources: ["deployments"]
+  verbs: ["create", "get", "list", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["create", "get", "list", "update", "patch", "delete"]
+- apiGroups: ["networking.k8s.io"]
+  resources: ["ingresses"]
+  verbs: ["create", "get", "list", "update", "patch", "delete"]
+```
+
+## Usage
+
+### Webhook Event Types
+
+The system responds to three types of Superposition webhook events:
+
+#### 1. ExperimentStarted
+
+Triggered when a new experiment begins. Creates initial deployment infrastructure:
+
+```json
+{
+  "event_info": {
+    "webhook_event": "ExperimentStarted",
+    "workspace_id": "nginxservice"
+  },
+  "payload": {
+    "context": {
+      "and": [{
+        "==": [{"var": "namespace"}, "mumbai"]
+      }]
+    },
+    "variants": [
+      {
+        "id": "variant-123",
+        "variant_type": "EXPERIMENTAL"
+      }
+    ],
+    "traffic_percentage": 10
+  }
+}
+```
+
+**Actions Performed:**
+- Creates Kubernetes Deployment with variant configuration
+- Creates Service to expose the deployment
+- Creates Ingress with canary annotations for traffic splitting
+
+#### 2. ExperimentInprogress
+
+Triggered when experiment traffic percentage is updated:
+
+```json
+{
+  "event_info": {
+    "webhook_event": "ExperimentInprogress",
+    "workspace_id": "nginxservice"
+  },
+  "payload": {
+    "traffic_percentage": 25,
+    "variants": [...]
+  }
+}
+```
+
+**Actions Performed:**
+- Updates Ingress resources with new traffic weights
+- Adjusts canary routing configuration
+
+#### 3. ExperimentConcluded
+
+Triggered when an experiment ends with a chosen variant:
+
+```json
+{
+  "event_info": {
+    "webhook_event": "ExperimentConcluded",
+    "workspace_id": "nginxservice"
+  },
+  "payload": {
+    "chosen_variant": "variant-123",
+    "variants": [...]
+  }
+}
+```
+
+**Actions Performed:**
+- Updates main service to point to winning variant deployment
+- Removes experimental Ingress resources
+- Cleans up unused Services and Deployments
+
+### Configuration Resolution
+
+The system fetches deployment configurations from Superposition using the `/config/resolve` endpoint:
+
+```
+GET /config/resolve?namespace={namespace}&variantIds={variant_id}
+Headers:
+  x-org-id: localorg
+  x-tenant: {service_name}
+```
+
+Expected configuration format:
+```json
+{
+  "replicas": 3,
+  "container.image": "nginx:latest",
+  "env.DATABASE_URL": "postgres://...",
+  "env.API_KEY": "secret-key"
+}
+```
+
+### Deployment Resource Generation
+
+The system generates Kubernetes resources with the following patterns:
+
+#### Deployment Names
+- Pattern: `{service}-dep-{variant_id}`
+- Example: `nginxservice-dep-variant-123`
+
+#### Service Names
+- Pattern: `{service}-service-{variant_id}`
+- Example: `nginxservice-service-variant-123`
+
+#### Ingress Names
+- Pattern: `{service}-ingress-{variant_id}`
+- Example: `nginxservice-ingress-variant-123`
+
+### Traffic Management
+
+The system uses NGINX Ingress Controller canary features:
+
+```yaml
+metadata:
+  annotations:
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-weight: "25"
+spec:
+  rules:
+  - host: nginxservice.mumbai
+    http:
+      paths:
+      - path: /
+        backend:
+          service:
+            name: nginxservice-service-variant-123
+            port:
+              number: 80
+```
+
+## Examples
+
+### Complete Experiment Workflow
+
+1. **Start Experiment** (10% traffic):
+```bash
+# Webhook triggered automatically by Superposition
+# Creates:
+# - Deployment: nginxservice-dep-variant-123
+# - Service: nginxservice-service-variant-123  
+# - Ingress: nginxservice-ingress-variant-123 (10% weight)
+```
+
+2. **Increase Traffic** (25% traffic):
+```bash
+# Webhook updates traffic distribution
+# Updates:
+# - Ingress: nginxservice-ingress-variant-123 (25% weight)
+```
+
+3. **Conclude Experiment**:
+```bash
+# Webhook promotes winning variant
+# Updates:
+# - Service: nginxservice-service points to variant-123 deployment
+# Deletes:
+# - Ingress: nginxservice-ingress-variant-123
+# - Service: nginxservice-service-variant-123
+```
+
+### Manual Testing
+
+Test webhook endpoints directly:
+
+```bash
+# Test ExperimentStarted
+curl -X GET http://127.0.0.1:8090/hi \
+  -H "Content-Type: application/json" \
+  -d '{
+    "event_info": {
+      "webhook_event": "ExperimentStarted",
+      "workspace_id": "testservice"
+    },
+    "payload": {
+      "context": {
+        "and": [{
+          "==": [{"var": "namespace"}, "mumbai"]
+        }]
+      },
+      "variants": [{
+        "id": "test-variant",
+        "variant_type": "EXPERIMENTAL"
+      }],
+      "traffic_percentage": 10
+    }
+  }'
+```
+
+## Monitoring and Debugging
+
+### Logging
+
+The application provides detailed logging for each operation:
+
+```
+deployment created successfully!
+service created successfully!
+Ingress created successfully!
+```
+
+### Error Handling
+
+Common error scenarios and troubleshooting:
+
+#### Kubernetes API Connection Issues
+```rust
+// Check K8S_API_SERVER and TOKEN configuration
+// Verify network connectivity to Kubernetes API
+// Ensure proper RBAC permissions
+```
+
+#### Configuration Resolution Failures
+```rust
+// Verify Superposition server is accessible
+// Check workspace_id and tenant configuration
+// Ensure variant configurations exist
+```
+
+#### Resource Creation Failures
+```rust
+// Check Kubernetes cluster resources
+// Verify namespace exists
+// Review RBAC permissions
+```
+
+### Health Checks
+
+Monitor the webhook endpoint:
+
+```bash
+# Basic health check
+curl http://127.0.0.1:8090/hi
+```
+
+## Advanced Configuration
+
+### Multi-Tenant Support
+
+Configure different tenants in `main.rs`:
+
+```rust
+let app_state = Data::new(AppState {
+    namespaces: ["mumbai".to_string(), "delhi".to_string()].to_vec(),
+    tenants: ["service1".to_string(), "service2".to_string()].to_vec(),
+});
+```
+
+### Custom Resource Templates
+
+Modify resource generation in respective modules:
+
+- `deployment.rs`: Customize Deployment specifications
+- `service.rs`: Modify Service configurations  
+- `ingress.rs`: Adjust Ingress rules and annotations
+
+### Namespace Mapping
+
+Customize namespace resolution in `utils.rs`:
+
+```rust
+pub fn get_namespace(context: Value) -> String {
+    // Custom logic to extract namespace from context
+    // Default implementation looks for comparison values
+}
+```
+
+## Security Considerations
+
+### TLS Configuration
+
+The current implementation disables TLS verification:
+
+```rust
+let client = Client::builder()
+    .danger_accept_invalid_certs(true) // ⚠️ Not for production
+    .build()
+```
+
+For production deployments:
+1. Use proper TLS certificates
+2. Enable certificate verification
+3. Use secure communication channels
+
+### Authentication
+
+- Store Kubernetes tokens securely (use Kubernetes secrets or vault systems)
+- Implement webhook authentication if needed
+- Use least-privilege RBAC policies
+
+### Network Security
+
+- Deploy in secure network environments
+- Use network policies to restrict traffic
+- Implement proper firewall rules
+
+## Troubleshooting
+
+### Common Issues
+
+#### Webhook Not Receiving Events
+- Verify Superposition webhook configuration
+- Check network connectivity
+- Ensure correct URL and port
+
+#### Kubernetes Resource Creation Fails
+- Verify RBAC permissions
+- Check resource quotas
+- Ensure namespaces exist
+
+#### Traffic Routing Not Working
+- Verify NGINX Ingress Controller is installed
+- Check Ingress resource annotations
+- Ensure DNS resolution works
+
+#### Configuration Resolution Fails
+- Verify Superposition server connectivity
+- Check workspace and tenant configuration
+- Ensure experiment contexts are properly configured
+
+### Debug Mode
+
+Enable verbose logging by modifying the application or adding environment variables for detailed operation tracking.
+
+## Contributing
+
+When contributing to this example:
+
+1. Maintain backward compatibility with Superposition webhook formats
+2. Follow Kubernetes resource naming conventions
+3. Add proper error handling for all operations
+4. Include comprehensive logging for debugging
+
+## License
+
+This example is part of the Superposition project. Please refer to the main project's license terms.


### PR DESCRIPTION
## Problem
The k8s-staggered-releaser and the cac_redis_module examples do not have docs on what they do and how to test them out.

## Solution
Add the docs

## Environment variable changes
NA

## Pre-deployment activity
NA

## Post-deployment activity
NA

## API changes
NA

## Possible Issues in the future
NA