### PR TITLE
fix: experiment groups provider changes

### DIFF
--- a/clients/haskell/hs-exp-client/src/Main.hs
+++ b/clients/haskell/hs-exp-client/src/Main.hs
@@ -25,8 +25,8 @@ main = do
         loopNTimes n client = do
             runningExperiments   <- getRunningExperiments client
             satisfiedExperiments <- getSatisfiedExperiments client "{\"os\": \"android\", \"client\": \"1mg\"}" Nothing
-            filteredExperiments <- getFilteredSatisfiedExperiments client (Just "{\"os\": \"android\"}") (Just "hyperpay")
-            variants             <- getApplicableVariants client "{}" "{\"os\": \"android\", \"client\": \"1mg\"}" "1mg-android"
+            filteredExperiments  <- getFilteredSatisfiedExperiments client (Just "{\"os\": \"android\"}") (Just "hyperpay")
+            variants             <- getApplicableVariants client "{}" "{\"os\": \"android\", \"client\": \"1mg\"}" "1mg-android" Nothing
             print "Running experiments"
             print runningExperiments
             print "experiments that satisfy context"

--- a/clients/java/bindings/src/main/kotlin/uniffi/superposition_client/superposition_client.kt
+++ b/clients/java/bindings/src/main/kotlin/uniffi/superposition_client/superposition_client.kt
@@ -30,21 +30,30 @@ import java.nio.CharBuffer
 import java.nio.charset.CodingErrorAction
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.ConcurrentHashMap
+import uniffi.superposition_types.Bucket
+import uniffi.superposition_types.Buckets
 import uniffi.superposition_types.Condition
 import uniffi.superposition_types.Context
 import uniffi.superposition_types.DimensionInfo
+import uniffi.superposition_types.FfiConverterTypeBucket
+import uniffi.superposition_types.FfiConverterTypeBuckets
 import uniffi.superposition_types.FfiConverterTypeCondition
 import uniffi.superposition_types.FfiConverterTypeContext
 import uniffi.superposition_types.FfiConverterTypeDimensionInfo
+import uniffi.superposition_types.FfiConverterTypeGroupType
 import uniffi.superposition_types.FfiConverterTypeOverrides
 import uniffi.superposition_types.FfiConverterTypeVariant
 import uniffi.superposition_types.FfiConverterTypeVariants
+import uniffi.superposition_types.GroupType
 import uniffi.superposition_types.Overrides
 import uniffi.superposition_types.Variant
 import uniffi.superposition_types.Variants
+import uniffi.superposition_types.RustBuffer as RustBufferBucket
+import uniffi.superposition_types.RustBuffer as RustBufferBuckets
 import uniffi.superposition_types.RustBuffer as RustBufferCondition
 import uniffi.superposition_types.RustBuffer as RustBufferContext
 import uniffi.superposition_types.RustBuffer as RustBufferDimensionInfo
+import uniffi.superposition_types.RustBuffer as RustBufferGroupType
 import uniffi.superposition_types.RustBuffer as RustBufferOverrides
 import uniffi.superposition_types.RustBuffer as RustBufferVariant
 import uniffi.superposition_types.RustBuffer as RustBufferVariants
@@ -1106,6 +1115,7 @@ public object FfiConverterString: FfiConverter<String, RustBuffer.ByValue> {
 
 data class ExperimentationArgs (
     var `experiments`: List<FfiExperiment>, 
+    var `experimentGroups`: List<FfiExperimentGroup>, 
     var `targetingKey`: kotlin.String
 ) {
     
@@ -1119,17 +1129,20 @@ public object FfiConverterTypeExperimentationArgs: FfiConverterRustBuffer<Experi
     override fun read(buf: ByteBuffer): ExperimentationArgs {
         return ExperimentationArgs(
             FfiConverterSequenceTypeFfiExperiment.read(buf),
+            FfiConverterSequenceTypeFfiExperimentGroup.read(buf),
             FfiConverterString.read(buf),
         )
     }
 
     override fun allocationSize(value: ExperimentationArgs) = (
             FfiConverterSequenceTypeFfiExperiment.allocationSize(value.`experiments`) +
+            FfiConverterSequenceTypeFfiExperimentGroup.allocationSize(value.`experimentGroups`) +
             FfiConverterString.allocationSize(value.`targetingKey`)
     )
 
     override fun write(value: ExperimentationArgs, buf: ByteBuffer) {
             FfiConverterSequenceTypeFfiExperiment.write(value.`experiments`, buf)
+            FfiConverterSequenceTypeFfiExperimentGroup.write(value.`experimentGroups`, buf)
             FfiConverterString.write(value.`targetingKey`, buf)
     }
 }
@@ -1171,6 +1184,54 @@ public object FfiConverterTypeFfiExperiment: FfiConverterRustBuffer<FfiExperimen
             FfiConverterUByte.write(value.`trafficPercentage`, buf)
             FfiConverterTypeVariants.write(value.`variants`, buf)
             FfiConverterTypeCondition.write(value.`context`, buf)
+    }
+}
+
+
+
+data class FfiExperimentGroup (
+    var `id`: kotlin.String, 
+    var `context`: Condition, 
+    var `trafficPercentage`: kotlin.UByte, 
+    var `memberExperimentIds`: List<kotlin.String>, 
+    var `groupType`: GroupType, 
+    var `buckets`: Buckets
+) {
+    
+    companion object
+}
+
+/**
+ * @suppress
+ */
+public object FfiConverterTypeFfiExperimentGroup: FfiConverterRustBuffer<FfiExperimentGroup> {
+    override fun read(buf: ByteBuffer): FfiExperimentGroup {
+        return FfiExperimentGroup(
+            FfiConverterString.read(buf),
+            FfiConverterTypeCondition.read(buf),
+            FfiConverterUByte.read(buf),
+            FfiConverterSequenceString.read(buf),
+            FfiConverterTypeGroupType.read(buf),
+            FfiConverterTypeBuckets.read(buf),
+        )
+    }
+
+    override fun allocationSize(value: FfiExperimentGroup) = (
+            FfiConverterString.allocationSize(value.`id`) +
+            FfiConverterTypeCondition.allocationSize(value.`context`) +
+            FfiConverterUByte.allocationSize(value.`trafficPercentage`) +
+            FfiConverterSequenceString.allocationSize(value.`memberExperimentIds`) +
+            FfiConverterTypeGroupType.allocationSize(value.`groupType`) +
+            FfiConverterTypeBuckets.allocationSize(value.`buckets`)
+    )
+
+    override fun write(value: FfiExperimentGroup, buf: ByteBuffer) {
+            FfiConverterString.write(value.`id`, buf)
+            FfiConverterTypeCondition.write(value.`context`, buf)
+            FfiConverterUByte.write(value.`trafficPercentage`, buf)
+            FfiConverterSequenceString.write(value.`memberExperimentIds`, buf)
+            FfiConverterTypeGroupType.write(value.`groupType`, buf)
+            FfiConverterTypeBuckets.write(value.`buckets`, buf)
     }
 }
 
@@ -1301,6 +1362,38 @@ public object FfiConverterOptionalTypeExperimentationArgs: FfiConverterRustBuffe
 /**
  * @suppress
  */
+public object FfiConverterOptionalTypeBucket: FfiConverterRustBuffer<Bucket?> {
+    override fun read(buf: ByteBuffer): Bucket? {
+        if (buf.get().toInt() == 0) {
+            return null
+        }
+        return FfiConverterTypeBucket.read(buf)
+    }
+
+    override fun allocationSize(value: Bucket?): ULong {
+        if (value == null) {
+            return 1UL
+        } else {
+            return 1UL + FfiConverterTypeBucket.allocationSize(value)
+        }
+    }
+
+    override fun write(value: Bucket?, buf: ByteBuffer) {
+        if (value == null) {
+            buf.put(0)
+        } else {
+            buf.put(1)
+            FfiConverterTypeBucket.write(value, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
 public object FfiConverterOptionalSequenceString: FfiConverterRustBuffer<List<kotlin.String>?> {
     override fun read(buf: ByteBuffer): List<kotlin.String>? {
         if (buf.get().toInt() == 0) {
@@ -1389,6 +1482,34 @@ public object FfiConverterSequenceTypeFfiExperiment: FfiConverterRustBuffer<List
 /**
  * @suppress
  */
+public object FfiConverterSequenceTypeFfiExperimentGroup: FfiConverterRustBuffer<List<FfiExperimentGroup>> {
+    override fun read(buf: ByteBuffer): List<FfiExperimentGroup> {
+        val len = buf.getInt()
+        return List<FfiExperimentGroup>(len) {
+            FfiConverterTypeFfiExperimentGroup.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<FfiExperimentGroup>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterTypeFfiExperimentGroup.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(value: List<FfiExperimentGroup>, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterTypeFfiExperimentGroup.write(it, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
 public object FfiConverterSequenceTypeContext: FfiConverterRustBuffer<List<Context>> {
     override fun read(buf: ByteBuffer): List<Context> {
         val len = buf.getInt()
@@ -1435,6 +1556,34 @@ public object FfiConverterSequenceTypeVariant: FfiConverterRustBuffer<List<Varia
         buf.putInt(value.size)
         value.iterator().forEach {
             FfiConverterTypeVariant.write(it, buf)
+        }
+    }
+}
+
+
+
+
+/**
+ * @suppress
+ */
+public object FfiConverterSequenceOptionalTypeBucket: FfiConverterRustBuffer<List<Bucket?>> {
+    override fun read(buf: ByteBuffer): List<Bucket?> {
+        val len = buf.getInt()
+        return List<Bucket?>(len) {
+            FfiConverterOptionalTypeBucket.read(buf)
+        }
+    }
+
+    override fun allocationSize(value: List<Bucket?>): ULong {
+        val sizeForLength = 4UL
+        val sizeForItems = value.map { FfiConverterOptionalTypeBucket.allocationSize(it) }.sum()
+        return sizeForLength + sizeForItems
+    }
+
+    override fun write(value: List<Bucket?>, buf: ByteBuffer) {
+        buf.putInt(value.size)
+        value.iterator().forEach {
+            FfiConverterOptionalTypeBucket.write(it, buf)
         }
     }
 }
@@ -1555,6 +1704,12 @@ public object FfiConverterMapStringTypeOverrides: FfiConverterRustBuffer<Map<kot
         }
     }
 }
+
+
+
+
+
+
 
 
 

--- a/clients/java/openfeature-provider/src/main/kotlin/io/juspay/superposition/openfeature/EvaluationArgs.kt
+++ b/clients/java/openfeature-provider/src/main/kotlin/io/juspay/superposition/openfeature/EvaluationArgs.kt
@@ -5,12 +5,15 @@ import dev.openfeature.sdk.EvaluationContext
 import dev.openfeature.sdk.Value
 import io.juspay.superposition.model.ContextPartial
 import io.juspay.superposition.model.ExperimentResponse
+import io.juspay.superposition.model.ExperimentGroupResponse
 import io.juspay.superposition.model.GetConfigOutput
 import software.amazon.smithy.java.core.serde.document.Document
 import uniffi.superposition_client.*
+import uniffi.superposition_types.Buckets
 import uniffi.superposition_types.Context
 import uniffi.superposition_types.DimensionInfo
 import uniffi.superposition_types.DimensionType
+import uniffi.superposition_types.GroupType
 import uniffi.superposition_types.Variant
 import uniffi.superposition_types.VariantType
 
@@ -82,6 +85,25 @@ internal class EvaluationArgs {
                 er.trafficPercentage().toUByte(),
                 variants,
                 serializeDocumentValues(er.context())
+            )
+        }
+
+        private fun toFfiGroupType(gt: io.juspay.superposition.model.GroupType): GroupType {
+            return when (gt) {
+                io.juspay.superposition.model.GroupType.USER_CREATED -> GroupType.USER_CREATED
+                else -> GroupType.SYSTEM_GENERATED
+            }
+        }
+
+        @JvmStatic
+        fun toFfiExperimentGroup(er: ExperimentGroupResponse): FfiExperimentGroup {
+            return FfiExperimentGroup(
+                er.id(),
+                serializeDocumentValues(er.context()),
+                er.trafficPercentage().toUByte(),
+                er.memberExperimentIds(),
+                toFfiGroupType(er.groupType()),
+                er.buckets() as Buckets
             )
         }
     }

--- a/clients/javascript/bindings/native-resolver.ts
+++ b/clients/javascript/bindings/native-resolver.ts
@@ -239,6 +239,7 @@ export class NativeResolver {
 
     getApplicableVariants(
         experiments: any[],
+        experiment_groups: any[],
         dimensions: Record<string, Record<string, any>>,
         userContext: Record<string, any>,
         identifier: string,
@@ -258,19 +259,22 @@ export class NativeResolver {
         }
 
         const experimentsJson = JSON.stringify(experiments);
+        const experimentGroupsJson = JSON.stringify(experiment_groups);
         const userContextJson = JSON.stringify(userContext);
         const dimensionsJson = JSON.stringify(dimensions);
         const filterPrefixesJson =
             filterPrefixes.length > 0 ? JSON.stringify(filterPrefixes) : null;
 
         console.log("Calling FFI getApplicableVariants with parameters:");
-        console.log("  experiments:", experiments);
+        console.log("  experiments:", experiments.length);
+        console.log("  experimentGroups:", experiment_groups.length);
         console.log("  userContext:", userContext);
         console.log("  identifier:", identifier);
         console.log("  filterPrefixes:", filterPrefixes);
 
         const result = this.lib.core_get_applicable_variants(
             experimentsJson,
+            experimentGroupsJson,
             dimensionsJson,
             userContextJson,
             identifier,

--- a/clients/javascript/open-feature-provider/configuration-client.ts
+++ b/clients/javascript/open-feature-provider/configuration-client.ts
@@ -11,7 +11,7 @@ import {
     GetConfigCommand,
     GetConfigCommandInput,
 } from "superposition-sdk";
-import { ExperimentationClient, Experiment } from "./experimentation-client";
+import { ExperimentationClient, Experiment, ExperimentGroup } from "./experimentation-client";
 import { ExperimentationOptions } from "./types";
 
 export class ConfigurationClient {
@@ -180,12 +180,14 @@ export class ConfigurationClient {
             if (this.experimentationClient && targetingKey) {
                 const experiments =
                     await this.experimentationClient.getExperiments();
+                const experiment_groups = await this.experimentationClient.getExperimentGroups();
                 const identifier =
                     this.experimentationOptions?.defaultIdentifier ||
                     (targetingKey ? targetingKey : "default");
 
                 const variantIds = await this.getApplicableVariants(
                     experiments,
+                    experiment_groups,
                     this.currentConfigData?.dimensions || {},
                     queryData,
                     identifier
@@ -223,6 +225,7 @@ export class ConfigurationClient {
     // Add method to get applicable variants
     private async getApplicableVariants(
         experiments: Experiment[],
+        experiment_groups: ExperimentGroup[],
         dimensions: Record<string, Record<string, any>>,
         queryData: Record<string, any>,
         identifier: string,
@@ -231,6 +234,7 @@ export class ConfigurationClient {
         // This would use the native resolver's getApplicableVariants method
         return this.resolver.getApplicableVariants(
             experiments,
+            experiment_groups,
             dimensions,
             queryData,
             identifier,

--- a/clients/javascript/open-feature-provider/experimentation-client.ts
+++ b/clients/javascript/open-feature-provider/experimentation-client.ts
@@ -1,4 +1,4 @@
-import { SuperpositionClient, ListExperimentCommand, ListExperimentCommandInput, ListExperimentGroupsCommandInput, ListExperimentGroupsCommand, GroupType } from 'superposition-sdk';
+import { SuperpositionClient, ListExperimentCommand, ListExperimentCommandInput, ListExperimentGroupsCommandInput, ListExperimentGroupsCommand, GroupType, Bucket } from 'superposition-sdk';
 import { SuperpositionOptions, ExperimentationOptions, PollingStrategy, OnDemandStrategy } from './types';
 
 export interface Variant {
@@ -22,6 +22,7 @@ export interface ExperimentGroup {
     member_experiment_ids: string[];
     traffic_percentage: number;
     group_type: GroupType;
+    buckets: (Bucket)[];
 }
 
 export class ExperimentationClient {
@@ -175,7 +176,8 @@ export class ExperimentationClient {
                     context: this.normalizeToStringRecord(exp_group.context),
                     traffic_percentage: exp_group.traffic_percentage || 100,
                     member_experiment_ids: exp_group.member_experiment_ids || [],
-                    group_type: exp_group.group_type as GroupType || GroupType.USER_CREATED
+                    group_type: exp_group.group_type as GroupType || GroupType.USER_CREATED,
+                    buckets: exp_group.buckets || []
                 });
             }
 

--- a/clients/python/bindings/superposition_bindings/superposition_client.py
+++ b/clients/python/bindings/superposition_bindings/superposition_client.py
@@ -28,21 +28,30 @@ import itertools
 import traceback
 import typing
 import platform
+from .superposition_types import Bucket
+from .superposition_types import Buckets
 from .superposition_types import Condition
 from .superposition_types import Context
 from .superposition_types import DimensionInfo
+from .superposition_types import GroupType
 from .superposition_types import Overrides
 from .superposition_types import Variant
 from .superposition_types import Variants
+from .superposition_types import _UniffiConverterTypeBucket
+from .superposition_types import _UniffiConverterTypeBuckets
 from .superposition_types import _UniffiConverterTypeCondition
 from .superposition_types import _UniffiConverterTypeContext
 from .superposition_types import _UniffiConverterTypeDimensionInfo
+from .superposition_types import _UniffiConverterTypeGroupType
 from .superposition_types import _UniffiConverterTypeOverrides
 from .superposition_types import _UniffiConverterTypeVariant
 from .superposition_types import _UniffiConverterTypeVariants
+from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferBucket
+from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferBuckets
 from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferCondition
 from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferContext
 from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferDimensionInfo
+from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferGroupType
 from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferOverrides
 from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferVariant
 from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferVariants
@@ -956,16 +965,20 @@ class _UniffiConverterString:
 
 class ExperimentationArgs:
     experiments: "typing.List[FfiExperiment]"
+    experiment_groups: "typing.List[FfiExperimentGroup]"
     targeting_key: "str"
-    def __init__(self, *, experiments: "typing.List[FfiExperiment]", targeting_key: "str"):
+    def __init__(self, *, experiments: "typing.List[FfiExperiment]", experiment_groups: "typing.List[FfiExperimentGroup]", targeting_key: "str"):
         self.experiments = experiments
+        self.experiment_groups = experiment_groups
         self.targeting_key = targeting_key
 
     def __str__(self):
-        return "ExperimentationArgs(experiments={}, targeting_key={})".format(self.experiments, self.targeting_key)
+        return "ExperimentationArgs(experiments={}, experiment_groups={}, targeting_key={})".format(self.experiments, self.experiment_groups, self.targeting_key)
 
     def __eq__(self, other):
         if self.experiments != other.experiments:
+            return False
+        if self.experiment_groups != other.experiment_groups:
             return False
         if self.targeting_key != other.targeting_key:
             return False
@@ -976,17 +989,20 @@ class _UniffiConverterTypeExperimentationArgs(_UniffiConverterRustBuffer):
     def read(buf):
         return ExperimentationArgs(
             experiments=_UniffiConverterSequenceTypeFfiExperiment.read(buf),
+            experiment_groups=_UniffiConverterSequenceTypeFfiExperimentGroup.read(buf),
             targeting_key=_UniffiConverterString.read(buf),
         )
 
     @staticmethod
     def check_lower(value):
         _UniffiConverterSequenceTypeFfiExperiment.check_lower(value.experiments)
+        _UniffiConverterSequenceTypeFfiExperimentGroup.check_lower(value.experiment_groups)
         _UniffiConverterString.check_lower(value.targeting_key)
 
     @staticmethod
     def write(value, buf):
         _UniffiConverterSequenceTypeFfiExperiment.write(value.experiments, buf)
+        _UniffiConverterSequenceTypeFfiExperimentGroup.write(value.experiment_groups, buf)
         _UniffiConverterString.write(value.targeting_key, buf)
 
 
@@ -1038,6 +1054,70 @@ class _UniffiConverterTypeFfiExperiment(_UniffiConverterRustBuffer):
         _UniffiConverterUInt8.write(value.traffic_percentage, buf)
         _UniffiConverterTypeVariants.write(value.variants, buf)
         _UniffiConverterTypeCondition.write(value.context, buf)
+
+
+class FfiExperimentGroup:
+    id: "str"
+    context: "Condition"
+    traffic_percentage: "int"
+    member_experiment_ids: "typing.List[str]"
+    group_type: "GroupType"
+    buckets: "Buckets"
+    def __init__(self, *, id: "str", context: "Condition", traffic_percentage: "int", member_experiment_ids: "typing.List[str]", group_type: "GroupType", buckets: "Buckets"):
+        self.id = id
+        self.context = context
+        self.traffic_percentage = traffic_percentage
+        self.member_experiment_ids = member_experiment_ids
+        self.group_type = group_type
+        self.buckets = buckets
+
+    def __str__(self):
+        return "FfiExperimentGroup(id={}, context={}, traffic_percentage={}, member_experiment_ids={}, group_type={}, buckets={})".format(self.id, self.context, self.traffic_percentage, self.member_experiment_ids, self.group_type, self.buckets)
+
+    def __eq__(self, other):
+        if self.id != other.id:
+            return False
+        if self.context != other.context:
+            return False
+        if self.traffic_percentage != other.traffic_percentage:
+            return False
+        if self.member_experiment_ids != other.member_experiment_ids:
+            return False
+        if self.group_type != other.group_type:
+            return False
+        if self.buckets != other.buckets:
+            return False
+        return True
+
+class _UniffiConverterTypeFfiExperimentGroup(_UniffiConverterRustBuffer):
+    @staticmethod
+    def read(buf):
+        return FfiExperimentGroup(
+            id=_UniffiConverterString.read(buf),
+            context=_UniffiConverterTypeCondition.read(buf),
+            traffic_percentage=_UniffiConverterUInt8.read(buf),
+            member_experiment_ids=_UniffiConverterSequenceString.read(buf),
+            group_type=_UniffiConverterTypeGroupType.read(buf),
+            buckets=_UniffiConverterTypeBuckets.read(buf),
+        )
+
+    @staticmethod
+    def check_lower(value):
+        _UniffiConverterString.check_lower(value.id)
+        _UniffiConverterTypeCondition.check_lower(value.context)
+        _UniffiConverterUInt8.check_lower(value.traffic_percentage)
+        _UniffiConverterSequenceString.check_lower(value.member_experiment_ids)
+        _UniffiConverterTypeGroupType.check_lower(value.group_type)
+        _UniffiConverterTypeBuckets.check_lower(value.buckets)
+
+    @staticmethod
+    def write(value, buf):
+        _UniffiConverterString.write(value.id, buf)
+        _UniffiConverterTypeCondition.write(value.context, buf)
+        _UniffiConverterUInt8.write(value.traffic_percentage, buf)
+        _UniffiConverterSequenceString.write(value.member_experiment_ids, buf)
+        _UniffiConverterTypeGroupType.write(value.group_type, buf)
+        _UniffiConverterTypeBuckets.write(value.buckets, buf)
 
 
 
@@ -1161,6 +1241,33 @@ class _UniffiConverterOptionalTypeExperimentationArgs(_UniffiConverterRustBuffer
 
 
 
+class _UniffiConverterOptionalTypeBucket(_UniffiConverterRustBuffer):
+    @classmethod
+    def check_lower(cls, value):
+        if value is not None:
+            _UniffiConverterTypeBucket.check_lower(value)
+
+    @classmethod
+    def write(cls, value, buf):
+        if value is None:
+            buf.write_u8(0)
+            return
+
+        buf.write_u8(1)
+        _UniffiConverterTypeBucket.write(value, buf)
+
+    @classmethod
+    def read(cls, buf):
+        flag = buf.read_u8()
+        if flag == 0:
+            return None
+        elif flag == 1:
+            return _UniffiConverterTypeBucket.read(buf)
+        else:
+            raise InternalError("Unexpected flag byte for optional type")
+
+
+
 class _UniffiConverterOptionalSequenceString(_UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, value):
@@ -1238,6 +1345,31 @@ class _UniffiConverterSequenceTypeFfiExperiment(_UniffiConverterRustBuffer):
 
 
 
+class _UniffiConverterSequenceTypeFfiExperimentGroup(_UniffiConverterRustBuffer):
+    @classmethod
+    def check_lower(cls, value):
+        for item in value:
+            _UniffiConverterTypeFfiExperimentGroup.check_lower(item)
+
+    @classmethod
+    def write(cls, value, buf):
+        items = len(value)
+        buf.write_i32(items)
+        for item in value:
+            _UniffiConverterTypeFfiExperimentGroup.write(item, buf)
+
+    @classmethod
+    def read(cls, buf):
+        count = buf.read_i32()
+        if count < 0:
+            raise InternalError("Unexpected negative sequence length")
+
+        return [
+            _UniffiConverterTypeFfiExperimentGroup.read(buf) for i in range(count)
+        ]
+
+
+
 class _UniffiConverterSequenceTypeContext(_UniffiConverterRustBuffer):
     @classmethod
     def check_lower(cls, value):
@@ -1284,6 +1416,31 @@ class _UniffiConverterSequenceTypeVariant(_UniffiConverterRustBuffer):
 
         return [
             _UniffiConverterTypeVariant.read(buf) for i in range(count)
+        ]
+
+
+
+class _UniffiConverterSequenceOptionalTypeBucket(_UniffiConverterRustBuffer):
+    @classmethod
+    def check_lower(cls, value):
+        for item in value:
+            _UniffiConverterOptionalTypeBucket.check_lower(item)
+
+    @classmethod
+    def write(cls, value, buf):
+        items = len(value)
+        buf.write_i32(items)
+        for item in value:
+            _UniffiConverterOptionalTypeBucket.write(item, buf)
+
+    @classmethod
+    def read(cls, buf):
+        count = buf.read_i32()
+        if count < 0:
+            raise InternalError("Unexpected negative sequence length")
+
+        return [
+            _UniffiConverterOptionalTypeBucket.read(buf) for i in range(count)
         ]
 
 
@@ -1387,11 +1544,17 @@ class _UniffiConverterMapStringTypeOverrides(_UniffiConverterRustBuffer):
 
 # objects.
 
+# External type Bucket: `from .superposition_types import Bucket`
+
 # External type Context: `from .superposition_types import Context`
 
 # External type DimensionInfo: `from .superposition_types import DimensionInfo`
 
 # External type Variant: `from .superposition_types import Variant`
+
+# External type GroupType: `from .superposition_types import GroupType`
+
+# External type Buckets: `from .superposition_types import Buckets`
 
 # External type Condition: `from .superposition_types import Condition`
 
@@ -1479,6 +1642,7 @@ __all__ = [
     "OperationError",
     "ExperimentationArgs",
     "FfiExperiment",
+    "FfiExperimentGroup",
     "ffi_eval_config",
     "ffi_eval_config_with_reasoning",
     "ffi_get_applicable_variants",

--- a/clients/python/provider/superposition_provider/configuration_client.py
+++ b/clients/python/provider/superposition_provider/configuration_client.py
@@ -68,6 +68,7 @@ class ConfigurationClient:
         if self.exp_config:
             experimentdata = ExperimentationArgs(
                 experiments=self.exp_config.cached_experiments,
+                experiment_groups=self.exp_config.cached_experiment_groups,
                 targeting_key= targeting_key if targeting_key else "",
             )
         try:
@@ -180,6 +181,7 @@ class ConfigurationClient:
         if self.exp_config:
             experimentdata = ExperimentationArgs(
                 experiments=self.exp_config.cached_experiments(),
+                experiment_groups=self.exp_config.cached_experiment_groups(),
                 targeting_key= targeting_key if targeting_key else "",
             )
             return ffi_get_applicable_variants(experimentdata, self.cac_config.cached_config.get('dimensions', {}), context, prefix=None)

--- a/crates/superposition_core/Cargo.toml
+++ b/crates/superposition_core/Cargo.toml
@@ -15,7 +15,7 @@ cfg-if = { workspace = true }
 chrono = { workspace = true }
 derive_more = { workspace = true }
 itertools = { workspace = true }
-jsonlogic = { workspace = true}
+jsonlogic = { workspace = true, optional = true }
 log = { workspace = true }
 mini-moka = { version = "0.10.3" }
 once_cell = { workspace = true }
@@ -34,7 +34,7 @@ tokio = { version = "1.29.1", features = ["full"] }
 uniffi = { workspace = true }
 
 [features]
-jsonlogic = ["superposition_types/jsonlogic"]
+jsonlogic = ["dep:jsonlogic", "superposition_types/jsonlogic"]
 
 [dev-dependencies]
 uniffi = { workspace = true }

--- a/crates/superposition_core/src/ffi.rs
+++ b/crates/superposition_core/src/ffi.rs
@@ -1,4 +1,3 @@
-use rand::Rng;
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 use superposition_types::{Context, DimensionInfo, Overrides};
@@ -57,16 +56,13 @@ fn ffi_eval_logic(
     if let Some(e_args) = experimentation {
         // NOTE Parsing to allow for testing. This has to be migrated to the new
         // bucketing procedure.
-        let toss = e_args
-            .targeting_key
-            .parse::<i8>()
-            .unwrap_or(rand::rng().random_range(0..=99))
-            % 100;
+        let identifier = e_args.targeting_key;
         let variants = get_applicable_variants(
             &dimensions,
             &e_args.experiments,
+            &e_args.experiment_groups,
             &_q,
-            toss,
+            &identifier,
             filter_prefixes.clone(),
         )
         .map_err(OperationError::Unexpected)?;
@@ -147,17 +143,13 @@ fn ffi_get_applicable_variants(
     let _query_data = json_from_map(query_data.clone())
         .map_err(|err| OperationError::Unexpected(err.to_string()))?;
 
-    // TODO Migrate to new bucketing procedure.
-    let toss = eargs
-        .targeting_key
-        .parse::<i8>()
-        .unwrap_or(rand::rng().random_range(0..=99))
-        % 100;
+    let identifier = eargs.targeting_key;
     let r = get_applicable_variants(
         &dimensions_info,
         &eargs.experiments,
+        &eargs.experiment_groups,
         &_query_data,
-        toss,
+        &identifier,
         prefix,
     )
     .map_err(OperationError::Unexpected)?;

--- a/crates/superposition_provider/src/provider.rs
+++ b/crates/superposition_provider/src/provider.rs
@@ -140,11 +140,7 @@ impl SuperpositionProvider {
         let dimensions_info = self.get_dimensions_info().await;
         let variant_ids = if let Some(exp_config) = &self.exp_config {
             exp_config
-                .get_applicable_variants(
-                    &dimensions_info,
-                    &context,
-                    targeting_key.unwrap_or_default().parse::<i8>().ok(),
-                )
+                .get_applicable_variants(&dimensions_info, &context, targeting_key)
                 .await?
         } else {
             vec![]

--- a/examples/experimentation_client_integration_example/src/main.rs
+++ b/examples/experimentation_client_integration_example/src/main.rs
@@ -45,7 +45,7 @@ async fn get_variants(
         "os": platform
     });
     let variant = state
-        .get_applicable_variant(&HashMap::new(), &contexts, &identifier)
+        .get_applicable_variant(&HashMap::new(), &contexts, &identifier, None)
         .await;
     println!("variant value: {:?}", variant);
     HttpResponse::Ok().body("check your console")

--- a/headers/libexperimentation_client.h
+++ b/headers/libexperimentation_client.h
@@ -22,7 +22,8 @@ struct Arc_Client *expt_get_client(const char *tenant);
 char *expt_get_applicable_variant(struct Arc_Client *client,
                                   const char *c_dimensions,
                                   const char *c_context,
-                                  const char *identifier);
+                                  const char *identifier,
+                                  const char *filter_prefix);
 
 char *expt_get_satisfied_experiments(struct Arc_Client *client,
                                      const char *c_context,


### PR DESCRIPTION
## Problem
This PR implements experiment groups support across the codebase. The primary goal is to add a new bucketing mechanism using experiment groups instead of the legacy random toss-based variant selection. The changes include updating FFI interfaces, adding experiment group data structures, modifying variant calculation logic, and updating client implementations across multiple languages.

Key Changes:

Replaced toss (random percentage) with deterministic identifier-based bucketing using hash functions
Added ExperimentGroups data structures and API endpoints for fetching/caching experiment groups
Updated get_applicable_variants function signature to accept experiment_groups and identifier parameters
Modified all client bindings (Python, JavaScript, Java/Kotlin, Haskell) to support the new experiment groups functionality
