### PR TITLE
ci: Downgraded runner to ubuntu-20.04 to downgrade glibc link version.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ concurrency:
 
 jobs:
     tag-release:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         permissions:
             contents: write
             id-token: write


### PR DESCRIPTION
Had to downgrade release.yaml's runner's OS version as using a newer version prevents us from using libsuperposition w/ older OS'es. This is primarily due to us generating a binary which requires a higher glibc version.
