### PR TITLE
feat(auth_n): Separate Saas OIDC login from core OIDC login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,13 +21,20 @@ ACTIX_KEEP_ALIVE=120
 MAX_DB_CONNECTION_POOL_SIZE=3
 TENANT_MIDDLEWARE_EXCLUSION_LIST="/health,/assets/favicon.ico,/pkg/frontend.js,/pkg,/pkg/frontend_bg.wasm,/pkg/tailwind.css,/pkg/style.css,/assets,/admin,/oidc/login,/admin/organisations,/organisations,/organisations/switch/{organisation_id},/"
 SERVICE_PREFIX=""
+### Env(s) for NO AuthN
 AUTH_PROVIDER=DISABLED
+### Env(s) for Simple OIDC AuthN
 # AUTH_PROVIDER=OIDC+http://localhost:8081/realms/users
 # OIDC_CLIENT_ID=superposition
 # OIDC_CLIENT_SECRET=superposition_secret
-# OIDC_TOKEN_ENDPOINT_FORMAT="http://localhost:8081/realms/<organisation>/protocol/openid-connect/token"
-# OIDC_ISSUER_ENDPOINT_FORMAT="http://localhost:8081/realms/<organisation>"
 # OIDC_REDIRECT_HOST="http://localhost:8080"
+### Env(s) for SaaS OIDC AuthN
+# AUTH_PROVIDER=OIDC_SAAS+http://localhost:8081/realms/users
+# OIDC_CLIENT_ID=superposition
+# OIDC_CLIENT_SECRET=superposition_secret
+# OIDC_REDIRECT_HOST="http://localhost:8080"
+# OIDC_ORG_TOKEN_ENDPOINT_FORMAT="http://localhost:8081/realms/<organisation>/protocol/openid-connect/token"
+# OIDC_ORG_ISSUER_ENDPOINT_FORMAT="http://localhost:8081/realms/<organisation>"
 WORKER_ID=1
 ENCRYPTED_KEYS="" # Used for webhook secrets, API keys, etc.
 # ENCRYPTED_KEYS="TEST_API_KEY,DASHBOARD_API_KEY"

--- a/crates/service_utils/src/middlewares/auth_n/helpers.rs
+++ b/crates/service_utils/src/middlewares/auth_n/helpers.rs
@@ -1,0 +1,44 @@
+use actix_web::{web::Data, HttpRequest};
+use diesel::{
+    query_dsl::methods::{OrderDsl, SelectDsl},
+    Connection, ExpressionMethods, RunQueryDsl,
+};
+use superposition_types::database::superposition_schema::superposition::organisations;
+
+use crate::service::types::AppState;
+
+pub(super) fn fetch_org_ids_from_db(
+    req: &HttpRequest,
+) -> Result<Vec<String>, &'static str> {
+    let app_state = match req.app_data::<Data<AppState>>() {
+        Some(state) => state,
+        None => {
+            log::info!("DbConnection-FromRequest: Unable to get app_data from request");
+            return Err("Unable to get app_data from request");
+        }
+    };
+
+    match app_state.db_pool.get() {
+        Ok(mut conn) => {
+            conn.set_prepared_statement_cache_size(
+                diesel::connection::CacheSize::Disabled,
+            );
+            let orgs = organisations::table
+                .order(organisations::created_at.desc())
+                .select(organisations::id)
+                .get_results::<String>(&mut conn);
+
+            match orgs {
+                Ok(orgs) => Ok(orgs),
+                Err(e) => {
+                    log::error!("Failed to fetch organisations: {:?}", e);
+                    Err("Failed to fetch organisations")
+                }
+            }
+        }
+        Err(e) => {
+            log::info!("Unable to get db connection from pool, error: {e}");
+            Err("Unable to get db connection from pool")
+        }
+    }
+}

--- a/crates/service_utils/src/middlewares/auth_n/no_auth.rs
+++ b/crates/service_utils/src/middlewares/auth_n/no_auth.rs
@@ -1,18 +1,14 @@
-use actix_web::{
-    error,
-    web::{Data, Json},
-    HttpRequest, HttpResponse, Scope,
-};
-use diesel::{Connection, ExpressionMethods, QueryDsl, RunQueryDsl};
+use actix_web::{error, HttpRequest, HttpResponse, Scope};
 use futures_util::future::LocalBoxFuture;
-use superposition_types::{
-    database::superposition_schema::superposition::organisations, User,
-};
+use superposition_types::User;
 
-use crate::service::types::AppState;
+use crate::middlewares::auth_n::helpers::fetch_org_ids_from_db;
 
 use super::authentication::{Authenticator, Login};
 
+/// An Authenticator implementation that performs no authentication
+/// This is primarily for development and testing purposes
+/// In production, a proper Authenticator (like OIDCAuthenticator) should be used
 pub struct DisabledAuthenticator {
     path_prefix: String,
 }
@@ -41,45 +37,8 @@ impl Authenticator for DisabledAuthenticator {
     }
 
     fn get_organisations(&self, req: &actix_web::HttpRequest) -> HttpResponse {
-        let app_state = match req.app_data::<Data<AppState>>() {
-            Some(state) => state,
-            None => {
-                log::info!(
-                    "DbConnection-FromRequest: Unable to get app_data from request"
-                );
-                return error::ErrorInternalServerError(
-                    "Unable to get app_data from request",
-                )
-                .into();
-            }
-        };
-
-        let result = match app_state.db_pool.get() {
-            Ok(mut conn) => {
-                conn.set_prepared_statement_cache_size(
-                    diesel::connection::CacheSize::Disabled,
-                );
-                let orgs = organisations::table
-                    .order(organisations::created_at.desc())
-                    .select(organisations::id)
-                    .get_results::<String>(&mut conn);
-
-                match orgs {
-                    Ok(orgs) => Ok(orgs),
-                    Err(e) => {
-                        log::error!("Failed to fetch organisations: {:?}", e);
-                        Err("Failed to fetch organisations")
-                    }
-                }
-            }
-            Err(e) => {
-                log::info!("Unable to get db connection from pool, error: {e}");
-                Err("Unable to get db connection from pool")
-            }
-        };
-
-        match result {
-            Ok(resp) => HttpResponse::Ok().json(Json(resp)),
+        match fetch_org_ids_from_db(req) {
+            Ok(resp) => HttpResponse::Ok().json(resp),
             Err(resp) => error::ErrorInternalServerError(resp).into(),
         }
     }

--- a/crates/service_utils/src/middlewares/auth_n/oidc.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc.rs
@@ -1,147 +1,40 @@
+mod saas_authenticator;
+mod simple_authenticator;
 mod types;
 mod utils;
 
-use std::sync::Arc;
-
 use actix_web::{
     cookie::{time::Duration, Cookie},
-    error::{ErrorBadRequest, ErrorInternalServerError},
-    get,
+    error::ErrorInternalServerError,
     http::header,
-    web::{self, Data, Json, Query},
+    web::{Data, Query},
     HttpRequest, HttpResponse,
 };
 use base64::{engine::general_purpose, Engine};
-use derive_more::{Deref, DerefMut};
-use futures_util::future::LocalBoxFuture;
 use openidconnect::{
     self as oidcrs,
-    core::{CoreClient, CoreProviderMetadata, CoreResponseType},
-    AuthenticationFlow, ClientId, ClientSecret, CsrfToken, IssuerUrl, Nonce, RedirectUrl,
-    ResourceOwnerPassword, ResourceOwnerUsername, Scope, TokenResponse, TokenUrl,
+    core::{CoreClient, CoreResponseType},
+    AuthenticationFlow, CsrfToken, Nonce, TokenResponse,
 };
+pub use saas_authenticator::SaasOIDCAuthenticator;
+pub use simple_authenticator::SimpleOIDCAuthenticator;
 use superposition_types::User;
-use types::{
-    GlobalUserClaims, GlobalUserTokenResponse, LoginParams, OrgUserClaims,
-    OrgUserTokenResponse, ProtectionCookie, RedirectionState,
+
+use crate::middlewares::auth_n::{
+    authentication::{Authenticator, Login},
+    oidc::types::{LoginParams, ProtectionCookie, RedirectionState},
 };
-use utils::{presence_no_check, try_user_from, verify_presence};
 
-use crate::{extensions::HttpRequestExt, helpers::get_from_env_unsafe};
+/// Trait defining OIDC specific authenticator methods
+/// This is to be implemented by any OIDC based authenticator - SimpleOIDCAuthenticator, SaasOIDCAuthenticator etc.
+trait OIDCAuthenticator: Authenticator {
+    fn get_client(&self) -> &CoreClient;
 
-use super::authentication::{Authenticator, Login};
-
-#[derive(Clone)]
-pub struct OIDCAuthenticatorInner {
-    client: CoreClient,
-    provider_metadata: CoreProviderMetadata,
-    client_id: String,
-    client_secret: String,
-    base_url: String,
-    path_prefix: String,
-    issuer_endpoint_format: String,
-    token_endpoint_format: String,
-}
-
-#[derive(Deref, DerefMut, Clone)]
-pub struct OIDCAuthenticator(Arc<OIDCAuthenticatorInner>);
-
-impl OIDCAuthenticator {
-    pub async fn new(
-        idp_url: String,
-        base_url: String,
-        path_prefix: String,
-        client_id: String,
-        client_secret: String,
-    ) -> Result<Self, Box<dyn std::error::Error>> {
-        let issuer_endpoint_format =
-            get_from_env_unsafe::<String>("OIDC_ISSUER_ENDPOINT_FORMAT").unwrap();
-        let token_endpoint_format =
-            get_from_env_unsafe::<String>("OIDC_TOKEN_ENDPOINT_FORMAT").unwrap();
-
-        let issuer_url = IssuerUrl::new(idp_url)
-            .map_err(|e| format!("Unable to create issuer url: {}", e))
-            .unwrap();
-
-        // Discover OpenID Provider metadata
-        let provider_metadata = CoreProviderMetadata::discover_async(
-            issuer_url,
-            oidcrs::reqwest::async_http_client,
-        )
-        .await?;
-
-        // Create client
-        let client = CoreClient::from_provider_metadata(
-            provider_metadata.clone(),
-            ClientId::new(client_id.clone()),
-            Some(ClientSecret::new(client_secret.clone())),
-        )
-        .set_redirect_uri(RedirectUrl::new(format!(
-            "{base_url}{path_prefix}/oidc/login"
-        ))?);
-
-        Ok(Self(Arc::new(OIDCAuthenticatorInner {
-            client,
-            provider_metadata,
-            client_id,
-            client_secret,
-            base_url,
-            path_prefix,
-            issuer_endpoint_format,
-            token_endpoint_format,
-        })))
-    }
-
-    fn get_org_client(&self, org_id: &str) -> Result<CoreClient, String> {
-        let issuer_url = match self.get_issuer_url(org_id) {
-            Ok(issuer_url) => issuer_url,
-            Err(e) => return Err(format!("Unable to create issuer url: {e}")),
-        };
-
-        let token_url = match self.get_token_url(org_id) {
-            Ok(token_url) => token_url,
-            Err(e) => return Err(format!("Unable to create token url: {e}")),
-        };
-
-        let redirect_url = match RedirectUrl::new(format!(
-            "{}{}/",
-            self.base_url.clone(),
-            self.path_prefix
-        )) {
-            Ok(redirect_url) => redirect_url,
-            Err(e) => return Err(format!("Unable to create redirect url: {e}")),
-        };
-
-        let provider = self
-            .provider_metadata
-            .clone()
-            .set_issuer(issuer_url)
-            .set_token_endpoint(Some(token_url));
-
-        Ok(CoreClient::from_provider_metadata(
-            provider,
-            ClientId::new(self.client_id.clone()),
-            Some(ClientSecret::new(self.client_secret.clone())),
-        )
-        .set_redirect_uri(redirect_url))
-    }
-
-    fn get_issuer_url(
+    fn get_global_user(
         &self,
-        organisation_id: &str,
-    ) -> Result<IssuerUrl, url::ParseError> {
-        let issuer_endpoint = self
-            .issuer_endpoint_format
-            .replace("<organisation>", organisation_id);
-        IssuerUrl::new(issuer_endpoint)
-    }
-
-    fn get_token_url(&self, organisation_id: &str) -> Result<TokenUrl, url::ParseError> {
-        let token_endpoint = self
-            .token_endpoint_format
-            .replace("<organisation>", organisation_id);
-        TokenUrl::new(token_endpoint)
-    }
+        request: &HttpRequest,
+        path: String,
+    ) -> Result<User, HttpResponse>;
 
     fn new_redirect(&self, cookie_type: &Login, path: String) -> HttpResponse {
         let state = RedirectionState {
@@ -153,7 +46,7 @@ impl OIDCAuthenticator {
             .encode(serde_json::to_string(&state).unwrap_or_default());
 
         let (auth_url, csrf_token, nonce) = self
-            .client
+            .get_client()
             .authorize_url(
                 AuthenticationFlow::<CoreResponseType>::AuthorizationCode,
                 || CsrfToken::new(encoded_state),
@@ -199,302 +92,75 @@ impl OIDCAuthenticator {
         }
     }
 
-    fn decode_global_token(&self, cookie: &str) -> Result<GlobalUserClaims, String> {
-        let ctr = serde_json::from_str::<GlobalUserTokenResponse>(cookie)
-            .map_err(|e| format!("Error while decoding token: {e}"))?;
-        ctr.id_token()
-            .ok_or(String::from("Id Token not found"))?
-            .claims(&self.client.id_token_verifier(), verify_presence)
-            .map_err(|e| format!("Error in claims verification: {e}"))
-            .cloned()
-    }
+    async fn login(
+        data: Data<Self>,
+        req: HttpRequest,
+        params: Query<LoginParams>,
+    ) -> actix_web::Result<HttpResponse> {
+        let login_type = Login::Global;
 
-    fn get_global_user(
-        &self,
-        request: &HttpRequest,
-        path: String,
-    ) -> Result<User, HttpResponse> {
-        let token = request.cookie(&Login::Global.to_string()).and_then(|c| {
-            self.decode_global_token(c.value())
-                .map_err(|e| log::error!("Error in decoding user : {e}"))
-                .ok()
-        });
-        if let Some(token_response) = token {
-            Ok(try_user_from(&token_response).map_err(|e| {
-                log::error!("Unable to get user: {e}");
-                ErrorBadRequest(String::from("Unable to get user"))
-            })?)
-        } else {
-            log::error!("Error user not found in cookies");
-            Err(self.new_redirect(&Login::Global, path))
-        }
-    }
-
-    fn decode_org_token(
-        &self,
-        org_id: &str,
-        cookie: &str,
-    ) -> Result<OrgUserClaims, String> {
-        let client = self
-            .get_org_client(org_id)
-            .map_err(|e| format!("Error in getting Org specific client: {e}"))?;
-        let id_token_verifier = client.id_token_verifier();
-
-        let ctr = serde_json::from_str::<OrgUserTokenResponse>(cookie)
-            .map_err(|e| format!("Error while decoding token: {e}"))?;
-        ctr.id_token()
-            .ok_or(String::from("Id Token not found"))?
-            .claims(&id_token_verifier, presence_no_check)
-            .map_err(|e| format!("Error in claims verification: {e}"))
-            .cloned()
-    }
-
-    async fn get_org_user(
-        self,
-        request: HttpRequest,
-        login_type: Login,
-    ) -> Result<User, HttpResponse> {
-        let org_id = request.get_organisation_id().unwrap_or_default();
-        let token = request.cookie(&login_type.to_string()).and_then(|c| {
-            self.decode_org_token(&org_id, c.value())
-                .map_err(|e| log::error!("Error in decoding org_user : {e}"))
-                .ok()
-        });
-        if let Some(token_response) = token {
-            Ok(try_user_from(&token_response).map_err(|e| {
-                log::error!("Unable to get org_user: {e}");
-                ErrorBadRequest(String::from("Unable to get user"))
-            })?)
-        } else {
-            self.generate_org_user(&request, &org_id, &login_type)
-                .await
-                .and_then(|token| {
-                    let cookie = Cookie::build(login_type.to_string(), token)
-                        .path(self.get_cookie_path())
-                        .http_only(true)
-                        .secure(true)
-                        .max_age(Duration::days(1))
-                        .finish();
-                    Err(HttpResponse::Found()
-                        .cookie(cookie)
-                        .insert_header((header::LOCATION, request.path().to_string()))
-                        .finish())
-                })
-        }
-    }
-}
-
-impl Authenticator for OIDCAuthenticator {
-    fn get_path_prefix(&self) -> String {
-        self.path_prefix.clone()
-    }
-
-    fn authenticate(
-        &self,
-        request: &HttpRequest,
-        login_type: &Login,
-    ) -> LocalBoxFuture<'static, Result<User, HttpResponse>> {
-        let auth_n = self.clone();
-        match login_type {
-            Login::None => Box::pin(async { Ok(User::default()) }),
-            Login::Global => {
-                let resp = auth_n.get_global_user(
-                    request,
-                    format!("{}/admin/organisations", self.path_prefix),
-                );
-                Box::pin(async { resp })
-            }
-            Login::Org(_) => {
-                match auth_n.get_global_user(request, request.path().to_string()) {
-                    Err(e) => Box::pin(async { Err(e) }),
-                    Ok(_) => {
-                        let fut =
-                            auth_n.get_org_user(request.clone(), login_type.clone());
-                        Box::pin(fut)
-                    }
-                }
-            }
-        }
-    }
-
-    fn routes(&self) -> actix_web::Scope {
-        web::scope("oidc")
-            .app_data(Data::new(self.to_owned()))
-            .service(login)
-    }
-
-    fn get_organisations(&self, req: &HttpRequest) -> HttpResponse {
-        let organisations = req
-            .cookie(&Login::Global.to_string())
-            .and_then(|user_cookie| {
-                self.decode_global_token(user_cookie.value())
-                    .map_err(|e| log::error!("Error in decoding user : {e}"))
-                    .ok()
-            })
-            .map(|claims| claims.additional_claims().organisations.clone());
-
-        match organisations {
-            Some(organisations) => HttpResponse::Ok().json(Json(organisations)),
-            None => self.new_redirect(
-                &Login::Global,
-                format!("{}/admin/organisations", self.path_prefix),
-            ),
-        }
-    }
-
-    fn generate_org_user(
-        &self,
-        req: &HttpRequest,
-        org_id: &str,
-        login_type: &Login,
-    ) -> LocalBoxFuture<'_, Result<String, HttpResponse>> {
-        let client = match self.get_org_client(org_id) {
-            Ok(client) => client,
+        let p_cookie = match ProtectionCookie::from_req(&req) {
+            Ok(p_cookie) => p_cookie,
             Err(e) => {
-                log::error!("Error in getting Org specific client: {e}");
-                return Box::pin(async {
-                    Err(ErrorInternalServerError(String::from(
-                        "Error in getting Org specific client",
-                    ))
-                    .into())
-                });
+                log::error!("OIDC: Missing/Bad protection-cookie, redirecting... {e}");
+                return Ok(data.new_redirect(
+                    &login_type,
+                    format!("{}/admin/organisations", data.get_path_prefix()),
+                ));
             }
         };
 
-        let user = req
-            .cookie(&Login::Global.to_string())
-            .and_then(|user_cookie| {
-                self.decode_global_token(user_cookie.value())
-                    .map_err(|e| log::error!("Error in decoding user : {e}"))
-                    .ok()
-            })
-            .map(|claims| {
-                (
-                    claims.preferred_username().cloned(),
-                    claims.additional_claims().switch_pass.clone(),
-                )
-            });
-        let (username, switch_pass) = if let Some(user) = user {
-            user
-        } else {
-            return Box::pin(async { Err(ErrorBadRequest("Cookie incorrect").into()) });
-        };
-
-        let username = if let Some(u) = username {
-            u
-        } else {
-            return Box::pin(async { Err(ErrorBadRequest("Username not found").into()) });
-        };
-
-        let user = ResourceOwnerUsername::new(username.to_string());
-        let pass = ResourceOwnerPassword::new(switch_pass);
-        let redirect = self.new_redirect(
-            login_type,
-            format!("{}/admin/organisations", self.path_prefix),
-        );
-
-        Box::pin(async move {
-            client
-                .exchange_password(&user, &pass)
-                .add_scope(Scope::new(String::from("openid")))
-                .request_async(oidcrs::reqwest::async_http_client)
-                .await
-                .map_err(|e| {
-                    log::error!("Failed to switch organisation for token: {e}");
-                    Some(ErrorInternalServerError(
-                        "Failed to switch organisation for token".to_string(),
-                    ))
-                })
-                .and_then(|tr| {
-                    tr.id_token()
-                        .ok_or_else(|| {
-                            log::error!("No identity-token!");
-                            None
-                        })?
-                        .claims(&client.id_token_verifier(), presence_no_check)
-                        .map_err(|e| {
-                            log::error!("Couldn't verify claims: {e}");
-                            None
-                        })?;
-
-                    serde_json::to_string(&tr).map_err(|e| {
-                        log::error!("Unable to stringify data: {e}");
-                        Some(ErrorInternalServerError(
-                            "Unable to stringify data".to_string(),
-                        ))
-                    })
-                })
-                .map_err(|e| e.map(Into::into).unwrap_or(redirect))
-        })
-    }
-}
-
-#[get("/login")]
-async fn login(
-    data: Data<OIDCAuthenticator>,
-    req: HttpRequest,
-    params: Query<LoginParams>,
-) -> actix_web::Result<HttpResponse> {
-    let login_type = Login::Global;
-    let p_cookie = match ProtectionCookie::from_req(&req) {
-        Ok(p_cookie) => p_cookie,
-        Err(e) => {
-            log::error!("OIDC: Missing/Bad protection-cookie, redirecting... {}", e);
+        if *params.state.csrf.secret() != *p_cookie.csrf.secret() {
+            log::error!("OIDC: Bad csrf");
             return Ok(data.new_redirect(
                 &login_type,
-                format!("{}/admin/organisations", data.path_prefix),
+                format!("{}/admin/organisations", data.get_path_prefix()),
             ));
         }
-    };
 
-    if *params.state.csrf.secret() != *p_cookie.csrf.secret() {
-        log::error!("OIDC: Bad csrf",);
-        return Ok(data.new_redirect(
-            &login_type,
-            format!("{}/admin/organisations", data.path_prefix),
-        ));
-    }
-
-    // Exchange the code with a token.
-    let token_response = data
-        .client
-        .exchange_code(params.code.clone())
-        .request_async(oidcrs::reqwest::async_http_client)
-        .await
-        .map_err(|e| {
-            log::error!("Failed to exchange auth-code for token: {e}");
-            ErrorInternalServerError("Failed to exchange auth-code for token".to_string())
-        })?;
-
-    let response = token_response
-        .id_token()
-        .ok_or_else(|| log::error!("No identity-token!"))
-        .and_then(|t| {
-            t.claims(&data.client.id_token_verifier(), &p_cookie.nonce)
-                .map_err(|e| log::error!("Couldn't verify claims: {e}"))
-        })
-        .map(|_| token_response.clone());
-
-    match response {
-        Ok(r) => {
-            let token = serde_json::to_string(&r).map_err(|e| {
-                log::error!("Unable to stringify data: {e}");
-                ErrorInternalServerError("Unable to stringify data".to_string())
+        // Exchange the code with a token.
+        let token_response = data
+            .get_client()
+            .exchange_code(params.code.clone())
+            .request_async(oidcrs::reqwest::async_http_client)
+            .await
+            .map_err(|e| {
+                log::error!("Failed to exchange auth-code for token: {e}");
+                ErrorInternalServerError(
+                    "Failed to exchange auth-code for token".to_string(),
+                )
             })?;
-            let cookie = Cookie::build(login_type.to_string(), token)
-                .path(data.get_cookie_path())
-                .http_only(true)
-                .secure(true)
-                .max_age(Duration::days(1))
-                .finish();
-            Ok(HttpResponse::Found()
-                .cookie(cookie)
-                .insert_header((header::LOCATION, params.state.redirect_uri.clone()))
-                .finish())
+
+        let response = token_response
+            .id_token()
+            .ok_or_else(|| log::error!("No identity-token!"))
+            .and_then(|t| {
+                t.claims(&data.get_client().id_token_verifier(), &p_cookie.nonce)
+                    .map_err(|e| log::error!("Couldn't verify claims: {e}"))
+            })
+            .map(|_| token_response.clone());
+
+        match response {
+            Ok(r) => {
+                let token = serde_json::to_string(&r).map_err(|e| {
+                    log::error!("Unable to stringify data: {e}");
+                    ErrorInternalServerError("Unable to stringify data".to_string())
+                })?;
+                let cookie = Cookie::build(login_type.to_string(), token)
+                    .path(data.get_cookie_path())
+                    .http_only(true)
+                    .secure(true)
+                    .max_age(Duration::days(1))
+                    .finish();
+                Ok(HttpResponse::Found()
+                    .cookie(cookie)
+                    .insert_header((header::LOCATION, params.state.redirect_uri.clone()))
+                    .finish())
+            }
+            Err(()) => Ok(data.new_redirect(
+                &login_type,
+                format!("{}/admin/organisations", data.get_path_prefix()),
+            )),
         }
-        Err(()) => Ok(data.new_redirect(
-            &login_type,
-            format!("{}/admin/organisations", data.path_prefix),
-        )),
     }
 }

--- a/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
@@ -1,0 +1,390 @@
+use std::sync::Arc;
+
+use actix_web::{
+    cookie::{time::Duration, Cookie},
+    error::{ErrorBadRequest, ErrorInternalServerError},
+    http::header,
+    web::{self, get, resource, Data, Json},
+    HttpRequest, HttpResponse,
+};
+use derive_more::{Deref, DerefMut};
+use futures_util::future::LocalBoxFuture;
+use openidconnect::{
+    self as oidcrs,
+    core::{CoreClient, CoreProviderMetadata},
+    ClientId, ClientSecret, IssuerUrl, RedirectUrl, ResourceOwnerPassword,
+    ResourceOwnerUsername, Scope, TokenResponse, TokenUrl,
+};
+use superposition_types::User;
+
+use crate::{
+    extensions::HttpRequestExt,
+    helpers::get_from_env_unsafe,
+    middlewares::auth_n::{
+        authentication::{Authenticator, Login},
+        oidc::{
+            types::{
+                GlobalUserClaims, GlobalUserTokenResponse, OrgUserClaims,
+                OrgUserTokenResponse,
+            },
+            utils::{presence_no_check, try_user_from, verify_presence},
+            OIDCAuthenticator,
+        },
+    },
+};
+
+#[derive(Clone)]
+pub struct AuthenticatorInner {
+    client: CoreClient,
+    provider_metadata: CoreProviderMetadata,
+    client_id: String,
+    client_secret: String,
+    base_url: String,
+    path_prefix: String,
+    issuer_endpoint_format: String,
+    token_endpoint_format: String,
+}
+
+/// An OIDC Authenticator implementation for SaaS setups
+/// where each organisation has its own OIDC provider endpoints
+/// First issuer also acts as a global identity provider which
+/// provides authorization to the individual orgs
+///
+/// Env(s) needed for OIDC SaaS Authenticator:
+/// OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_REDIRECT_HOST - reused from Simple OIDC Authenticator
+/// OIDC_ORG_TOKEN_ENDPOINT_FORMAT, OIDC_ORG_ISSUER_ENDPOINT_FORMAT - new envs for SaaS setup
+#[derive(Deref, DerefMut, Clone)]
+pub struct SaasOIDCAuthenticator(Arc<AuthenticatorInner>);
+
+impl SaasOIDCAuthenticator {
+    pub async fn new(
+        idp_url: String,
+        base_url: String,
+        path_prefix: String,
+        client_id: String,
+        client_secret: String,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let issuer_endpoint_format =
+            get_from_env_unsafe::<String>("OIDC_ORG_ISSUER_ENDPOINT_FORMAT").unwrap();
+        let token_endpoint_format =
+            get_from_env_unsafe::<String>("OIDC_ORG_TOKEN_ENDPOINT_FORMAT").unwrap();
+
+        let issuer_url = IssuerUrl::new(idp_url)
+            .map_err(|e| format!("Unable to create issuer url: {}", e))
+            .unwrap();
+
+        // Discover OpenID Provider metadata
+        let provider_metadata = CoreProviderMetadata::discover_async(
+            issuer_url,
+            oidcrs::reqwest::async_http_client,
+        )
+        .await?;
+
+        // Create client
+        let client = CoreClient::from_provider_metadata(
+            provider_metadata.clone(),
+            ClientId::new(client_id.clone()),
+            Some(ClientSecret::new(client_secret.clone())),
+        )
+        .set_redirect_uri(RedirectUrl::new(format!(
+            "{base_url}{path_prefix}/oidc/login"
+        ))?);
+
+        Ok(Self(Arc::new(AuthenticatorInner {
+            client,
+            provider_metadata,
+            client_id,
+            client_secret,
+            base_url,
+            path_prefix,
+            issuer_endpoint_format,
+            token_endpoint_format,
+        })))
+    }
+
+    fn get_org_client(&self, org_id: &str) -> Result<CoreClient, String> {
+        let issuer_url = match self.get_issuer_url(org_id) {
+            Ok(issuer_url) => issuer_url,
+            Err(e) => return Err(format!("Unable to create issuer url: {e}")),
+        };
+
+        let token_url = match self.get_token_url(org_id) {
+            Ok(token_url) => token_url,
+            Err(e) => return Err(format!("Unable to create token url: {e}")),
+        };
+
+        let redirect_url = match RedirectUrl::new(format!(
+            "{}{}/",
+            self.base_url.clone(),
+            self.path_prefix
+        )) {
+            Ok(redirect_url) => redirect_url,
+            Err(e) => return Err(format!("Unable to create redirect url: {e}")),
+        };
+
+        let provider = self
+            .provider_metadata
+            .clone()
+            .set_issuer(issuer_url)
+            .set_token_endpoint(Some(token_url));
+
+        Ok(CoreClient::from_provider_metadata(
+            provider,
+            ClientId::new(self.client_id.clone()),
+            Some(ClientSecret::new(self.client_secret.clone())),
+        )
+        .set_redirect_uri(redirect_url))
+    }
+
+    fn get_issuer_url(
+        &self,
+        organisation_id: &str,
+    ) -> Result<IssuerUrl, url::ParseError> {
+        let issuer_endpoint = self
+            .issuer_endpoint_format
+            .replace("<organisation>", organisation_id);
+        IssuerUrl::new(issuer_endpoint)
+    }
+
+    fn get_token_url(&self, organisation_id: &str) -> Result<TokenUrl, url::ParseError> {
+        let token_endpoint = self
+            .token_endpoint_format
+            .replace("<organisation>", organisation_id);
+        TokenUrl::new(token_endpoint)
+    }
+
+    fn decode_global_token(&self, cookie: &str) -> Result<GlobalUserClaims, String> {
+        let ctr = serde_json::from_str::<GlobalUserTokenResponse>(cookie)
+            .map_err(|e| format!("Error while decoding token: {e}"))?;
+        ctr.id_token()
+            .ok_or(String::from("Id Token not found"))?
+            .claims(&self.client.id_token_verifier(), verify_presence)
+            .map_err(|e| format!("Error in claims verification: {e}"))
+            .cloned()
+    }
+
+    fn decode_org_token(
+        &self,
+        org_id: &str,
+        cookie: &str,
+    ) -> Result<OrgUserClaims, String> {
+        let client = self
+            .get_org_client(org_id)
+            .map_err(|e| format!("Error in getting Org specific client: {e}"))?;
+        let id_token_verifier = client.id_token_verifier();
+
+        let ctr = serde_json::from_str::<OrgUserTokenResponse>(cookie)
+            .map_err(|e| format!("Error while decoding token: {e}"))?;
+        ctr.id_token()
+            .ok_or(String::from("Id Token not found"))?
+            .claims(&id_token_verifier, presence_no_check)
+            .map_err(|e| format!("Error in claims verification: {e}"))
+            .cloned()
+    }
+
+    async fn get_org_user(
+        self,
+        request: HttpRequest,
+        login_type: Login,
+    ) -> Result<User, HttpResponse> {
+        let org_id = request.get_organisation_id().unwrap_or_default();
+        let token = request.cookie(&login_type.to_string()).and_then(|c| {
+            self.decode_org_token(&org_id, c.value())
+                .map_err(|e| log::error!("Error in decoding org_user : {e}"))
+                .ok()
+        });
+        if let Some(token_response) = token {
+            Ok(try_user_from(&token_response).map_err(|e| {
+                log::error!("Unable to get org_user: {e}");
+                ErrorBadRequest(String::from("Unable to get user"))
+            })?)
+        } else {
+            self.generate_org_user(&request, &org_id, &login_type)
+                .await
+                .and_then(|token| {
+                    let cookie = Cookie::build(login_type.to_string(), token)
+                        .path(self.get_cookie_path())
+                        .http_only(true)
+                        .secure(true)
+                        .max_age(Duration::days(1))
+                        .finish();
+                    Err(HttpResponse::Found()
+                        .cookie(cookie)
+                        .insert_header((header::LOCATION, request.path().to_string()))
+                        .finish())
+                })
+        }
+    }
+}
+
+impl OIDCAuthenticator for SaasOIDCAuthenticator {
+    fn get_client(&self) -> &CoreClient {
+        &self.client
+    }
+
+    fn get_global_user(
+        &self,
+        request: &HttpRequest,
+        path: String,
+    ) -> Result<User, HttpResponse> {
+        let token = request.cookie(&Login::Global.to_string()).and_then(|c| {
+            self.decode_global_token(c.value())
+                .map_err(|e| log::error!("Error in decoding user : {e}"))
+                .ok()
+        });
+        if let Some(token_response) = token {
+            Ok(try_user_from(&token_response).map_err(|e| {
+                log::error!("Unable to get user: {e}");
+                ErrorBadRequest(String::from("Unable to get user"))
+            })?)
+        } else {
+            log::error!("Error user not found in cookies");
+            Err(self.new_redirect(&Login::Global, path))
+        }
+    }
+}
+
+impl Authenticator for SaasOIDCAuthenticator {
+    fn get_path_prefix(&self) -> String {
+        self.path_prefix.clone()
+    }
+
+    fn authenticate(
+        &self,
+        request: &HttpRequest,
+        login_type: &Login,
+    ) -> LocalBoxFuture<'static, Result<User, HttpResponse>> {
+        let auth_n = self.clone();
+        match login_type {
+            Login::None => Box::pin(async { Ok(User::default()) }),
+            Login::Global => {
+                let resp = auth_n.get_global_user(
+                    request,
+                    format!("{}/admin/organisations", self.path_prefix),
+                );
+                Box::pin(async { resp })
+            }
+            Login::Org(_) => {
+                match auth_n.get_global_user(request, request.path().to_string()) {
+                    Err(e) => Box::pin(async { Err(e) }),
+                    Ok(_) => {
+                        let fut =
+                            auth_n.get_org_user(request.clone(), login_type.clone());
+                        Box::pin(fut)
+                    }
+                }
+            }
+        }
+    }
+
+    fn routes(&self) -> actix_web::Scope {
+        web::scope("oidc")
+            .app_data(Data::new(self.to_owned()))
+            .service(resource("login").route(get().to(Self::login)))
+    }
+
+    fn get_organisations(&self, req: &HttpRequest) -> HttpResponse {
+        let organisations = req
+            .cookie(&Login::Global.to_string())
+            .and_then(|user_cookie| {
+                self.decode_global_token(user_cookie.value())
+                    .map_err(|e| log::error!("Error in decoding user : {e}"))
+                    .ok()
+            })
+            .map(|claims| claims.additional_claims().organisations.clone());
+
+        match organisations {
+            Some(organisations) => HttpResponse::Ok().json(Json(organisations)),
+            None => self.new_redirect(
+                &Login::Global,
+                format!("{}/admin/organisations", self.path_prefix),
+            ),
+        }
+    }
+
+    fn generate_org_user(
+        &self,
+        req: &HttpRequest,
+        org_id: &str,
+        login_type: &Login,
+    ) -> LocalBoxFuture<'_, Result<String, HttpResponse>> {
+        let client = match self.get_org_client(org_id) {
+            Ok(client) => client,
+            Err(e) => {
+                log::error!("Error in getting Org specific client: {e}");
+                return Box::pin(async {
+                    Err(ErrorInternalServerError(String::from(
+                        "Error in getting Org specific client",
+                    ))
+                    .into())
+                });
+            }
+        };
+
+        let user = req
+            .cookie(&Login::Global.to_string())
+            .and_then(|user_cookie| {
+                self.decode_global_token(user_cookie.value())
+                    .map_err(|e| log::error!("Error in decoding user : {e}"))
+                    .ok()
+            })
+            .map(|claims| {
+                (
+                    claims.preferred_username().cloned(),
+                    claims.additional_claims().switch_pass.clone(),
+                )
+            });
+        let (username, switch_pass) = if let Some(user) = user {
+            user
+        } else {
+            return Box::pin(async { Err(ErrorBadRequest("Cookie incorrect").into()) });
+        };
+
+        let username = if let Some(u) = username {
+            u
+        } else {
+            return Box::pin(async { Err(ErrorBadRequest("Username not found").into()) });
+        };
+
+        let user = ResourceOwnerUsername::new(username.to_string());
+        let pass = ResourceOwnerPassword::new(switch_pass);
+        let redirect = self.new_redirect(
+            login_type,
+            format!("{}/admin/organisations", self.path_prefix),
+        );
+
+        Box::pin(async move {
+            client
+                .exchange_password(&user, &pass)
+                .add_scope(Scope::new(String::from("openid")))
+                .request_async(oidcrs::reqwest::async_http_client)
+                .await
+                .map_err(|e| {
+                    log::error!("Failed to switch organisation for token: {e}");
+                    Some(ErrorInternalServerError(
+                        "Failed to switch organisation for token".to_string(),
+                    ))
+                })
+                .and_then(|tr| {
+                    tr.id_token()
+                        .ok_or_else(|| {
+                            log::error!("No identity-token!");
+                            None
+                        })?
+                        .claims(&client.id_token_verifier(), presence_no_check)
+                        .map_err(|e| {
+                            log::error!("Couldn't verify claims: {e}");
+                            None
+                        })?;
+
+                    serde_json::to_string(&tr).map_err(|e| {
+                        log::error!("Unable to stringify data: {e}");
+                        Some(ErrorInternalServerError(
+                            "Unable to stringify data".to_string(),
+                        ))
+                    })
+                })
+                .map_err(|e| e.map(Into::into).unwrap_or(redirect))
+        })
+    }
+}

--- a/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
@@ -1,0 +1,179 @@
+use std::sync::Arc;
+
+use actix_web::{
+    error::{ErrorBadRequest, ErrorInternalServerError},
+    web::{self, get, resource, Data},
+    HttpRequest, HttpResponse,
+};
+use derive_more::{Deref, DerefMut};
+use futures_util::future::LocalBoxFuture;
+use openidconnect::{
+    self as oidcrs,
+    core::{CoreClient, CoreIdTokenClaims, CoreProviderMetadata, CoreTokenResponse},
+    ClientId, ClientSecret, IssuerUrl, RedirectUrl, TokenResponse,
+};
+use superposition_types::User;
+
+use crate::middlewares::auth_n::{
+    authentication::{Authenticator, Login},
+    helpers::fetch_org_ids_from_db,
+    oidc::{
+        utils::{try_user_from, verify_presence},
+        OIDCAuthenticator,
+    },
+};
+
+#[derive(Clone)]
+pub struct AuthenticatorInner {
+    client: CoreClient,
+    path_prefix: String,
+}
+
+/// A simple OIDC Authenticator implementation that uses a single
+/// OpenID Provider for authentication, no org specific issuers
+///
+/// Env(s) needed for Simple OIDC Authenticator:
+/// OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_REDIRECT_HOST
+#[derive(Deref, DerefMut, Clone)]
+pub struct SimpleOIDCAuthenticator(Arc<AuthenticatorInner>);
+
+impl SimpleOIDCAuthenticator {
+    pub async fn new(
+        idp_url: String,
+        base_url: String,
+        path_prefix: String,
+        client_id: String,
+        client_secret: String,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let issuer_url = IssuerUrl::new(idp_url)
+            .map_err(|e| format!("Unable to create issuer url: {}", e))
+            .unwrap();
+
+        // Discover OpenID Provider metadata
+        let provider_metadata = CoreProviderMetadata::discover_async(
+            issuer_url,
+            oidcrs::reqwest::async_http_client,
+        )
+        .await?;
+
+        // Create client
+        let client = CoreClient::from_provider_metadata(
+            provider_metadata.clone(),
+            ClientId::new(client_id.clone()),
+            Some(ClientSecret::new(client_secret.clone())),
+        )
+        .set_redirect_uri(RedirectUrl::new(format!(
+            "{base_url}{path_prefix}/oidc/login"
+        ))?);
+
+        Ok(Self(Arc::new(AuthenticatorInner {
+            client,
+            path_prefix,
+        })))
+    }
+
+    fn decode_global_token(&self, cookie: &str) -> Result<CoreIdTokenClaims, String> {
+        let ctr = serde_json::from_str::<CoreTokenResponse>(cookie)
+            .map_err(|e| format!("Error while decoding token: {e}"))?;
+        ctr.id_token()
+            .ok_or(String::from("Id Token not found"))?
+            .claims(&self.client.id_token_verifier(), verify_presence)
+            .map_err(|e| format!("Error in claims verification: {e}"))
+            .cloned()
+    }
+}
+
+impl OIDCAuthenticator for SimpleOIDCAuthenticator {
+    fn get_client(&self) -> &CoreClient {
+        &self.client
+    }
+
+    fn get_global_user(
+        &self,
+        request: &HttpRequest,
+        path: String,
+    ) -> Result<User, HttpResponse> {
+        let token = request.cookie(&Login::Global.to_string()).and_then(|c| {
+            self.decode_global_token(c.value())
+                .map_err(|e| log::error!("Error in decoding user : {e}"))
+                .ok()
+        });
+        if let Some(token_response) = token {
+            Ok(try_user_from(&token_response).map_err(|e| {
+                log::error!("Unable to get user: {e}");
+                ErrorBadRequest(String::from("Unable to get user"))
+            })?)
+        } else {
+            log::error!("Error user not found in cookies");
+            Err(self.new_redirect(&Login::Global, path))
+        }
+    }
+}
+
+impl Authenticator for SimpleOIDCAuthenticator {
+    fn get_path_prefix(&self) -> String {
+        self.path_prefix.clone()
+    }
+
+    fn authenticate(
+        &self,
+        request: &HttpRequest,
+        login_type: &Login,
+    ) -> LocalBoxFuture<'static, Result<User, HttpResponse>> {
+        let auth_n = self.clone();
+        match login_type {
+            Login::None => Box::pin(async { Ok(User::default()) }),
+            Login::Global => {
+                let resp = auth_n.get_global_user(
+                    request,
+                    format!("{}/admin/organisations", self.path_prefix),
+                );
+                Box::pin(async { resp })
+            }
+            Login::Org(_) => {
+                let resp = auth_n.get_global_user(request, request.path().to_string());
+                Box::pin(async { resp })
+            }
+        }
+    }
+
+    fn routes(&self) -> actix_web::Scope {
+        web::scope("oidc")
+            .app_data(Data::new(self.to_owned()))
+            .service(resource("login").route(get().to(Self::login)))
+    }
+
+    fn get_organisations(&self, req: &actix_web::HttpRequest) -> HttpResponse {
+        match fetch_org_ids_from_db(req) {
+            Ok(resp) => HttpResponse::Ok().json(resp),
+            Err(resp) => ErrorInternalServerError(resp).into(),
+        }
+    }
+
+    fn generate_org_user(
+        &self,
+        req: &HttpRequest,
+        _: &str,
+        login_type: &Login,
+    ) -> LocalBoxFuture<'_, Result<String, HttpResponse>> {
+        let user = req
+            .cookie(&Login::Global.to_string())
+            .and_then(|user_cookie| {
+                self.decode_global_token(user_cookie.value())
+                    .map_err(|e| log::error!("Error in decoding user : {e}"))
+                    .map(|_| user_cookie.value().to_string())
+                    .ok()
+            });
+
+        match user {
+            Some(u) => Box::pin(async { Ok(u) }),
+            None => {
+                let redirect = self.new_redirect(
+                    login_type,
+                    format!("{}/admin/organisations", self.path_prefix),
+                );
+                Box::pin(async { Err(redirect) })
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Problem
Current OIDC login setup was coupled to the SaaS setup

## Solution
Separate out SaaS OIDC login from core OIDC login into `OIDC_SAAS` and `OIDC` login types

## Note
### Difference between SimpleOIDC and SaasOIDC
In SaaS setup, each organisation has its own OIDC provider endpoints and the first issuer also acts as a global identity provider which provides authorization to the individual orgs and in Simple OIDC a global IDP is used and no org specific providers