### PR TITLE
fix(helm): replace http with 80 in service port

### DIFF
--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: http
+    - port: 80
       targetPort: {{ .Values.service.port }}
       protocol: TCP
       name: http


### PR DESCRIPTION
## Problem
Describe the problem you are trying to solve here

Service port was using `http` alias for `80` port. This caused issue during deployment as kubernetes couldn't resolve the port

## Solution
Provide a brief summary of your solution so that reviewers can understand your code

Updated the `http` alias to 80

## Environment variable changes

What ENVs need to be added or changed

## Pre-deployment activity
Things needed to be done before deploying this change (if any)

## Post-deployment activity
Things needed to be done after deploying this change (if any)

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
Describe any possible issues that could occur because of this change