### PR TITLE
fix: remove redundant logs and npm release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -529,7 +529,7 @@ jobs:
 
             - uses: actions/setup-node@v4
               with:
-                  node-version: "24.0.0"
+                  node-version: "24.12.0"
                   registry-url: "https://registry.npmjs.org"
 
             - name: Download all rust binary artifacts

--- a/clients/javascript/package.json
+++ b/clients/javascript/package.json
@@ -5,7 +5,7 @@
     "private": true,
     "repository": {
         "type": "git",
-        "url": "https://github.com/juspay/superposition.git"
+        "url": "git+https://github.com/juspay/superposition.git"
     },
     "workspaces": [
         "bindings",

--- a/crates/context_aware_config/src/api/context/handlers.rs
+++ b/crates/context_aware_config/src/api/context/handlers.rs
@@ -89,12 +89,7 @@ async fn put_handler(
     };
     let req_change_reason = req.change_reason.clone();
 
-    validate_change_reason(&req_change_reason, &mut db_conn, &schema_name).map_err(
-        |err| {
-            log::error!("change reason validation failed with error: {:?}", err);
-            err
-        },
-    )?;
+    validate_change_reason(&req_change_reason, &mut db_conn, &schema_name)?;
 
     let (put_response, version_id) = db_conn
         .transaction::<_, superposition::AppError, _>(|transaction_conn| {
@@ -152,12 +147,7 @@ async fn update_override_handler(
     let tags = parse_config_tags(custom_headers.config_tags)?;
     let req_change_reason = req.change_reason.clone();
 
-    validate_change_reason(&req_change_reason, &mut db_conn, &schema_name).map_err(
-        |err| {
-            log::error!("change reason validation failed with error: {:?}", err);
-            err
-        },
-    )?;
+    validate_change_reason(&req_change_reason, &mut db_conn, &schema_name)?;
 
     let (override_resp, version_id) = db_conn
         .transaction::<_, superposition::AppError, _>(|transaction_conn| {
@@ -219,12 +209,7 @@ async fn move_handler(
         )?,
     };
 
-    validate_change_reason(&req.change_reason, &mut db_conn, &schema_name).map_err(
-        |err| {
-            log::error!("change reason validation failed with error: {:?}", err);
-            err
-        },
-    )?;
+    validate_change_reason(&req.change_reason, &mut db_conn, &schema_name)?;
 
     let (move_response, version_id) = db_conn
         .transaction::<_, superposition::AppError, _>(|transaction_conn| {
@@ -515,14 +500,7 @@ async fn bulk_operations(
                             &put_req.change_reason,
                             transaction_conn,
                             &schema_name,
-                        )
-                        .map_err(|err| {
-                            log::error!(
-                                "change reason validation failed with error: {:?}",
-                                err
-                            );
-                            err
-                        })?;
+                        )?;
 
                         let description = if put_req.description.is_none() {
                             query_description(

--- a/crates/context_aware_config/src/api/dimension/handlers.rs
+++ b/crates/context_aware_config/src/api/dimension/handlers.rs
@@ -71,12 +71,7 @@ async fn create(
     let schema_value = Value::from(&create_req.schema);
     let tags = parse_config_tags(custom_headers.config_tags)?;
 
-    validate_change_reason(&create_req.change_reason, &mut conn, &schema_name).map_err(
-        |err| {
-            log::error!("change reason validation failed with error: {:?}", err);
-            err
-        },
-    )?;
+    validate_change_reason(&create_req.change_reason, &mut conn, &schema_name)?;
 
     let num_rows = dimensions
         .count()
@@ -276,12 +271,7 @@ async fn update(
     let tags = parse_config_tags(custom_headers.config_tags)?;
     let update_req = req.into_inner();
 
-    validate_change_reason(&update_req.change_reason, &mut conn, &schema_name).map_err(
-        |err| {
-            log::error!("change reason validation failed with error: {:?}", err);
-            err
-        },
-    )?;
+    validate_change_reason(&update_req.change_reason, &mut conn, &schema_name)?;
 
     let dimension_data: Dimension = dimensions::dsl::dimensions
         .filter(dimensions::dimension.eq(name.clone()))

--- a/crates/context_aware_config/src/api/functions/handlers.rs
+++ b/crates/context_aware_config/src/api/functions/handlers.rs
@@ -62,12 +62,7 @@ async fn create(
         ));
     }
 
-    validate_change_reason(&req.change_reason, &mut conn, &schema_name).map_err(
-        |err| {
-            log::error!("change reason validation failed with error: {:?}", err);
-            err
-        },
-    )?;
+    validate_change_reason(&req.change_reason, &mut conn, &schema_name)?;
 
     compile_fn(&req.function)?;
 
@@ -145,12 +140,7 @@ async fn update(
         compile_fn(function)?;
 
         if function_type != FunctionType::ChangeReasonValidation {
-            validate_change_reason(&req.change_reason, &mut conn, &schema_name).map_err(
-                |err| {
-                    log::error!("change reason validation failed with error: {:?}", err);
-                    err
-                },
-            )?;
+            validate_change_reason(&req.change_reason, &mut conn, &schema_name)?;
         }
     }
 
@@ -231,10 +221,6 @@ async fn delete_function(
     let function = fetch_function(&f_name, &mut conn, &schema_name)?;
     match function.function_type {
         FunctionType::ContextValidation | FunctionType::ChangeReasonValidation => {
-            log::error!(
-                "Attempted to delete reserved function type: {:?}",
-                function.function_type
-            );
             return Err(bad_argument!(
                 "Cannot delete function of type {:?}: This function type is reserved and cannot be deleted.",
                 function.function_type
@@ -284,7 +270,6 @@ async fn test(
             match (function.published_code, function.published_runtime_version) {
                 (Some(code), Some(version)) => (code, version),
                 _ => {
-                    log::error!("Function test failed: function not published yet");
                     return Err(bad_argument!(
                         "Function test failed as function not published yet"
                     ));
@@ -320,12 +305,7 @@ async fn publish(
     let req = request.into_inner();
 
     if function.function_type != FunctionType::ChangeReasonValidation {
-        validate_change_reason(&req.change_reason, &mut conn, &schema_name).map_err(
-            |err| {
-                log::error!("change reason validation failed with error: {:?}", err);
-                err
-            },
-        )?;
+        validate_change_reason(&req.change_reason, &mut conn, &schema_name)?;
     }
 
     let updated_function = diesel::update(functions::functions)


### PR DESCRIPTION
## Problem

1. Redundant logging, `AppError` type already logs the error message which is being forwarded separate logging is not needed [ref](https://github.com/juspay/superposition/blob/main/crates/superposition_types/src/result.rs#L82)
2. Trust publishers is supported from Node 24.12.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated JavaScript package repository URL format for improved compatibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->