### PR TITLE
build: fix local client build

### DIFF
--- a/makefile
+++ b/makefile
@@ -269,7 +269,8 @@ smithy-clients: smithy-build
 	mkdir -p clients/java/sdk/src/main/java
 	cp -r $(SMITHY_BUILD_SRC)/java-client-codegen/*\
 				clients/java/sdk/src/main/java
-	git restore clients/java/sdk/src/main/java/io/juspay/superposition/client/auth/AuthHelper.java
+	git restore clients/java/sdk/src/main/java/io/juspay/superposition/client/auth/BasicAuthIdentityResolver.java
+	git restore clients/java/sdk/src/main/java/io/juspay/superposition/client/auth/BearerTokenIdentityResolver.java
 
 	rm -rf clients/python/sdk
 	mkdir -p clients/python/sdk


### PR DESCRIPTION
## Problem
Client builds are broken as we remove auth related files added in a previous commit as part of client generation.

## Solution
This restores those files back.

## Environment variable changes
NA

## Pre-deployment activity
NA

## Post-deployment activity
NA

## API changes
NA

## Possible Issues in the future
NA