### PR TITLE
fix: Auth behaviour in python provider

### DIFF
--- a/clients/java/bindings/src/main/kotlin/uniffi/superposition_types/superposition_types.kt
+++ b/clients/java/bindings/src/main/kotlin/uniffi/superposition_types/superposition_types.kt
@@ -1139,7 +1139,7 @@ data class DimensionInfo (
     var `position`: kotlin.Int, 
     var `dimensionType`: DimensionType, 
     var `dependencyGraph`: DependencyGraph, 
-    var `autocompleteFunctionName`: kotlin.String?
+    var `valueComputeFunctionName`: kotlin.String?
 ) {
     
     companion object
@@ -1164,7 +1164,7 @@ public object FfiConverterTypeDimensionInfo: FfiConverterRustBuffer<DimensionInf
             FfiConverterInt.allocationSize(value.`position`) +
             FfiConverterTypeDimensionType.allocationSize(value.`dimensionType`) +
             FfiConverterTypeDependencyGraph.allocationSize(value.`dependencyGraph`) +
-            FfiConverterOptionalString.allocationSize(value.`autocompleteFunctionName`)
+            FfiConverterOptionalString.allocationSize(value.`valueComputeFunctionName`)
     )
 
     override fun write(value: DimensionInfo, buf: ByteBuffer) {
@@ -1172,7 +1172,7 @@ public object FfiConverterTypeDimensionInfo: FfiConverterRustBuffer<DimensionInf
             FfiConverterInt.write(value.`position`, buf)
             FfiConverterTypeDimensionType.write(value.`dimensionType`, buf)
             FfiConverterTypeDependencyGraph.write(value.`dependencyGraph`, buf)
-            FfiConverterOptionalString.write(value.`autocompleteFunctionName`, buf)
+            FfiConverterOptionalString.write(value.`valueComputeFunctionName`, buf)
     }
 }
 

--- a/clients/java/openfeature-provider/src/main/java/io/juspay/superposition/openfeature/SuperpositionOpenFeatureProvider.java
+++ b/clients/java/openfeature-provider/src/main/java/io/juspay/superposition/openfeature/SuperpositionOpenFeatureProvider.java
@@ -2,15 +2,12 @@ package io.juspay.superposition.openfeature;
 
 import com.google.gson.JsonSyntaxException;
 import io.juspay.superposition.client.SuperpositionAsyncClient;
+import io.juspay.superposition.client.auth.BearerTokenIdentityResolver;
 import io.juspay.superposition.model.*;
 import lombok.NonNull;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
-import software.amazon.smithy.java.auth.api.AuthProperties;
-import software.amazon.smithy.java.client.core.auth.identity.IdentityResolver;
-import software.amazon.smithy.java.auth.api.identity.TokenIdentity;
-import software.amazon.smithy.java.client.core.auth.identity.IdentityResult;
 import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
 import dev.openfeature.sdk.*;
 import com.google.gson.Gson;
@@ -22,10 +19,7 @@ import uniffi.superposition_client.OperationException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
-
-import static software.amazon.smithy.java.auth.api.identity.TokenIdentity.*;
 
 /**
  * Openfeature Provider implementation for Superposition.
@@ -85,7 +79,7 @@ public class SuperpositionOpenFeatureProvider implements FeatureProvider {
         }
         var builder = SuperpositionAsyncClient.builder()
             .endpointResolver(EndpointResolver.staticEndpoint(options.endpoint))
-            .addIdentityResolver(new IdentityResolverImpl(options.token));
+            .addIdentityResolver(new BearerTokenIdentityResolver(options.token));
         this.sdk = builder.build();
         var getConfigInput = GetConfigInput.builder()
             .context(Map.of())
@@ -316,25 +310,5 @@ public class SuperpositionOpenFeatureProvider implements FeatureProvider {
             }
         }
         return null;
-    }
-
-    // TODO EXPLAIN???
-    @SuppressWarnings("rawtypes")
-    private static class IdentityResolverImpl implements IdentityResolver {
-        TokenIdentity identity;
-
-        IdentityResolverImpl(String token) {
-            this.identity = create(token);
-        }
-
-        @Override
-        public CompletableFuture<IdentityResult> resolveIdentity(AuthProperties requestProperties) {
-            return CompletableFuture.completedFuture(IdentityResult.of(identity));
-        }
-
-        @Override
-        public Class identityType() {
-            return TokenIdentity.class;
-        }
     }
 }

--- a/clients/java/openfeature-provider/src/test/java/io/juspay/superposition/openfeature/DefaultConfigPopulator.java
+++ b/clients/java/openfeature-provider/src/test/java/io/juspay/superposition/openfeature/DefaultConfigPopulator.java
@@ -1,11 +1,8 @@
 package io.juspay.superposition.openfeature;
 
 import io.juspay.superposition.client.SuperpositionClient;
+import io.juspay.superposition.client.auth.BearerTokenIdentityResolver;
 import io.juspay.superposition.model.*;
-import software.amazon.smithy.java.auth.api.AuthProperties;
-import software.amazon.smithy.java.auth.api.identity.TokenIdentity;
-import software.amazon.smithy.java.client.core.auth.identity.IdentityResolver;
-import software.amazon.smithy.java.client.core.auth.identity.IdentityResult;
 import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
 import software.amazon.smithy.java.core.serde.document.Document;
 
@@ -16,9 +13,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-
-import static software.amazon.smithy.java.auth.api.identity.TokenIdentity.create;
 
 /**
  * Utility class to populate Superposition with default configuration data.
@@ -48,7 +42,7 @@ public class DefaultConfigPopulator {
         // Build Superposition client
         SuperpositionClient.Builder clientBuilder = SuperpositionClient.builder()
             .endpointResolver(EndpointResolver.staticEndpoint(baseUrl))
-            .addIdentityResolver(new IdentityResolverImpl(bearerToken));
+            .addIdentityResolver(new BearerTokenIdentityResolver(bearerToken));
         this.client = clientBuilder.build();
     }
 
@@ -277,24 +271,6 @@ public class DefaultConfigPopulator {
             this.changeReason = changeReason;
             this.functionName = functionName;
             this.autocompleteFunctionName = autocompleteFunctionName;
-        }
-    }
-
-    private static class IdentityResolverImpl implements IdentityResolver {
-        TokenIdentity identity;
-
-        IdentityResolverImpl(String token) {
-            this.identity = create(token);
-        }
-
-        @Override
-        public CompletableFuture<IdentityResult> resolveIdentity(AuthProperties requestProperties) {
-            return CompletableFuture.completedFuture(IdentityResult.of(identity));
-        }
-
-        @Override
-        public Class identityType() {
-            return TokenIdentity.class;
         }
     }
 

--- a/clients/java/sdk/AUTH_README.md
+++ b/clients/java/sdk/AUTH_README.md
@@ -1,0 +1,299 @@
+# Superposition Java SDK - Authentication Guide
+
+## Overview
+
+The Superposition Java SDK is generated using Smithy, which provides a flexible authentication framework. This guide explains how to authenticate API requests using Bearer tokens or Basic authentication.
+
+## Authentication Methods
+
+### Bearer Token Authentication (Recommended)
+
+Bearer token authentication is the recommended approach for API access. It provides a secure way to authenticate without sending credentials in every request.
+
+#### Usage Example
+
+```java
+import io.juspay.superposition.client.SuperpositionAsyncClient;
+import io.juspay.superposition.client.auth.BearerTokenIdentityResolver;
+import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
+
+// Create client with bearer token
+SuperpositionAsyncClient client = SuperpositionAsyncClient.builder()
+    .endpointResolver(EndpointResolver.staticEndpoint("https://api.example.com"))
+    .addIdentityResolver(new BearerTokenIdentityResolver("your-bearer-token"))
+    .build();
+
+// Use client to make API calls
+var result = client.getConfig(getConfigInput).get();
+```
+
+### Basic Authentication
+
+Basic authentication encodes username and password in Base64 format for the `Authorization` header.
+
+#### Usage Example
+
+```java
+import io.juspay.superposition.client.SuperpositionAsyncClient;
+import io.juspay.superposition.client.auth.BasicAuthIdentityResolver;
+import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
+
+// Create client with basic auth
+SuperpositionAsyncClient client = SuperpositionAsyncClient.builder()
+    .endpointResolver(EndpointResolver.staticEndpoint("https://api.example.com"))
+    .addIdentityResolver(new BasicAuthIdentityResolver("username", "password"))
+    .build();
+
+// Use client to make API calls
+var result = client.getConfig(getConfigInput).get();
+```
+
+## Implementation Details
+
+### File Structure
+
+The SDK provides two authentication resolver implementations in separate files following Java conventions (one public class per file):
+
+-   **`BearerTokenIdentityResolver.java`** - Bearer token authentication
+-   **`BasicAuthIdentityResolver.java`** - HTTP Basic authentication
+
+Both are located in the `io.juspay.superposition.client.auth` package.
+
+### Why Custom Resolvers?
+
+Smithy Java's code generator (v0.0.1+) includes the authentication framework but requires implementations of the `IdentityResolver` interface for specific authentication schemes. The Superposition SDK provides ready-made implementations:
+
+#### `BearerTokenIdentityResolver`
+
+-   **Purpose**: Authenticates using HTTP Bearer tokens (RFC 6750)
+-   **Location**: `io.juspay.superposition.client.auth.BearerTokenIdentityResolver`
+-   **File**: `BearerTokenIdentityResolver.java`
+-   **Header Added**: `Authorization: Bearer {token}`
+-   **Validation**: Ensures token is not null or empty
+
+```java
+public BearerTokenIdentityResolver(String token) {
+    if (token == null || token.trim().isEmpty()) {
+        throw new IllegalArgumentException("Bearer token cannot be null or empty");
+    }
+    // ...
+}
+```
+
+#### `BasicAuthIdentityResolver`
+
+-   **Purpose**: Authenticates using HTTP Basic Authentication (RFC 7617)
+-   **Location**: `io.juspay.superposition.client.auth.BasicAuthIdentityResolver`
+-   **File**: `BasicAuthIdentityResolver.java`
+-   **Header Added**: `Authorization: Basic {base64(username:password)}`
+-   **Validation**: Ensures username and password are not null or empty
+-   **Encoding**: Automatically encodes credentials as Base64
+
+```java
+public BasicAuthIdentityResolver(String username, String password) {
+    // Validates inputs
+    // Encodes as Base64: username:password
+    // Creates TokenIdentity
+}
+```
+
+### Architecture
+
+Both resolvers implement the Smithy `IdentityResolver` interface and follow the same pattern:
+
+1. **Validation**: Input parameters are validated in the constructor
+2. **Identity Creation**: A `TokenIdentity` is created with the appropriate credentials
+3. **Resolution**: When a request is made, `resolveIdentity()` returns the identity
+4. **Signing**: The Smithy framework uses the identity to add the appropriate `Authorization` header
+
+```
+Client Request
+    ↓
+IdentityResolver.resolveIdentity()
+    ↓
+TokenIdentity with credentials
+    ↓
+Smithy Framework adds Authorization header
+    ↓
+HTTP Request sent to API
+```
+
+## Error Handling
+
+Both resolvers validate their inputs and throw `IllegalArgumentException` if invalid:
+
+```java
+try {
+    var resolver = new BearerTokenIdentityResolver(null);
+} catch (IllegalArgumentException e) {
+    System.err.println(e.getMessage()); // "Bearer token cannot be null or empty"
+}
+
+try {
+    var resolver = new BasicAuthIdentityResolver("", "password");
+} catch (IllegalArgumentException e) {
+    System.err.println(e.getMessage()); // "Username cannot be null or empty"
+}
+```
+
+## Comparison with Other Smithy SDKs
+
+### Rust SDK (Mature) ✅
+
+```rust
+let config = SdkConfig::builder()
+    .endpoint_url(&endpoint)
+    .bearer_token(token.into())  // Built-in!
+    .build();
+```
+
+### TypeScript SDK (Mature) ✅
+
+```typescript
+const client = new SuperpositionClient({
+    endpoint,
+    token, // Built-in HttpBearerAuthSigner!
+});
+```
+
+### Java SDK (Current Approach) 📋
+
+```java
+// Requires explicit resolver instantiation
+client.builder()
+    .addIdentityResolver(new BearerTokenIdentityResolver(token))
+    .build();
+```
+
+The Java approach is more explicit but provides the same level of security and functionality.
+
+## Best Practices
+
+### 1. Use Environment Variables for Credentials
+
+Never hardcode credentials. Use environment variables:
+
+```java
+String token = System.getenv("SUPERPOSITION_API_TOKEN");
+SuperpositionAsyncClient client = SuperpositionAsyncClient.builder()
+    .endpointResolver(EndpointResolver.staticEndpoint("https://api.example.com"))
+    .addIdentityResolver(new BearerTokenIdentityResolver(token))
+    .build();
+```
+
+### 2. Reuse Client Instances
+
+Create the client once and reuse it for multiple requests:
+
+```java
+// ✅ Good - reuse across requests
+SuperpositionAsyncClient client = createClient();
+var result1 = client.getConfig(input1).get();
+var result2 = client.getConfig(input2).get();
+
+// ❌ Avoid - creating new client for each request
+new BearerTokenIdentityResolver(token); // Don't do this repeatedly
+```
+
+### 3. Handle Validation Errors
+
+Catch `IllegalArgumentException` when creating resolvers:
+
+```java
+try {
+    var resolver = new BearerTokenIdentityResolver(userProvidedToken);
+    // Use resolver...
+} catch (IllegalArgumentException e) {
+    log.error("Invalid token: {}", e.getMessage());
+    // Handle error appropriately
+}
+```
+
+### 4. Choose the Right Auth Method
+
+-   **Bearer Token**: Use for service-to-service authentication, API tokens
+-   **Basic Auth**: Use when the API requires username/password, development/testing
+
+## OpenFeature Integration
+
+The Superposition Java SDK integrates seamlessly with OpenFeature:
+
+```java
+var options = SuperpositionProviderOptions.builder()
+    .endpoint("https://api.example.com")
+    .token("your-bearer-token")  // Token is used internally
+    .orgId("org-id")
+    .workspaceId("workspace-id")
+    .build();
+
+SuperpositionOpenFeatureProvider provider =
+    new SuperpositionOpenFeatureProvider(options);
+
+OpenFeatureAPI.getInstance().setProvider(provider);
+```
+
+The provider handles creating the `BearerTokenIdentityResolver` automatically.
+
+## Security Considerations
+
+1. **Always use HTTPS**: Ensure API endpoint uses HTTPS protocol
+2. **Protect tokens**: Never log or expose authentication tokens
+3. **Rotate tokens regularly**: Follow your security policy for token rotation
+4. **Use secure credential storage**: Store credentials in secure vaults, not config files
+5. **Validate inputs**: Both resolvers validate their inputs - never bypass this
+
+## Troubleshooting
+
+### "Bearer token cannot be null or empty"
+
+**Cause**: Token is `null` or an empty string
+
+**Solution**: Verify token is correctly loaded from environment or configuration:
+
+```java
+String token = System.getenv("SUPERPOSITION_API_TOKEN");
+if (token == null || token.trim().isEmpty()) {
+    throw new IllegalStateException("SUPERPOSITION_API_TOKEN not set");
+}
+```
+
+### "Username cannot be null or empty"
+
+**Cause**: Username is `null` or empty string
+
+**Solution**: Verify username is provided correctly
+
+### "Password cannot be null"
+
+**Cause**: Password is `null`
+
+**Solution**: Password can be empty but not null. Provide an empty string if needed:
+
+```java
+var resolver = new BasicAuthIdentityResolver("user", ""); // Valid
+var resolver = new BasicAuthIdentityResolver("user", null); // Invalid!
+```
+
+### Authentication Fails on Request
+
+**Cause**: Token/credentials are valid but request is rejected
+
+**Possible Solutions**:
+
+1. Verify endpoint URL is correct
+2. Check if token/credentials are still valid
+3. Verify API permissions for the authenticated user
+4. Check API documentation for required headers or parameters
+
+## References
+
+-   [RFC 6750 - Bearer Token Usage](https://datatracker.ietf.org/doc/html/rfc6750)
+-   [RFC 7617 - HTTP Basic Authentication](https://datatracker.ietf.org/doc/html/rfc7617)
+-   [Smithy Authentication Traits](https://smithy.io/2.0/spec/authentication-traits.html)
+-   [Smithy Java GitHub](https://github.com/smithy-lang/smithy-java)
+
+## See Also
+
+-   [BearerTokenIdentityResolver.java](src/main/java/io/juspay/superposition/client/auth/BearerTokenIdentityResolver.java) - Bearer token implementation
+-   [BasicAuthIdentityResolver.java](src/main/java/io/juspay/superposition/client/auth/BasicAuthIdentityResolver.java) - Basic auth implementation
+-   [SuperpositionOpenFeatureProvider.java](../openfeature-provider/src/main/java/io/juspay/superposition/openfeature/SuperpositionOpenFeatureProvider.java) - Integration example

--- a/clients/java/sdk/src/main/java/io/juspay/superposition/client/auth/BasicAuthIdentityResolver.java
+++ b/clients/java/sdk/src/main/java/io/juspay/superposition/client/auth/BasicAuthIdentityResolver.java
@@ -1,0 +1,95 @@
+package io.juspay.superposition.client.auth;
+
+import software.amazon.smithy.java.auth.api.AuthProperties;
+import software.amazon.smithy.java.auth.api.identity.TokenIdentity;
+import software.amazon.smithy.java.client.core.auth.identity.IdentityResolver;
+import software.amazon.smithy.java.client.core.auth.identity.IdentityResult;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * IdentityResolver implementation for HTTP Basic authentication.
+ *
+ * <p>This resolver validates the credentials, encodes them as base64(username:password),
+ * and creates a TokenIdentity for the {@code Authorization: Basic <credentials>} header.</p>
+ *
+ * <p>Basic authentication is defined in <a href="https://datatracker.ietf.org/doc/html/rfc7617">RFC 7617</a>.
+ * While simpler than bearer tokens, basic auth requires transmitting credentials with each request,
+ * so HTTPS should always be used.</p>
+ *
+ * <h2>Example Usage:</h2>
+ * <pre>{@code
+ * import io.juspay.superposition.client.SuperpositionAsyncClient;
+ * import io.juspay.superposition.client.auth.BasicAuthIdentityResolver;
+ * import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
+ *
+ * // Create a client with basic authentication
+ * SuperpositionAsyncClient client = SuperpositionAsyncClient.builder()
+ *     .endpointResolver(EndpointResolver.staticEndpoint("https://api.example.com"))
+ *     .addIdentityResolver(new BasicAuthIdentityResolver("username", "password"))
+ *     .build();
+ *
+ * // Make API calls - credentials are automatically included in Authorization header
+ * var response = client.getConfig(getConfigInput).get();
+ * }</pre>
+ *
+ * <h2>Error Handling:</h2>
+ * The constructor validates the credentials and throws {@link IllegalArgumentException}
+ * if username is null/empty or if password is null:
+ *
+ * <pre>{@code
+ * try {
+ *     new BasicAuthIdentityResolver("", "password");
+ * } catch (IllegalArgumentException e) {
+ *     System.err.println("Username required: " + e.getMessage());
+ * }
+ * }</pre>
+ *
+ * <h2>Security Considerations:</h2>
+ * <ul>
+ *     <li>Always use HTTPS when transmitting basic auth credentials</li>
+ *     <li>Never hardcode credentials - use environment variables or secure vaults</li>
+ *     <li>Basic auth credentials are sent with every request, so token rotation is important</li>
+ *     <li>Consider using bearer tokens (BearerTokenIdentityResolver) for better security</li>
+ * </ul>
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc7617">RFC 7617 - The 'Basic' HTTP Authentication Scheme</a>
+ * @see BearerTokenIdentityResolver
+ */
+@SuppressWarnings("rawtypes")
+public class BasicAuthIdentityResolver implements IdentityResolver {
+    private final TokenIdentity identity;
+
+    /**
+     * Creates a new Basic authentication identity resolver.
+     *
+     * @param username the username for basic authentication. Must not be null or empty.
+     * @param password the password for basic authentication. Must not be null (can be empty).
+     * @throws IllegalArgumentException if username is null or empty (after trimming),
+     *                                  or if password is null
+     */
+    public BasicAuthIdentityResolver(String username, String password) {
+        if (username == null || username.trim().isEmpty()) {
+            throw new IllegalArgumentException("Username cannot be null or empty");
+        }
+        if (password == null) {
+            throw new IllegalArgumentException("Password cannot be null");
+        }
+
+        // For Basic auth, encode as base64(username:password)
+        String credentials = username + ":" + password;
+        String encodedCredentials = java.util.Base64.getEncoder()
+            .encodeToString(credentials.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        this.identity = TokenIdentity.create(encodedCredentials);
+    }
+
+    @Override
+    public CompletableFuture<IdentityResult> resolveIdentity(AuthProperties requestProperties) {
+        return CompletableFuture.completedFuture(IdentityResult.of(identity));
+    }
+
+    @Override
+    public Class identityType() {
+        return TokenIdentity.class;
+    }
+}

--- a/clients/java/sdk/src/main/java/io/juspay/superposition/client/auth/BearerTokenIdentityResolver.java
+++ b/clients/java/sdk/src/main/java/io/juspay/superposition/client/auth/BearerTokenIdentityResolver.java
@@ -1,0 +1,76 @@
+package io.juspay.superposition.client.auth;
+
+import software.amazon.smithy.java.auth.api.AuthProperties;
+import software.amazon.smithy.java.auth.api.identity.TokenIdentity;
+import software.amazon.smithy.java.client.core.auth.identity.IdentityResolver;
+import software.amazon.smithy.java.client.core.auth.identity.IdentityResult;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * IdentityResolver implementation for Bearer token authentication.
+ *
+ * <p>This resolver validates the token and creates a TokenIdentity that will be used
+ * by the Smithy auth framework to add the {@code Authorization: Bearer <token>} header.</p>
+ *
+ * <p>Bearer tokens are commonly used for API authentication and are defined in
+ * <a href="https://datatracker.ietf.org/doc/html/rfc6750">RFC 6750</a>.</p>
+ *
+ * <h2>Example Usage:</h2>
+ * <pre>{@code
+ * import io.juspay.superposition.client.SuperpositionAsyncClient;
+ * import io.juspay.superposition.client.auth.BearerTokenIdentityResolver;
+ * import software.amazon.smithy.java.client.core.endpoint.EndpointResolver;
+ *
+ * // Create a client with bearer token authentication
+ * SuperpositionAsyncClient client = SuperpositionAsyncClient.builder()
+ *     .endpointResolver(EndpointResolver.staticEndpoint("https://api.example.com"))
+ *     .addIdentityResolver(new BearerTokenIdentityResolver("your-api-token"))
+ *     .build();
+ *
+ * // Make API calls - token is automatically included in Authorization header
+ * var response = client.getConfig(getConfigInput).get();
+ * }</pre>
+ *
+ * <h2>Error Handling:</h2>
+ * The constructor validates the token and throws {@link IllegalArgumentException}
+ * if the token is null or empty:
+ *
+ * <pre>{@code
+ * try {
+ *     new BearerTokenIdentityResolver(null);
+ * } catch (IllegalArgumentException e) {
+ *     System.err.println("Token required: " + e.getMessage());
+ * }
+ * }</pre>
+ *
+ * @see <a href="https://datatracker.ietf.org/doc/html/rfc6750">RFC 6750 - The OAuth 2.0 Bearer Token Usage</a>
+ * @see BasicAuthIdentityResolver
+ */
+@SuppressWarnings("rawtypes")
+public class BearerTokenIdentityResolver implements IdentityResolver {
+    private final TokenIdentity identity;
+
+    /**
+     * Creates a new Bearer token identity resolver.
+     *
+     * @param token the bearer token for authentication. Must not be null or empty.
+     * @throws IllegalArgumentException if token is null or empty (after trimming)
+     */
+    public BearerTokenIdentityResolver(String token) {
+        if (token == null || token.trim().isEmpty()) {
+            throw new IllegalArgumentException("Bearer token cannot be null or empty");
+        }
+        this.identity = TokenIdentity.create(token);
+    }
+
+    @Override
+    public CompletableFuture<IdentityResult> resolveIdentity(AuthProperties requestProperties) {
+        return CompletableFuture.completedFuture(IdentityResult.of(identity));
+    }
+
+    @Override
+    public Class identityType() {
+        return TokenIdentity.class;
+    }
+}

--- a/clients/python/provider/superposition_provider/cac_config.py
+++ b/clients/python/provider/superposition_provider/cac_config.py
@@ -2,8 +2,11 @@ import json
 import logging
 from decimal import Decimal
 from typing import Any, Dict, Optional, TypeVar
+
 from .types import OnDemandStrategy, PollingStrategy, SuperpositionOptions, ConfigurationOptions
-from superposition_sdk.client import Superposition, Config, GetConfigInput
+from superposition_sdk.client import Superposition, GetConfigInput
+from superposition_sdk.config import Config
+from superposition_sdk.auth_helpers import bearer_auth_config
 from superposition_sdk.models import (
     DimensionType as SDKDimensionType,
     DimensionTypeLOCAL_COHORT,
@@ -18,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 from smithy_core.documents import Document
 from smithy_core.shapes import ShapeType
+
 
 class DecimalEncoder(json.JSONEncoder):
     """Custom JSON encoder that handles Decimal types"""
@@ -185,9 +189,14 @@ class CacConfig:
             Dict containing the configuration data
         """
         try:
-            # Create SDK config
+            # Create SDK config with bearer token authentication
+            (resolver, schemes) = bearer_auth_config(
+                token=superposition_options.token
+            )
             sdk_config = Config(
-                endpoint_uri=superposition_options.endpoint
+                endpoint_uri=superposition_options.endpoint,
+                http_auth_scheme_resolver=resolver,
+                http_auth_schemes=schemes
             )
 
             # Create Superposition client

--- a/clients/python/provider/superposition_provider/exp_config.py
+++ b/clients/python/provider/superposition_provider/exp_config.py
@@ -6,7 +6,9 @@ from superposition_bindings.superposition_client import FfiExperiment, FfiExperi
 from superposition_sdk.models import ExperimentStatusType, GroupType as SDKGroupType
 from superposition_bindings.superposition_types import GroupType
 from .types import OnDemandStrategy, PollingStrategy, SuperpositionOptions, ExperimentationOptions
-from superposition_sdk.client import Superposition, Config, ListExperimentInput, ListExperimentGroupsInput
+from superposition_sdk.client import Superposition, ListExperimentInput, ListExperimentGroupsInput
+from superposition_sdk.config import Config
+from superposition_sdk.auth_helpers import bearer_auth_config
 import asyncio
 from datetime import datetime, timedelta
 from superposition_bindings.superposition_types import Variant, VariantType
@@ -137,9 +139,14 @@ class ExperimentationConfig():
             Dict containing the configuration data
         """
         try:
-            # Create SDK config
+            # Create SDK config with bearer token authentication
+            (resolver, schemes) = bearer_auth_config(   
+                token=superposition_options.token
+            )
             sdk_config = Config(
-                endpoint_uri=superposition_options.endpoint
+                endpoint_uri=superposition_options.endpoint,
+                http_auth_scheme_resolver=resolver,
+                http_auth_schemes=schemes
             )
 
             # Create Superposition client
@@ -208,9 +215,14 @@ class ExperimentationConfig():
             Dict containing the configuration data
         """
         try:
-            # Create SDK config
+            # Create SDK config with bearer token authentication
+            (resolver, schemes) = bearer_auth_config(   
+                token=superposition_options.token
+            )
             sdk_config = Config(
-                endpoint_uri=superposition_options.endpoint
+                endpoint_uri=superposition_options.endpoint,
+                http_auth_scheme_resolver=resolver,
+                http_auth_schemes=schemes
             )
 
             # Create Superposition client

--- a/clients/python/sdk/AUTH_README.md
+++ b/clients/python/sdk/AUTH_README.md
@@ -1,0 +1,167 @@
+# Superposition Python SDK - Authentication Guide
+
+## ⚠️ Current State: Workaround Required
+
+The Smithy Python code generator (version `0.0.1`) is currently in **early alpha** and does not automatically generate convenience methods for HTTP authentication like the Rust and TypeScript SDKs do.
+
+### Comparison with Other SDKs:
+
+#### Rust SDK (Mature) ✅
+
+```rust
+let config = SdkConfig::builder()
+    .endpoint_url(&endpoint)
+    .bearer_token(token.into())  // Built-in!
+    .build();
+```
+
+#### TypeScript SDK (Mature) ✅
+
+```typescript
+const client = new SuperpositionClient({
+    endpoint,
+    token, // Built-in HttpBearerAuthSigner!
+});
+```
+
+#### Python SDK (Alpha) ⚠️
+
+```python
+# Manual implementation required!
+# See auth_helpers.py
+```
+
+## Solution: Use `auth_helpers.py`
+
+We've created a **temporary workaround** module (`auth_helpers.py`) that provides the authentication implementations until smithy-python adds built-in support.
+
+### Usage Example
+
+#### Bearer Token Authentication (Recommended)
+
+```python
+from superposition_sdk.auth_helpers import bearer_auth_config
+from superposition_sdk.client import Superposition
+from superposition_sdk.config import Config
+
+# Get bearer auth config
+(resolver, schemes) = bearer_auth_config(token="your-bearer-token-here")
+
+# Create config
+config = Config(
+    endpoint_uri="https://api.example.com",
+    http_auth_scheme_resolver=resolver,
+    http_auth_schemes=schemes
+)
+
+# Create client
+client = Superposition(config)
+
+# Make API calls
+response = await client.get_config(input_data)
+```
+
+#### Basic Authentication
+
+```python
+from superposition_sdk.auth_helpers import basic_auth_config
+from superposition_sdk.client import Superposition
+from superposition_sdk.config import Config
+
+# Get basic auth config
+(resolver, schemes) = basic_auth_config(username="user", password="pass")
+
+# Create config
+config = Config(
+    endpoint_uri="https://api.example.com",
+    http_auth_scheme_resolver=resolver,
+    http_auth_schemes=schemes
+)
+
+# Create client
+client = Superposition(config)
+```
+
+## Architecture
+
+The `auth_helpers.py` module implements:
+
+### Bearer Token Authentication:
+
+1. **`BearerTokenIdentity`** - Holds the bearer token
+2. **`BearerTokenSigner`** - Adds `Authorization: Bearer {token}` header
+3. **`BearerTokenResolver`** - Provides token identity
+4. **`BearerAuthScheme`** - Complete auth scheme implementation
+5. **`BearerAuthSchemeResolver`** - Resolves which auth to use
+6. **`bearer_auth_config()`** - Returns tuple of (resolver, schemes dict)
+
+### Basic Authentication:
+
+1. **`BasicAuthIdentity`** - Holds username and password
+2. **`BasicAuthSigner`** - Adds `Authorization: Basic {base64(user:pass)}` header
+3. **`BasicAuthResolver`** - Provides basic auth identity
+4. **`BasicAuthScheme`** - Complete auth scheme implementation
+5. **`BasicAuthSchemeResolver`** - Resolves which auth to use
+6. **`basic_auth_config()`** - Returns tuple of (resolver, schemes dict)
+
+## Why Is This Necessary?
+
+Smithy uses a plugin architecture where each language's code generator can implement features differently. The Python generator is newer and hasn't yet implemented the convenience methods for auth that other languages have.
+
+### What Smithy Python SHOULD Generate (but doesn't yet):
+
+```python
+# This would be ideal (like Rust):
+config = Config.builder()
+    .endpoint_url(endpoint)
+    .bearer_token(token)  # ← This doesn't exist yet!
+    .build()
+```
+
+### What We Have To Do Instead:
+
+Manually implement the full Smithy HTTP Auth protocol:
+
+-   Identity classes
+-   Signers
+-   Resolvers
+-   Auth schemes
+-   Auth scheme resolvers
+
+## Future
+
+Once smithy-python reaches version `1.0` or later, it should include built-in auth support. At that point:
+
+1. Remove `auth_helpers.py`
+2. Update all code to use the built-in methods
+3. Update this README
+
+## For SDK Users
+
+If you're using the Superposition Python SDK, always use the helper functions:
+
+```python
+from superposition_sdk.auth_helpers import bearer_auth_config
+from superposition_sdk.config import Config
+
+# Don't manually implement auth - use the helper!
+(resolver, schemes) = bearer_auth_config(token="your-token-here")
+config = Config(
+    endpoint_uri="https://api.example.com",
+    http_auth_scheme_resolver=resolver,
+    http_auth_schemes=schemes
+)
+```
+
+This ensures:
+
+-   ✅ Consistent auth implementation across the codebase
+-   ✅ Easier migration when smithy-python adds built-in support
+-   ✅ Proper auth protocol implementation
+-   ✅ Less boilerplate in your code
+
+## References
+
+-   [Smithy Authentication Traits](https://smithy.io/2.0/spec/authentication-traits.html)
+-   [Smithy Python GitHub](https://github.com/smithy-lang/smithy-python)
+-   [AWS Smithy Rust (for comparison)](https://github.com/smithy-lang/smithy-rs)

--- a/clients/python/sdk/superposition_sdk/auth_helpers.py
+++ b/clients/python/sdk/superposition_sdk/auth_helpers.py
@@ -1,0 +1,263 @@
+"""
+Authentication helpers for Superposition SDK.
+
+This module provides Bearer Token and Basic authentication implementations for the Smithy-generated
+Python SDK. This is a temporary workaround until smithy-python codegen adds built-in
+auth support (similar to Rust and TypeScript SDKs).
+
+Supported authentication schemes:
+    - Bearer Token: HTTP Bearer authentication using bearer tokens
+    - Basic Auth: HTTP Basic authentication using username and password
+
+TODO: Remove this once smithy-python 1.0+ provides built-in HTTP auth schemes.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict
+
+from smithy_core.aio.interfaces.identity import IdentityResolver
+from smithy_core.interfaces.identity import Identity, IdentityProperties
+from smithy_http import Field, Fields
+from smithy_http.aio import HTTPRequest
+from smithy_http.aio.interfaces.auth import (
+    HTTPAuthOption,
+    HTTPAuthScheme,
+    HTTPSigner,
+)
+
+from .auth import HTTPAuthParams, HTTPAuthSchemeResolver
+from .config import Config
+
+
+@dataclass
+class BearerTokenIdentity(Identity):
+    """Identity containing a bearer token."""
+
+    token: str
+
+
+class BearerTokenSigner(HTTPSigner[BearerTokenIdentity, IdentityProperties]):
+    """Signer that adds bearer token to Authorization header."""
+
+    async def sign(
+        self,
+        *,
+        http_request: HTTPRequest,
+        identity: BearerTokenIdentity,
+        signing_properties: IdentityProperties,
+    ) -> HTTPRequest:
+        """Add bearer token to the Authorization header."""
+        http_request.fields.extend(
+            Fields([Field(name="Authorization", values=[f"Bearer {identity.token}"])])
+        )
+        return http_request
+
+
+class BearerTokenResolver(
+    IdentityResolver[BearerTokenIdentity, IdentityProperties]
+):
+    """Resolver that provides the bearer token identity."""
+
+    def __init__(self, token: str):
+        if not token or not token.strip():
+            raise ValueError("Bearer token cannot be None or empty")
+        self._token = token
+
+    async def get_identity(
+        self, *, identity_properties: IdentityProperties
+    ) -> BearerTokenIdentity:
+        """Return the bearer token identity."""
+        return BearerTokenIdentity(token=self._token)
+
+
+@dataclass
+class BearerAuthScheme(
+    HTTPAuthScheme[
+        BearerTokenIdentity, Config, IdentityProperties, Dict[str, Any]
+    ]
+):
+    """HTTP Bearer authentication scheme."""
+
+    scheme_id: str = "smithy.api#httpBearerAuth"
+    signer: HTTPSigner[BearerTokenIdentity, IdentityProperties] = None
+    _token: str = None
+
+    def __init__(self, token: str):
+        if not token or not token.strip():
+            raise ValueError("Bearer token cannot be None or empty")
+        self.scheme_id = "smithy.api#httpBearerAuth"
+        self._token = token
+        self.signer = BearerTokenSigner()
+
+    def identity_resolver(
+        self, *, config: Config
+    ) -> IdentityResolver[BearerTokenIdentity, IdentityProperties]:
+        """Return the identity resolver for this auth scheme."""
+        return BearerTokenResolver(self._token)
+
+
+class BearerAuthSchemeResolver(HTTPAuthSchemeResolver):
+    """Auth scheme resolver that returns bearer auth option."""
+
+    def resolve_auth_scheme(
+        self, auth_parameters: HTTPAuthParams
+    ) -> list[HTTPAuthOption]:
+        """Return bearer auth as the authentication option."""
+        return [
+            HTTPAuthOption(
+                scheme_id="smithy.api#httpBearerAuth",
+                identity_properties={},
+                signer_properties={},
+            )
+        ]
+
+
+def bearer_auth_config(token: str) -> tuple[BearerAuthSchemeResolver, Dict[str, BearerAuthScheme]]:
+    """
+    Convenience function to get the config for bearer token authentication.
+
+    Args:
+        token: The bearer token for authentication
+
+    Returns:
+        Tuple of BearerAuthSchemeResolver and dict of BearerAuthSchemes
+
+    Example:
+        >>> from superposition_sdk.auth_helpers import bearer_auth_config
+        >>> from superposition_sdk.client import Superposition
+        >>> from superposition_sdk.config import Config
+        >>>
+        >>> (resolver, schemes) = bearer_auth_config(token="your-token-here")
+        >>> config = Config(
+        ...     endpoint_uri="https://api.example.com",
+        ...     http_auth_scheme_resolver=resolver,
+        ...     http_auth_schemes=schemes
+        ... )
+        >>> client = Superposition(config)
+    """
+    bearer_scheme = BearerAuthScheme(token=token)
+    auth_resolver = BearerAuthSchemeResolver()
+
+    return auth_resolver, {"smithy.api#httpBearerAuth": bearer_scheme}
+
+
+# Basic Auth implementation (similar pattern)
+@dataclass
+class BasicAuthIdentity(Identity):
+    """Identity containing username and password for basic auth."""
+
+    username: str
+    password: str
+
+
+class BasicAuthSigner(HTTPSigner[BasicAuthIdentity, IdentityProperties]):
+    """Signer that adds basic auth to Authorization header."""
+
+    async def sign(
+        self,
+        *,
+        http_request: HTTPRequest,
+        identity: BasicAuthIdentity,
+        signing_properties: IdentityProperties,
+    ) -> HTTPRequest:
+        """Add basic auth to the Authorization header."""
+        import base64
+
+        credentials = f"{identity.username}:{identity.password}"
+        encoded = base64.b64encode(credentials.encode()).decode()
+        http_request.fields.extend(
+            Fields([Field(name="Authorization", values=[f"Basic {encoded}"])])
+        )
+        return http_request
+
+
+class BasicAuthResolver(IdentityResolver[BasicAuthIdentity, IdentityProperties]):
+    """Resolver that provides the basic auth identity."""
+
+    def __init__(self, username: str, password: str):
+        if not username or not username.strip():
+            raise ValueError("Username cannot be None or empty")
+        if not password or not password.strip():
+            raise ValueError("Password cannot be None or empty")
+        self._username = username
+        self._password = password
+
+    async def get_identity(
+        self, *, identity_properties: IdentityProperties
+    ) -> BasicAuthIdentity:
+        """Return the basic auth identity."""
+        return BasicAuthIdentity(username=self._username, password=self._password)
+
+
+@dataclass
+class BasicAuthScheme(
+    HTTPAuthScheme[BasicAuthIdentity, Config, IdentityProperties, Dict[str, Any]]
+):
+    """HTTP Basic authentication scheme."""
+
+    scheme_id: str = "smithy.api#httpBasicAuth"
+    signer: HTTPSigner[BasicAuthIdentity, IdentityProperties] = None
+    _username: str = None
+    _password: str = None
+
+    def __init__(self, username: str, password: str):
+        if not username or not username.strip():
+            raise ValueError("Username cannot be None or empty")
+        if not password or not password.strip():
+            raise ValueError("Password cannot be None or empty")
+        self.scheme_id = "smithy.api#httpBasicAuth"
+        self._username = username
+        self._password = password
+        self.signer = BasicAuthSigner()
+
+    def identity_resolver(
+        self, *, config: Config
+    ) -> IdentityResolver[BasicAuthIdentity, IdentityProperties]:
+        """Return the identity resolver for this auth scheme."""
+        return BasicAuthResolver(self._username, self._password)
+
+
+class BasicAuthSchemeResolver(HTTPAuthSchemeResolver):
+    """Auth scheme resolver that returns basic auth option."""
+
+    def resolve_auth_scheme(
+        self, auth_parameters: HTTPAuthParams
+    ) -> list[HTTPAuthOption]:
+        """Return basic auth as the authentication option."""
+        return [
+            HTTPAuthOption(
+                scheme_id="smithy.api#httpBasicAuth",
+                identity_properties={},
+                signer_properties={},
+            )
+        ]
+
+
+def basic_auth_config(username: str, password: str) -> tuple[BasicAuthSchemeResolver, Dict[str, BasicAuthScheme]]:
+    """
+    Convenience function to get the config for basic authentication.
+
+    Args:
+        username: The username for basic auth
+        password: The password for basic auth
+
+    Returns:
+        Tuple of BasicAuthSchemeResolver and dict of BasicAuthSchemes
+
+    Example:
+        >>> from superposition_sdk.auth_helpers import basic_auth_config
+        >>> from superposition_sdk.client import Superposition
+        >>> from superposition_sdk.config import Config
+        >>>
+        >>> (resolver, schemes) = basic_auth_config(username="user", password="pass")
+        >>> config = Config(
+        ...     endpoint_uri="https://api.example.com",
+        ...     http_auth_scheme_resolver=resolver,
+        ...     http_auth_schemes=schemes
+        ... )
+        >>> client = Superposition(config)
+    """
+    basic_scheme = BasicAuthScheme(username=username, password=password)
+    auth_resolver = BasicAuthSchemeResolver()
+
+    return auth_resolver, {"smithy.api#httpBasicAuth": basic_scheme}

--- a/makefile
+++ b/makefile
@@ -268,11 +268,14 @@ smithy-clients: smithy-build
 	mkdir -p clients/java/sdk/src/main/java
 	cp -r $(SMITHY_BUILD_SRC)/java-client-codegen/*\
 				clients/java/sdk/src/main/java
+	git restore clients/java/sdk/src/main/java/io/juspay/superposition/client/auth/AuthHelper.java
 
 	rm -rf clients/python/sdk
 	mkdir -p clients/python/sdk
 	cp -r $(SMITHY_BUILD_SRC)/python-client-codegen/*\
 				clients/python/sdk
+	git restore clients/python/sdk/superposition_sdk/auth_helpers.py
+	git restore clients/python/sdk/AUTH_README.md
 
 	rm -rf clients/haskell/sdk
 	mkdir -p clients/haskell/sdk


### PR DESCRIPTION
## Problem
token not being passed to sdk client in python provider

## Solution
pass the token to the client by doing proper configuration

### Note
java and python smithy generators do not have complete support for auth generation yet
it requires implementing a few types which needs to be passed to the sdk client as config during setup
this was already being done correctly inside java, but the implemented types were present in the java-provider
this setup, inherently, requires all users of the java sdk to reimplement these types on their side to be able to use

to avoid this, moved this piece of code to the java sdk itself, and introduced the same change for the python sdk also