### PR TITLE
fix: superposition_core header file generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -263,7 +263,7 @@ jobs:
               run: |
                   cargo build --package superposition_core --release --target ${{ matrix.platform.target }}
                   mv target/${{ matrix.platform.target }}/release/${{ matrix.platform.superposition_core_bin_name }} ${{ matrix.platform.superposition_core_bin_name }}
-                  mv crates/superposition_core/src/core.h core.h
+                  mv crates/superposition_core/include/superposition_core.h core.h
                   zip -r ${{ matrix.platform.superposition_core_zip_name }} ${{ matrix.platform.superposition_core_bin_name }} core.h
 
             - name: Build and package for ${{ matrix.platform.os }} on windows
@@ -271,7 +271,7 @@ jobs:
               run: |
                   cargo build --package superposition_core --release --target ${{ matrix.platform.target }}
                   Move-Item -Path "target\${{ matrix.platform.target }}\release\${{ matrix.platform.superposition_core_bin_name }}" -Destination "lib${{ matrix.platform.superposition_core_bin_name }}"
-                  Move-Item -Path "crates\superposition_core\src\core.h" -Destination "core.h"
+                  Move-Item -Path "crates\superposition_core\include\superposition_core.h" -Destination "core.h"
                   Compress-Archive -Path "lib${{ matrix.platform.superposition_core_bin_name }}","core.h" -DestinationPath ${{ matrix.platform.superposition_core_zip_name }}
 
             # Why multiple upload artifact jobs? Read: https://github.com/actions/upload-artifact/issues/331

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5447,6 +5447,7 @@ version = "0.94.0"
 dependencies = [
  "actix-web",
  "anyhow",
+ "cbindgen",
  "cfg-if",
  "chrono",
  "derive_more",

--- a/crates/superposition_core/.gitignore
+++ b/crates/superposition_core/.gitignore
@@ -1,0 +1,1 @@
+include/

--- a/crates/superposition_core/Cargo.toml
+++ b/crates/superposition_core/Cargo.toml
@@ -50,3 +50,6 @@ name = "superposition_core"
 # This can be whatever name makes sense for your project, but the rest of this tutorial assumes uniffi-bindgen.
 name = "uniffi-bindgen"
 path = "uniffi-bindgen.rs"
+
+[build-dependencies]
+cbindgen = "0.26.0"

--- a/crates/superposition_core/build.rs
+++ b/crates/superposition_core/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    let crate_dir = std::env!("CARGO_MANIFEST_DIR");
+    let mut config: cbindgen::Config = Default::default();
+    config.language = cbindgen::Language::C;
+    cbindgen::generate_with_config(crate_dir, config)
+        .expect("Failed to generate bindings")
+        .write_to_file("include/superposition_core.h");
+}

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -224,7 +224,6 @@
             crane = {
               args = {
                 nativeBuildInputs = [
-                  pkgs.rust-cbindgen
                   pkgs.pkg-config
                 ];
                 buildInputs =
@@ -242,7 +241,8 @@
                 # https://discourse.nixos.org/t/how-to-use-install-name-tool-on-darwin/9931/2
                 postInstall = ''
                   ${if isDarwin then "fixDarwinDylibNames" else ""}
-                  cbindgen --config crates/superposition_core/cbindgen.toml --crate superposition_core --output $out/include/superposition_core.h
+                  mkdir -p $out/include
+                  cp crates/superposition_core/include/* $out/include/
                 '';
               };
             };


### PR DESCRIPTION
Superposition core's header file generation wasn't automated, used `cbindgen` via `build.rs` to generate the header file during it's build.
- Added `build.rs` in `superposition_core` for generating the header file in `include/`.
- Updated `rust.nix` to copy the header file in it's output.
- Updated path in `release.yaml` from `src/` to `include/`.