### PR TITLE
fix: Moved header file generation outside of crate dir as it causes an error during publish.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -263,7 +263,7 @@ jobs:
               run: |
                   cargo build --package superposition_core --release --target ${{ matrix.platform.target }}
                   mv target/${{ matrix.platform.target }}/release/${{ matrix.platform.superposition_core_bin_name }} ${{ matrix.platform.superposition_core_bin_name }}
-                  mv crates/superposition_core/include/superposition_core.h core.h
+                  mv target/include/superposition_core.h core.h
                   zip -r ${{ matrix.platform.superposition_core_zip_name }} ${{ matrix.platform.superposition_core_bin_name }} core.h
 
             - name: Build and package for ${{ matrix.platform.os }} on windows
@@ -271,7 +271,7 @@ jobs:
               run: |
                   cargo build --package superposition_core --release --target ${{ matrix.platform.target }}
                   Move-Item -Path "target\${{ matrix.platform.target }}\release\${{ matrix.platform.superposition_core_bin_name }}" -Destination "lib${{ matrix.platform.superposition_core_bin_name }}"
-                  Move-Item -Path "crates\superposition_core\include\superposition_core.h" -Destination "core.h"
+                  Move-Item -Path "target\include\superposition_core.h" -Destination "core.h"
                   Compress-Archive -Path "lib${{ matrix.platform.superposition_core_bin_name }}","core.h" -DestinationPath ${{ matrix.platform.superposition_core_zip_name }}
 
             # Why multiple upload artifact jobs? Read: https://github.com/actions/upload-artifact/issues/331

--- a/crates/superposition_core/.gitignore
+++ b/crates/superposition_core/.gitignore
@@ -1,1 +1,0 @@
-include/

--- a/crates/superposition_core/build.rs
+++ b/crates/superposition_core/build.rs
@@ -4,5 +4,5 @@ fn main() {
     config.language = cbindgen::Language::C;
     cbindgen::generate_with_config(crate_dir, config)
         .expect("Failed to generate bindings")
-        .write_to_file("include/superposition_core.h");
+        .write_to_file("../../target/include/superposition_core.h");
 }

--- a/nix/rust.nix
+++ b/nix/rust.nix
@@ -242,7 +242,7 @@
                 postInstall = ''
                   ${if isDarwin then "fixDarwinDylibNames" else ""}
                   mkdir -p $out/include
-                  cp crates/superposition_core/include/* $out/include/
+                  cp target/include/superposition_core.h $out/include/
                 '';
               };
             };


### PR DESCRIPTION
fix: Moved header file generation outside of crate dir as it causes an error during publish.