### PR TITLE
chore: fix shell warnings due to old macos sdks

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,1 @@
 use flake
-unset DEVELOPER_DIR

--- a/flake.nix
+++ b/flake.nix
@@ -82,6 +82,11 @@
               # go client
               # go
             ];
+
+            shellHook = ''
+                # If it exists from the host system, kill it
+                unset DEVELOPER_DIR
+            '';
           };
 
         };


### PR DESCRIPTION
## Problem
We are seeing the following warning in the shell inside the superposition directory persistently on the developer laptop.

```
unhandled Platform key FamilyDisplayName
```

## Solution

>  On macOS, Nix sometimes sets DEVELOPER_DIR to point to a specific Nix-provided Apple SDK. When you run common commands (like git or ls), if they are the versions provided by Apple in /usr/bin/, they check this variable. Because the Nix SDK is “stripped down” compared to a full Xcode install, the Apple tools complain about missing or “unhandled” display metadata. Unsetting the variable stops this check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated environment configuration to unset the DEVELOPER_DIR environment variable.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->