### PR TITLE
fix: Use macos-15-intel for intel based builds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -245,7 +245,7 @@ jobs:
                       target: x86_64-unknown-linux-gnu
                       superposition_core_bin_name: libsuperposition_core.so
                       superposition_core_zip_name: superposition_core-x86_64-unknown-linux-gnu.zip
-                    - os: macos-13
+                    - os: macos-15-intel
                       target: x86_64-apple-darwin
                       superposition_core_bin_name: libsuperposition_core.dylib
                       superposition_core_zip_name: superposition_core-x86_64-apple-darwin.zip


### PR DESCRIPTION
## Problem
Describe the problem you are trying to solve here

## Solution
Provide a brief summary of your solution so that reviewers can understand your code

## Environment variable changes

What ENVs need to be added or changed

## Pre-deployment activity
Things needed to be done before deploying this change (if any)

## Post-deployment activity
Things needed to be done after deploying this change (if any)

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
Describe any possible issues that could occur because of this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS version used for binary generation from macOS 13 to macOS 15 Intel in build workflows.

---

**Note:** This is a build infrastructure update with no user-facing changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->