### PR TITLE
feat(UI): use browser locale time

### DIFF
--- a/crates/frontend/Cargo.toml
+++ b/crates/frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frontend"
-description  = "the UI interface that is provided to interact, configure and manage superposition, organisations and application workspaces"
+description = "the UI interface that is provided to interact, configure and manage superposition, organisations and application workspaces"
 version.workspace = true
 edition = "2021"
 include = ["src/**/*", "src-js/**/*"]
@@ -48,6 +48,7 @@ web-sys = { version = "0.3.64", features = [
     "KeyboardEvent",
     "Document",
     "Node",
+    "Navigator",
 ] }
 
 [features]

--- a/crates/frontend/src/app.rs
+++ b/crates/frontend/src/app.rs
@@ -3,6 +3,7 @@ use leptos_meta::*;
 use leptos_router::*;
 use serde_json::json;
 
+use crate::components::datetime::DatetimeConversionScript;
 use crate::hoc::layout::{use_org, CommonLayout, Layout, Providers};
 use crate::pages::compare_overrides::CompareOverrides;
 use crate::pages::config_version::ConfigVersion;
@@ -57,6 +58,7 @@ pub fn app(app_envs: Envs) -> impl IntoView {
                     type_="text/javascript"
                     src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"
                 />
+                <DatetimeConversionScript />
                 {move || {
                     if base.is_empty() {
                         view! {}.into_view()

--- a/crates/frontend/src/components.rs
+++ b/crates/frontend/src/components.rs
@@ -7,6 +7,7 @@ pub mod cohort_schema;
 pub mod condition_pills;
 pub mod context_card;
 pub mod context_form;
+pub mod datetime;
 pub mod default_config_form;
 pub mod delete_modal;
 pub mod description;

--- a/crates/frontend/src/components/context_card.rs
+++ b/crates/frontend/src/components/context_card.rs
@@ -9,6 +9,7 @@ use superposition_types::{
 use crate::{
     components::{
         condition_pills::Condition as ConditionComponent,
+        datetime::Datetime,
         description::InfoDescription,
         table::{types::Column, Table},
         tooltip::Tooltip,
@@ -151,10 +152,7 @@ pub fn context_card(
                                 </div>
                                 <div class="flex gap-1 items-center">
                                     <i class="ri-time-line text-gray-950" />
-                                    <span>
-                                        {context
-                                            .with_value(|c| c.created_at.format("%v %T").to_string())}
-                                    </span>
+                                    <Datetime datetime=context.with_value(|c| c.created_at) />
                                 </div>
                             </div>
                             <div class="flex flex-col gap-1">
@@ -167,12 +165,7 @@ pub fn context_card(
                                 </div>
                                 <div class="flex gap-1 items-center">
                                     <i class="ri-time-line text-gray-950" />
-                                    <span>
-                                        {context
-                                            .with_value(|c| {
-                                                c.last_modified_at.format("%v %T").to_string()
-                                            })}
-                                    </span>
+                                    <Datetime datetime=context.with_value(|c| c.last_modified_at) />
                                 </div>
                             </div>
                         </div>

--- a/crates/frontend/src/components/datetime.rs
+++ b/crates/frontend/src/components/datetime.rs
@@ -1,0 +1,200 @@
+#[cfg(target_arch = "wasm32")]
+use chrono::Datelike;
+use chrono::{offset::Utc, DateTime, NaiveDate};
+#[cfg(target_arch = "wasm32")]
+use js_sys::{Date, Object};
+use leptos::*;
+use leptos_meta::*;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::JsValue;
+
+use crate::providers::csr_provider::use_client_side_ready;
+
+#[cfg(target_arch = "wasm32")]
+fn browser_locale() -> String {
+    web_sys::window()
+        .and_then(|w| w.navigator().language())
+        .unwrap_or_else(|| "en-GB".to_string())
+}
+
+#[cfg(target_arch = "wasm32")]
+fn format_local_datetime(time: &DateTime<Utc>) -> String {
+    let millis = time.timestamp_millis();
+    let date = Date::new(&JsValue::from_f64(millis as f64));
+    let locale = browser_locale();
+
+    date.to_locale_string(&locale, &Object::new()).into()
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn format_local_datetime(time: &DateTime<Utc>) -> String {
+    time.to_rfc3339()
+}
+
+fn format_local_datetime_from_str(time: &str) -> String {
+    match DateTime::parse_from_rfc3339(time) {
+        Ok(dt) => format_local_datetime(&dt.with_timezone(&Utc)),
+        Err(_) => time.to_string(),
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn format_local_date(time: &DateTime<Utc>) -> String {
+    let millis = time.timestamp_millis();
+    let date = Date::new(&JsValue::from_f64(millis as f64));
+
+    let year = date.get_full_year();
+    let month = date.get_month() + 1; // JS months are 0-based
+    let day = date.get_date();
+
+    format!("{:04}-{:02}-{:02}", year, month, day)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn format_local_date(time: &DateTime<Utc>) -> String {
+    time.format("%Y-%m-%d").to_string()
+}
+
+fn format_local_date_from_str(time: &str) -> String {
+    match DateTime::parse_from_rfc3339(time) {
+        Ok(dt) => format_local_date(&dt.with_timezone(&Utc)),
+        Err(_) => time.to_string(),
+    }
+}
+
+pub fn use_format_local_date(datetime: &DateTime<Utc>) -> String {
+    let _ = use_client_side_ready().get(); // need this to rehydrate on client side
+    format_local_date(datetime)
+}
+
+#[cfg(target_arch = "wasm32")]
+pub fn try_utc_date_from_locale_date(locale_date: &str) -> Option<DateTime<Utc>> {
+    let date = NaiveDate::parse_from_str(locale_date, "%Y-%m-%d").ok()?;
+    let millis = Date::new_with_year_month_day(
+        date.year() as u32,
+        date.month() as i32 - 1, // JS months are 0-based
+        date.day() as i32,
+    )
+    .get_time();
+
+    let secs = (millis / 1000.0) as i64;
+    let nanos = ((millis % 1000.0) * 1_000_000.0) as u32;
+
+    DateTime::<Utc>::from_timestamp(secs, nanos)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn try_utc_date_from_locale_date(locale_date: &str) -> Option<DateTime<Utc>> {
+    use chrono::NaiveTime;
+
+    let date = NaiveDate::parse_from_str(locale_date, "%Y-%m-%d").ok()?;
+    let date_time =
+        DateTime::from_naive_utc_and_offset(date.and_time(NaiveTime::default()), Utc);
+
+    Some(date_time)
+}
+
+#[derive(Default)]
+pub enum DatetimeFormat {
+    Date,
+    #[default]
+    DateTime,
+}
+
+impl DatetimeFormat {
+    fn class(&self) -> &'static str {
+        match self {
+            Self::Date => "datetime_date",
+            Self::DateTime => "datetime",
+        }
+    }
+}
+
+/// Component to display a datetime in local format
+/// # Arguments
+/// * `datetime` - A DateTime<Utc> object
+/// * `class` - An optional CSS class for styling the span element
+/// * `format` - An optional format enum to specify date or datetime display
+/// # Returns
+/// A view displaying the formatted datetime based on the user's locale
+/// For SSR, it will display the datetime as in RFC 3339 format, which is converted
+/// to local format on the client side using JavaScript on page load.
+/// To ensure proper conversion, include the `DatetimeConversionScript` component is added in the app root.
+#[component]
+pub fn datetime(
+    datetime: DateTime<Utc>,
+    #[prop(into, optional)] class: String,
+    #[prop(optional)] format: DatetimeFormat,
+) -> impl IntoView {
+    let class = format!("{} {}", format.class(), class);
+    view! {
+        <time class=class datetime=datetime.to_rfc3339()>
+            {match format {
+                DatetimeFormat::Date => format_local_date(&datetime),
+                DatetimeFormat::DateTime => format_local_datetime(&datetime),
+            }}
+        </time>
+    }
+}
+
+/// Component to display a datetime string in local format
+/// # Arguments
+/// * `datetime` - A datetime string in RFC3339 format UTC time zone
+/// * `class` - An optional CSS class for styling the span element
+/// * `format` - An optional format enum to specify whether to display date only or date and time
+/// # Returns
+/// A view displaying the formatted datetime based on the user's locale
+/// For SSR, it will display the datetime as in RFC 3339 format, which is converted
+/// to local format on the client side using JavaScript on page load.
+/// To ensure proper conversion, include the `DatetimeConversionScript` component is added in the app root.
+#[component]
+pub fn datetime_str(
+    datetime: String,
+    #[prop(into, optional)] class: String,
+    #[prop(optional)] format: DatetimeFormat,
+) -> impl IntoView {
+    let class = format!("{} {}", format.class(), class);
+    view! {
+        <time class=class datetime=datetime.clone()>
+            {match format {
+                DatetimeFormat::Date => format_local_date_from_str(&datetime),
+                DatetimeFormat::DateTime => format_local_datetime_from_str(&datetime),
+            }}
+        </time>
+    }
+}
+
+/// Script to fetch the inner content of both the time tag with class 'datetime' and time tag with class 'datetime_date' to
+/// convert it to local datetime and local date, respectively, from date strings in RFC 3339 format
+/// to avoid hydration mismatches between server and client rendering, leading to a flicker effect.
+#[component]
+pub fn datetime_conversion_script() -> impl IntoView {
+    view! {
+        <Script type_="text/javascript">
+            r#"
+            const dateToString = (date) => {
+                const year = date.getFullYear();
+                const month = String(date.getMonth() + 1).padStart(2, '0');
+                const day = String(date.getDate()).padStart(2, '0');
+            
+                return `${year}-${month}-${day}`;
+            }
+            
+            const convertDates = () => {
+                const elements = document.querySelectorAll('.datetime, .datetime_date');
+                elements.forEach(elem => {
+                    const date = new Date(elem.getAttribute('datetime'));
+                    if (isNaN(date.getTime())) return;
+            
+                    if (elem.classList.contains('datetime_date')) {
+                        elem.textContent = dateToString(date);
+                    } else {
+                        elem.textContent = date.toLocaleString(navigator.language);
+                    }
+                });
+            };
+            window.addEventListener('DOMContentLoaded', convertDates);
+            "#
+        </Script>
+    }
+}

--- a/crates/frontend/src/components/default_config_form.rs
+++ b/crates/frontend/src/components/default_config_form.rs
@@ -235,8 +235,9 @@ pub fn default_config_form(
                             .map(|p| {
                                 view! {
                                     <GrayPill
-                                        text=p
+                                        data=p
                                         deletable=false
+                                        on_delete=Callback::new(|_: String| {})
                                         icon_class="ri-map-pin-2-fill"
                                     />
                                 }

--- a/crates/frontend/src/components/description.rs
+++ b/crates/frontend/src/components/description.rs
@@ -2,7 +2,7 @@ use chrono::{DateTime, Utc};
 use leptos::*;
 use superposition_types::database::models::{ChangeReason, Description};
 
-use crate::components::info_modal::InfoModal;
+use crate::components::{datetime::Datetime, info_modal::InfoModal};
 
 #[component]
 pub fn info_description(
@@ -74,14 +74,16 @@ pub fn content_description(
                     <div class="stat-value text-sm">{created_by}</div>
                 </div> <div class="h-fit w-[250px]">
                     <div class="stat-title">"Created at"</div>
-                    <div class="stat-value text-sm">{created_at.format("%v %T").to_string()}</div>
+                    <div class="stat-value text-sm">
+                        <Datetime datetime=created_at />
+                    </div>
                 </div> <div class="h-fit w-[250px]">
                     <div class="stat-title">"Last Modified by"</div>
                     <div class="stat-value text-sm">{last_modified_by}</div>
                 </div> <div class="h-fit w-[250px]">
                     <div class="stat-title">"Last Modified at"</div>
                     <div class="stat-value text-sm">
-                        {last_modified_at.format("%v %T").to_string()}
+                        <Datetime datetime=last_modified_at />
                     </div>
                 </div> <div class="h-fit w-[250px]">
                     <div class="stat-title">"Change Reason"</div>

--- a/crates/frontend/src/components/experiment.rs
+++ b/crates/frontend/src/components/experiment.rs
@@ -7,6 +7,7 @@ use superposition_types::database::models::experimentation::{
     ExperimentStatusType, Variant, VariantType,
 };
 
+use crate::components::datetime::Datetime;
 use crate::components::{
     button::Button,
     table::{types::Column, Table},
@@ -53,7 +54,7 @@ fn experiment_info(experiment: StoredValue<ExperimentResponse>) -> impl IntoView
                 <div class="h-fit w-[300px]">
                     <div class="stat-title">Created at</div>
                     <div class="stat-value text-sm">
-                        {format!("{}", experiment.with_value(|v| v.created_at.format("%v %T")))}
+                        <Datetime datetime=experiment.with_value(|v| v.created_at) />
                     </div>
                 </div>
                 <div class="h-fit w-[300px]">
@@ -100,7 +101,7 @@ fn experiment_info(experiment: StoredValue<ExperimentResponse>) -> impl IntoView
                             <div class="h-fit w-[300px]">
                                 <div class="stat-title">Started at</div>
                                 <div class="stat-value text-sm">
-                                    {format!("{}", started_at.format("%v %T"))}
+                                    <Datetime datetime=started_at />
                                 </div>
                             </div>
                         }
@@ -116,7 +117,7 @@ fn experiment_info(experiment: StoredValue<ExperimentResponse>) -> impl IntoView
                 <div class="h-fit w-[300px]">
                     <div class="stat-title">Last Modified at</div>
                     <div class="stat-value text-sm">
-                        {format!("{}", experiment.with_value(|v| v.last_modified.format("%v %T")))}
+                        <Datetime datetime=experiment.with_value(|v| v.last_modified) />
                     </div>
                 </div>
                 <div class="h-fit w-[300px]">

--- a/crates/frontend/src/pages/audit_log.rs
+++ b/crates/frontend/src/pages/audit_log.rs
@@ -13,6 +13,7 @@ use crate::{
     api::audit_log,
     components::{
         change_summary::{ChangeLogPopup, ChangeSummary},
+        datetime::DatetimeStr,
         skeleton::Skeleton,
         stat::Stat,
         table::{
@@ -53,7 +54,9 @@ fn audit_log_table_columns(
         Column::new(
             "timestamp".to_string(),
             false,
-            default_formatter,
+            move |value, _row| {
+                view! { <DatetimeStr datetime=value.into() /> }
+            },
             ColumnSortable::Yes {
                 sort_fn: Callback::new(move |_| {
                     let filters = filters_rws.get();
@@ -198,15 +201,7 @@ pub fn AuditLog() -> impl IntoView {
                 let table_rows = value
                     .data
                     .iter()
-                    .map(|ele| {
-                        let mut ele_map = json!(ele).as_object().unwrap().clone();
-                        ele_map
-                            .insert(
-                                "timestamp".to_string(),
-                                Value::String(ele.timestamp.format("%v %T").to_string()),
-                            );
-                        ele_map
-                    })
+                    .map(|ele| json!(ele).as_object().unwrap().clone())
                     .collect::<Vec<Map<String, Value>>>();
                 let pagination_params = pagination_params_rws.get();
                 let pagination_props = TablePaginationProps {

--- a/crates/frontend/src/pages/audit_log/filter.rs
+++ b/crates/frontend/src/pages/audit_log/filter.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Display, str::FromStr};
 
-use chrono::{DateTime, Days, Duration, Utc};
+use chrono::{DateTime, Days, Duration, TimeZone, Utc};
 use leptos::*;
 use superposition_types::{
     api::audit_log::AuditQueryFilters,
@@ -10,6 +10,7 @@ use superposition_types::{
 use crate::components::{
     badge::{GlassyPills, GrayPill, ListPills},
     button::{Button, ButtonStyle},
+    datetime::{Datetime, DatetimeFormat},
     drawer::{close_drawer, Drawer, DrawerBtn},
     form::label::Label,
     input::DateInput,
@@ -78,7 +79,13 @@ pub fn filter_summary(filters_rws: RwSignal<AuditQueryFilters>) -> impl IntoView
                                     <div class="flex gap-2 items-center">
                                         <span class="text-xs">"From Date"</span>
                                         <GrayPill
-                                            text=from_date.format("%Y-%m-%d").to_string()
+                                            data=from_date
+                                            renderer=Some(
+                                                Callback::new(move |datetime: DateTime<Utc>| {
+                                                    view! { <Datetime datetime format=DatetimeFormat::Date /> }
+                                                        .into_view()
+                                                }),
+                                            )
                                             on_delete=move |_| {
                                                 filters_rws.update(|f| f.from_date = None);
                                             }
@@ -95,7 +102,13 @@ pub fn filter_summary(filters_rws: RwSignal<AuditQueryFilters>) -> impl IntoView
                                     <div class="flex gap-2 items-center">
                                         <span class="text-xs">"To Date"</span>
                                         <GrayPill
-                                            text=to_date.format("%Y-%m-%d").to_string()
+                                            data=to_date
+                                            renderer=Some(
+                                                Callback::new(move |datetime: DateTime<Utc>| {
+                                                    view! { <Datetime datetime format=DatetimeFormat::Date /> }
+                                                        .into_view()
+                                                }),
+                                            )
                                             on_delete=move |_| {
                                                 filters_rws.update(|f| f.to_date = None);
                                             }
@@ -140,8 +153,8 @@ pub fn filter_summary(filters_rws: RwSignal<AuditQueryFilters>) -> impl IntoView
                                     <div class="flex gap-2 items-center">
                                         <span class="text-xs">"Username"</span>
                                         <GrayPill
-                                            text=username.clone()
-                                            on_delete=move |_| {
+                                            data=username
+                                            on_delete=move |_: String| {
                                                 filters_rws.update(|f| f.username = None);
                                             }
                                         />
@@ -183,11 +196,11 @@ pub fn audit_log_filter_widget(
                         <DateInput
                             id="audit_from_date_input"
                             name="audit_from_date"
-                            min="2020-01-01"
-                            value=filters_buffer_rws
-                                .with(|f| f.from_date)
-                                .map(|s| s.format("%Y-%m-%d").to_string())
+                            min=Utc
+                                .with_ymd_and_hms(2020, 1, 1, 0, 0, 0)
+                                .single()
                                 .unwrap_or_default()
+                            value=filters_buffer_rws.with(|f| f.from_date)
                             on_change=Callback::new(move |new_date: DateTime<Utc>| {
                                 filters_buffer_rws.update(|f| f.from_date = Some(new_date));
                             })
@@ -202,10 +215,7 @@ pub fn audit_log_filter_widget(
                         <DateInput
                             id="audit_to_date_input"
                             name="audit_to_date"
-                            value=filters_buffer_rws
-                                .with(|f| f.to_date)
-                                .map(|s| s.format("%Y-%m-%d").to_string())
-                                .unwrap_or_default()
+                            value=filters_buffer_rws.with(|f| f.to_date)
                             on_change=Callback::new(move |new_date: DateTime<Utc>| {
                                 filters_buffer_rws
                                     .update(|f| {

--- a/crates/frontend/src/pages/config_version.rs
+++ b/crates/frontend/src/pages/config_version.rs
@@ -4,6 +4,7 @@ use leptos_router::use_params_map;
 use crate::api::snapshots::fetch;
 use crate::components::alert::{Alert, AlertType};
 use crate::components::badge::Badge;
+use crate::components::datetime::Datetime;
 use crate::components::skeleton::{Skeleton, SkeletonVariant};
 use crate::components::toast::Toast;
 use crate::types::{OrganisationId, Workspace};
@@ -52,7 +53,7 @@ pub fn config_version() -> impl IntoView {
                                             <div class="h-fit w-[250px]">
                                                 <div class="stat-title">"Created at"</div>
                                                 <div class="stat-value text-sm">
-                                                    {snapshot.created_at.format("%v %T").to_string()}
+                                                    <Datetime datetime=snapshot.created_at />
                                                 </div>
                                             </div>
                                         </div>

--- a/crates/frontend/src/pages/config_version_list.rs
+++ b/crates/frontend/src/pages/config_version_list.rs
@@ -9,10 +9,10 @@ use superposition_types::{
     PaginatedResponse,
 };
 
-use crate::components::skeleton::Skeleton;
 use crate::components::stat::Stat;
 use crate::components::table::types::{ColumnSortable, Expandable, TablePaginationProps};
 use crate::components::table::{types::Column, Table};
+use crate::components::{datetime::DatetimeStr, skeleton::Skeleton};
 use crate::query_updater::{use_param_updater, use_signal_from_query};
 use crate::types::{OrganisationId, Workspace};
 use crate::utils::unwrap_or_default_with_error;
@@ -75,21 +75,10 @@ pub fn config_version_list() -> impl IntoView {
                                     let resp = snapshot_resp
                                         .data
                                         .into_iter()
-                                        .map(|config_version| {
-                                            let mut map = unwrap_or_default_with_error(
-                                                json!(config_version).as_object().cloned(),
-                                                "Failed to parse config version",
-                                            );
-                                            map.insert(
-                                                "id".to_string(),
-                                                Value::String(config_version.id.to_string()),
-                                            );
-                                            map.insert(
-                                                "created_at".to_string(),
-                                                json!(config_version.created_at.format("%v %T").to_string()),
-                                            );
-                                            map
-                                        })
+                                        .map(|config_version| unwrap_or_default_with_error(
+                                            json!(config_version).as_object().cloned(),
+                                            "Failed to parse config version",
+                                        ))
                                         .collect();
                                     let pagination_props = TablePaginationProps {
                                         enabled: true,
@@ -138,7 +127,11 @@ pub fn snapshot_table_columns() -> Vec<Column> {
             default_column_formatter,
         ),
         Column::default("description".to_string()),
-        Column::default_no_collapse("created_at".to_string()),
+        Column::default_with_cell_formatter("created_at".to_string(), |value, _| {
+            view! {
+                <DatetimeStr datetime=value.into() />
+            }
+        }),
         Column::default_with_cell_formatter(
             "tags".to_string(),
             |_value: &str, row: &Map<String, Value>| {

--- a/crates/frontend/src/pages/context_override/filter.rs
+++ b/crates/frontend/src/pages/context_override/filter.rs
@@ -155,8 +155,8 @@ pub fn context_filter_summary(
                         <div class="flex gap-2 items-center">
                             <span class="text-xs">"Exact match context"</span>
                             <GrayPill
-                                text="Enabled"
-                                on_delete=move |_| {
+                                data="Enabled"
+                                on_delete=move |_: String| {
                                     context_filters_rws
                                         .update(|f| f.dimension_match_strategy = None)
                                 }
@@ -185,8 +185,8 @@ pub fn context_filter_summary(
                                     <div class="flex gap-2 items-center">
                                         <span class="text-xs">"Free text"</span>
                                         <GrayPill
-                                            text=plaintext.clone()
-                                            on_delete=move |_| {
+                                            data=plaintext
+                                            on_delete=move |_: String| {
                                                 context_filters_rws.update(|f| f.plaintext = None);
                                             }
                                         />

--- a/crates/frontend/src/pages/default_config_list.rs
+++ b/crates/frontend/src/pages/default_config_list.rs
@@ -15,6 +15,7 @@ use types::PageParams;
 use utils::{get_bread_crums, modify_rows, BreadCrums};
 
 use crate::components::{
+    datetime::DatetimeStr,
     default_config_form::DefaultConfigForm,
     drawer::PortalDrawer,
     skeleton::Skeleton,
@@ -135,10 +136,23 @@ pub fn default_config_list() -> impl IntoView {
                 default_column_formatter,
             ),
             Column::default("value".to_string()),
-            Column::default("created_at".to_string()),
-            Column::default_with_column_formatter("last_modified_at".to_string(), |_| {
-                default_column_formatter("Modified At")
+            Column::default_with_cell_formatter("created_at".to_string(), |value, _| {
+                view! {
+                    <DatetimeStr datetime=value.into() />
+                }
             }),
+            Column::new(
+                "last_modified_at".to_string(),
+                false,
+                |value, _| {
+                    view! {
+                        <DatetimeStr datetime=value.into() />
+                    }
+                },
+                ColumnSortable::No,
+                Expandable::Enabled(100),
+                |_| default_column_formatter("Modified At"),
+            ),
         ]
     });
 
@@ -151,20 +165,7 @@ pub fn default_config_list() -> impl IntoView {
                 let table_rows = default_config
                     .data
                     .into_iter()
-                    .map(|config| {
-                        let mut ele_map = json!(config).as_object().unwrap().to_owned();
-                        ele_map
-                            .insert(
-                                "created_at".to_string(),
-                                Value::String(config.created_at.format("%v %T").to_string()),
-                            );
-                        ele_map
-                            .insert(
-                                "last_modified_at".to_string(),
-                                Value::String(config.last_modified_at.format("%v %T").to_string()),
-                            );
-                        ele_map
-                    })
+                    .map(|config| json!(config).as_object().unwrap().to_owned())
                     .collect::<Vec<Map<String, Value>>>();
                 let mut filtered_rows = table_rows;
                 let page_params = page_params_rws.get();

--- a/crates/frontend/src/pages/default_config_list/filter.rs
+++ b/crates/frontend/src/pages/default_config_list/filter.rs
@@ -77,8 +77,8 @@ pub(super) fn filter_summary(
                                     <div class="flex gap-2 items-center">
                                         <span class="text-xs">"Prefix"</span>
                                         <GrayPill
-                                            text=name
-                                            on_delete=move |_| {
+                                            data=name
+                                            on_delete=move |_: String| {
                                                 filters_rws.update(|f| f.name = None);
                                             }
                                         />

--- a/crates/frontend/src/pages/dimensions.rs
+++ b/crates/frontend/src/pages/dimensions.rs
@@ -7,6 +7,7 @@ use superposition_types::database::models::cac::DimensionType;
 
 use crate::api::dimensions;
 use crate::components::button::ButtonAnchor;
+use crate::components::datetime::DatetimeStr;
 use crate::components::skeleton::Skeleton;
 use crate::components::table::types::{
     default_column_formatter, ColumnSortable, Expandable,
@@ -73,10 +74,23 @@ pub fn dimensions() -> impl IntoView {
                 .into_view()
             },
         ),
-        Column::default("created_at".to_string()),
-        Column::default_with_column_formatter("last_modified_at".to_string(), |_| {
-            default_column_formatter("Modified At")
+        Column::default_with_cell_formatter("created_at".to_string(), |value, _| {
+            view! {
+                <DatetimeStr datetime=value.into() />
+            }
         }),
+        Column::new(
+            "last_modified_at".to_string(),
+            false,
+            |value, _| {
+                view! {
+                    <DatetimeStr datetime=value.into() />
+                }
+            },
+            ColumnSortable::No,
+            Expandable::Enabled(100),
+            |_| default_column_formatter("Modified At"),
+        ),
     ]);
 
     view! {
@@ -88,20 +102,7 @@ pub fn dimensions() -> impl IntoView {
                 let table_rows = value
                     .data
                     .iter()
-                    .map(|ele| {
-                        let mut ele_map = json!(ele).as_object().unwrap().clone();
-                        ele_map
-                            .insert(
-                                "created_at".to_string(),
-                                Value::String(ele.created_at.format("%v %T").to_string()),
-                            );
-                        ele_map
-                            .insert(
-                                "last_modified_at".to_string(),
-                                Value::String(ele.last_modified_at.format("%v %T").to_string()),
-                            );
-                        ele_map
-                    })
+                    .map(|ele| json!(ele).as_object().unwrap().clone())
                     .collect::<Vec<Map<String, Value>>>();
                 let pagination_params = pagination_params_rws.get();
                 let pagination_props = TablePaginationProps {

--- a/crates/frontend/src/pages/experiment_group_listing.rs
+++ b/crates/frontend/src/pages/experiment_group_listing.rs
@@ -27,14 +27,15 @@ use crate::{
     },
     components::{
         condition_pills::Condition as ConditionComponent,
+        datetime::DatetimeStr,
         drawer::{close_drawer, Drawer, DrawerBtn},
         experiment_group_form::{ChangeLogSummary, ChangeType, ExperimentGroupForm},
         skeleton::Skeleton,
         stat::Stat,
         table::{
             types::{
-                default_column_formatter, default_formatter, Column, ColumnSortable,
-                Expandable, TablePaginationProps,
+                default_column_formatter, Column, ColumnSortable, Expandable,
+                TablePaginationProps,
             },
             Table,
         },
@@ -175,8 +176,14 @@ fn table_columns(filters_rws: RwSignal<ExpGroupFilters>) -> Vec<Column> {
             },
         ),
         Column::default("group_type".to_string()),
-        Column::default_with_sort(
+        Column::new(
             "created_at".to_string(),
+            false,
+            |value, _| {
+                view! {
+                    <DatetimeStr datetime=value.into() />
+                }
+            },
             ColumnSortable::Yes {
                 sort_fn: Callback::new(move |_| {
                     let filters = filters_rws.get();
@@ -191,12 +198,18 @@ fn table_columns(filters_rws: RwSignal<ExpGroupFilters>) -> Vec<Column> {
                 sort_by: current_sort_by.clone(),
                 currently_sorted: current_sort_on == SortOn::CreatedAt,
             },
+            Expandable::Enabled(100),
+            default_column_formatter,
         ),
         Column::default("created_by".to_string()),
         Column::new(
             "last_modified_at".to_string(),
             false,
-            default_formatter,
+            |value, _| {
+                view! {
+                    <DatetimeStr datetime=value.into() />
+                }
+            },
             ColumnSortable::Yes {
                 sort_fn: Callback::new(move |_| {
                     let filters = filters_rws.get();
@@ -338,23 +351,7 @@ pub fn experiment_group_listing() -> impl IntoView {
                                         .experiment_groups
                                         .data
                                         .iter()
-                                        .map(|ele| {
-                                            let mut ele_map = json!(ele)
-                                                .as_object()
-                                                .unwrap()
-                                                .to_owned();
-                                            ele_map
-                                                .insert(
-                                                    "created_at".to_string(),
-                                                    json!(ele.created_at.format("%v %T").to_string()),
-                                                );
-                                            ele_map
-                                                .insert(
-                                                    "last_modified_at".to_string(),
-                                                    json!(ele.last_modified_at.format("%v %T").to_string()),
-                                                );
-                                            ele_map
-                                        })
+                                        .map(|ele| json!(ele).as_object().unwrap().to_owned())
                                         .collect::<Vec<Map<String, Value>>>()
                                         .to_owned();
                                     let pagination_props = TablePaginationProps {

--- a/crates/frontend/src/pages/experiment_group_listing/filter.rs
+++ b/crates/frontend/src/pages/experiment_group_listing/filter.rs
@@ -79,8 +79,8 @@ pub(super) fn filter_summary(filters_rws: RwSignal<ExpGroupFilters>) -> impl Int
                                     <div class="flex gap-2 items-center">
                                         <span class="text-xs">"Name"</span>
                                         <GrayPill
-                                            text=name
-                                            on_delete=move |_| {
+                                            data=name
+                                            on_delete=move |_: String| {
                                                 filters_rws.update(|f| f.name = None);
                                             }
                                         />
@@ -96,8 +96,8 @@ pub(super) fn filter_summary(filters_rws: RwSignal<ExpGroupFilters>) -> impl Int
                                     <div class="flex gap-2 items-center">
                                         <span class="text-xs">"Created By"</span>
                                         <GrayPill
-                                            text=created_by
-                                            on_delete=move |_| {
+                                            data=created_by
+                                            on_delete=move |_: String| {
                                                 filters_rws.update(|f| f.created_by = None);
                                             }
                                         />
@@ -113,8 +113,8 @@ pub(super) fn filter_summary(filters_rws: RwSignal<ExpGroupFilters>) -> impl Int
                                     <div class="flex gap-2 items-center">
                                         <span class="text-xs">"Last Modified By"</span>
                                         <GrayPill
-                                            text=last_modified_by
-                                            on_delete=move |_| {
+                                            data=last_modified_by
+                                            on_delete=move |_: String| {
                                                 filters_rws.update(|f| f.last_modified_by = None);
                                             }
                                         />

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -174,23 +174,7 @@ pub fn experiment_list() -> impl IntoView {
                                         .experiments
                                         .data
                                         .iter()
-                                        .map(|ele| {
-                                            let mut ele_map = json!(ele)
-                                                .as_object()
-                                                .unwrap()
-                                                .to_owned();
-                                            ele_map
-                                                .insert(
-                                                    "created_at".to_string(),
-                                                    json!(ele.created_at.format("%v %T").to_string()),
-                                                );
-                                            ele_map
-                                                .insert(
-                                                    "last_modified".to_string(),
-                                                    json!(ele.last_modified.format("%v %T").to_string()),
-                                                );
-                                            ele_map
-                                        })
+                                        .map(|ele| json!(ele).as_object().unwrap().to_owned())
                                         .collect::<Vec<Map<String, Value>>>()
                                         .to_owned();
                                     let pagination_props = TablePaginationProps {
@@ -200,6 +184,7 @@ pub fn experiment_list() -> impl IntoView {
                                         total_pages: v.experiments.total_pages,
                                         on_page_change: handle_page_change,
                                     };
+
                                     view! {
                                         <ConditionCollapseProvider>
                                             <Table

--- a/crates/frontend/src/pages/experiment_list/utils.rs
+++ b/crates/frontend/src/pages/experiment_list/utils.rs
@@ -1,10 +1,8 @@
 use crate::{
     components::{
         condition_pills::Condition as ConditionComponent,
-        table::types::{
-            default_column_formatter, default_formatter, Column, ColumnSortable,
-            Expandable,
-        },
+        datetime::DatetimeStr,
+        table::types::{default_column_formatter, Column, ColumnSortable, Expandable},
     },
     logic::Conditions,
 };
@@ -152,8 +150,14 @@ pub fn experiment_table_columns(
                 .into_view()
             },
         ),
-        Column::default_with_sort(
+        Column::new(
             "created_at".to_string(),
+            false,
+            |value, _| {
+                view! {
+                    <DatetimeStr datetime=value.into() />
+                }
+            },
             ColumnSortable::Yes {
                 sort_fn: Callback::new(move |_| {
                     let filters = filters_rws.get();
@@ -168,11 +172,17 @@ pub fn experiment_table_columns(
                 sort_by: current_sort_by.clone(),
                 currently_sorted: current_sort_on == ExperimentSortOn::CreatedAt,
             },
+            Expandable::Enabled(100),
+            default_column_formatter,
         ),
         Column::new(
             "last_modified".to_string(),
             false,
-            default_formatter,
+            |value, _| {
+                view! {
+                    <DatetimeStr datetime=value.into() />
+                }
+            },
             ColumnSortable::Yes {
                 sort_fn: Callback::new(move |_| {
                     let filters = filters_rws.get();

--- a/crates/frontend/src/pages/function.rs
+++ b/crates/frontend/src/pages/function.rs
@@ -19,7 +19,6 @@ use superposition_types::{
 };
 use types::PageParams;
 
-use crate::api::fetch_function;
 use crate::components::{
     button::Button,
     description::ContentDescription,
@@ -31,6 +30,7 @@ use crate::query_updater::{
 };
 use crate::types::{OrganisationId, Workspace};
 use crate::utils::to_title_case;
+use crate::{api::fetch_function, components::datetime::Datetime};
 
 fn stage_to_action(stage: Stage) -> String {
     match stage {
@@ -77,7 +77,7 @@ fn function_code_info(
                             <div class="h-fit w-[250px]">
                                 <div class="stat-title">{format!("{action_type} At")}</div>
                                 <div class="stat-value text-sm">
-                                    {time.format("%v %T").to_string()}
+                                    <Datetime datetime=time />
                                 </div>
                             </div>
                         }

--- a/crates/frontend/src/pages/function/function_list.rs
+++ b/crates/frontend/src/pages/function/function_list.rs
@@ -97,21 +97,7 @@ pub fn function_list() -> impl IntoView {
                                         .functions
                                         .data
                                         .iter()
-                                        .map(|ele| {
-                                            let mut ele_map = json!(ele)
-                                                .as_object()
-                                                .unwrap()
-                                                .to_owned();
-                                            ele_map
-                                                .insert(
-                                                    "published_at".to_string(),
-                                                    match ele.published_at {
-                                                        Some(val) => Value::String(val.format("%v %T").to_string()),
-                                                        None => Value::String("null".to_string()),
-                                                    },
-                                                );
-                                            ele_map
-                                        })
+                                        .map(|ele| json!(ele).as_object().unwrap().to_owned())
                                         .collect::<Vec<Map<String, Value>>>()
                                         .to_owned();
                                     let total_pages = v.functions.total_pages;

--- a/crates/frontend/src/pages/function/utils.rs
+++ b/crates/frontend/src/pages/function/utils.rs
@@ -5,6 +5,7 @@ use superposition_types::{
     api::functions::FunctionStateChangeRequest, database::models::ChangeReason,
 };
 
+use crate::components::datetime::DatetimeStr;
 use crate::components::table::types::{
     default_column_formatter, Column, ColumnSortable, Expandable,
 };
@@ -30,7 +31,11 @@ pub fn function_table_columns() -> Vec<Column> {
         ),
         Column::default("function_type".to_string()),
         Column::default("published_runtime_version".to_string()),
-        Column::default("published_at".to_string()),
+        Column::default_with_cell_formatter("published_at".to_string(), |value, _| {
+            view! {
+                <DatetimeStr datetime=value.into() />
+            }
+        }),
         Column::default("published_by".to_string()),
     ]
 }

--- a/crates/frontend/src/pages/type_templates.rs
+++ b/crates/frontend/src/pages/type_templates.rs
@@ -5,6 +5,7 @@ use superposition_macros::box_params;
 use superposition_types::custom_query::{CustomQuery, PaginationParams, Query};
 
 use crate::api::fetch_types;
+use crate::components::datetime::DatetimeStr;
 use crate::components::table::types::TablePaginationProps;
 use crate::components::{
     button::Button,
@@ -64,10 +65,23 @@ pub fn types_page() -> impl IntoView {
             default_column_formatter,
         ),
         Column::default("created_by".to_string()),
-        Column::default("created_at".to_string()),
-        Column::default_with_column_formatter("last_modified_at".to_string(), |_| {
-            default_column_formatter("Modified At")
+        Column::default_with_cell_formatter("created_at".to_string(), |value, _| {
+            view! {
+                <DatetimeStr datetime=value.into() />
+            }
         }),
+        Column::new(
+            "last_modified_at".to_string(),
+            false,
+            |value, _| {
+                view! {
+                    <DatetimeStr datetime=value.into() />
+                }
+            },
+            ColumnSortable::No,
+            Expandable::Enabled(100),
+            |_| default_column_formatter("Modified At"),
+        ),
     ]);
 
     let handle_page_change = Callback::new(move |page: i64| {
@@ -84,22 +98,8 @@ pub fn types_page() -> impl IntoView {
                     .data
                     .iter()
                     .map(|ele| {
-                        let mut ele_map = unwrap_option_or_default_with_error(
-                                json!(ele).as_object(),
-                                &Map::new(),
-                            )
-                            .to_owned();
-                        ele_map
-                            .insert(
-                                "created_at".to_string(),
-                                Value::String(ele.created_at.format("%v %T").to_string()),
-                            );
-                        ele_map
-                            .insert(
-                                "last_modified_at".to_string(),
-                                Value::String(ele.last_modified_at.format("%v %T").to_string()),
-                            );
-                        ele_map
+                        unwrap_option_or_default_with_error(json!(ele).as_object(), &Map::new())
+                            .to_owned()
                     })
                     .collect::<Vec<Map<String, Value>>>()
                     .to_owned();

--- a/crates/frontend/src/pages/variables_list.rs
+++ b/crates/frontend/src/pages/variables_list.rs
@@ -11,6 +11,7 @@ use superposition_types::{
 };
 
 use crate::api::variables;
+use crate::components::datetime::DatetimeStr;
 use crate::components::{
     button::Button,
     drawer::PortalDrawer,
@@ -85,8 +86,14 @@ fn variable_table_columns(
             |_| default_column_formatter("Variable Name"),
         ),
         Column::default("value".to_string()),
-        Column::default_with_sort(
+        Column::new(
             "created_at".to_string(),
+            false,
+            |value, _| {
+                view! {
+                    <DatetimeStr datetime=value.into() />
+                }
+            },
             ColumnSortable::Yes {
                 sort_fn: Callback::new(move |_| {
                     let filters = filters_rws.get();
@@ -107,9 +114,17 @@ fn variable_table_columns(
                 sort_by: current_sort_by.clone(),
                 currently_sorted: current_sort_on == SortOn::CreatedAt,
             },
+            Expandable::Enabled(100),
+            default_column_formatter,
         ),
-        Column::default_with_sort(
+        Column::new(
             "last_modified_at".to_string(),
+            false,
+            |value, _| {
+                view! {
+                    <DatetimeStr datetime=value.into() />
+                }
+            },
             ColumnSortable::Yes {
                 sort_fn: Callback::new(move |_| {
                     let filters = filters_rws.get();
@@ -130,6 +145,8 @@ fn variable_table_columns(
                 sort_by: current_sort_by.clone(),
                 currently_sorted: current_sort_on == SortOn::LastModifiedAt,
             },
+            Expandable::Enabled(100),
+            |_| default_column_formatter("Modified At"),
         ),
     ]
 }
@@ -182,20 +199,7 @@ pub fn variables_list() -> impl IntoView {
                 let table_rows = variables
                     .data
                     .into_iter()
-                    .map(|var| {
-                        let mut ele_map = json!(var).as_object().unwrap().to_owned();
-                        ele_map
-                            .insert(
-                                "created_at".to_string(),
-                                Value::String(var.created_at.format("%v %T").to_string()),
-                            );
-                        ele_map
-                            .insert(
-                                "last_modified_at".to_string(),
-                                Value::String(var.last_modified_at.format("%v %T").to_string()),
-                            );
-                        ele_map
-                    })
+                    .map(|var| json!(var).as_object().unwrap().to_owned())
                     .collect::<Vec<Map<String, Value>>>();
                 let total_variables = variables.total_items.to_string();
                 let pagination_params = pagination_params_rws.get();

--- a/crates/frontend/src/pages/variables_list/filter.rs
+++ b/crates/frontend/src/pages/variables_list/filter.rs
@@ -81,8 +81,8 @@ pub fn filter_summary(filters_rws: RwSignal<VariableFilters>) -> impl IntoView {
                                             <div class="flex gap-2 items-center">
                                                 <span class="text-xs">"Name"</span>
                                                 <GrayPill
-                                                    text=name.clone()
-                                                    on_delete=move |_| {
+                                                    data=name
+                                                    on_delete=move |_: String| {
                                                         filters_rws
                                                             .update(|f| { f.name = filter_index(&f.name, idx) });
                                                     }
@@ -107,8 +107,8 @@ pub fn filter_summary(filters_rws: RwSignal<VariableFilters>) -> impl IntoView {
                                             <div class="flex gap-2 items-center">
                                                 <span class="text-xs">"Created By"</span>
                                                 <GrayPill
-                                                    text=created_by.clone()
-                                                    on_delete=move |_| {
+                                                    data=created_by
+                                                    on_delete=move |_: String| {
                                                         filters_rws
                                                             .update(|f| {
                                                                 f.created_by = filter_index(&f.created_by, idx)
@@ -135,8 +135,8 @@ pub fn filter_summary(filters_rws: RwSignal<VariableFilters>) -> impl IntoView {
                                             <div class="flex gap-2 items-center">
                                                 <span class="text-xs">"Modified By"</span>
                                                 <GrayPill
-                                                    text=last_modified_by.clone()
-                                                    on_delete=move |_| {
+                                                    data=last_modified_by
+                                                    on_delete=move |_: String| {
                                                         filters_rws
                                                             .update(|f| {
                                                                 f.last_modified_by = filter_index(&f.last_modified_by, idx)

--- a/crates/frontend/src/pages/webhook.rs
+++ b/crates/frontend/src/pages/webhook.rs
@@ -7,6 +7,7 @@ use superposition_types::database::models::others::Webhook;
 
 use crate::api::{delete_webhooks, get_webhook};
 use crate::components::badge::Badge;
+use crate::components::datetime::Datetime;
 use crate::components::description::ContentDescription;
 use crate::components::input::Toggle;
 use crate::components::{
@@ -76,7 +77,7 @@ fn webhook_info(webhook: Webhook) -> impl IntoView {
                                     <div class="h-fit w-[250px] flex gap-4">
                                         <div class="stat-title">"Last Triggered At"</div>
                                         <div class="stat-value text-base">
-                                            {last_triggered_at.format("%v %T").to_string()}
+                                            <Datetime datetime=last_triggered_at />
                                         </div>
                                     </div>
                                 }

--- a/crates/frontend/src/pages/webhooks.rs
+++ b/crates/frontend/src/pages/webhooks.rs
@@ -12,6 +12,7 @@ use crate::{
     components::{
         badge::Badge,
         button::Button,
+        datetime::DatetimeStr,
         drawer::PortalDrawer,
         skeleton::Skeleton,
         stat::Stat,
@@ -95,10 +96,23 @@ pub fn webhooks() -> impl IntoView {
             default_column_formatter,
         ),
         Column::default("last_triggered_at".to_string()),
-        Column::default("created_at".to_string()),
-        Column::default_with_column_formatter("last_modified_at".to_string(), |_| {
-            default_column_formatter("Modified At")
+        Column::default_with_cell_formatter("created_at".to_string(), |value, _| {
+            view! {
+                <DatetimeStr datetime=value.into() />
+            }
         }),
+        Column::new(
+            "last_modified_at".to_string(),
+            false,
+            |value, _| {
+                view! {
+                    <DatetimeStr datetime=value.into() />
+                }
+            },
+            ColumnSortable::No,
+            Expandable::Enabled(100),
+            |_| default_column_formatter("Modified At"),
+        ),
     ]);
 
     view! {
@@ -111,20 +125,7 @@ pub fn webhooks() -> impl IntoView {
                 let table_rows = value
                     .data
                     .iter()
-                    .map(|ele| {
-                        let mut ele_map = json!(ele).as_object().unwrap().clone();
-                        ele_map
-                            .insert(
-                                "created_at".to_string(),
-                                json!(ele.created_at.format("%v %T").to_string()),
-                            );
-                        ele_map
-                            .insert(
-                                "last_modified_at".to_string(),
-                                json!(ele.last_modified_at.format("%v %T").to_string()),
-                            );
-                        ele_map
-                    })
+                    .map(|ele| json!(ele).as_object().unwrap().clone())
                     .collect::<Vec<Map<String, Value>>>();
                 let pagination_params = pagination_params_rws.get();
                 let pagination_props = TablePaginationProps {

--- a/crates/frontend/src/pages/workspace.rs
+++ b/crates/frontend/src/pages/workspace.rs
@@ -9,6 +9,7 @@ use superposition_types::{
 
 use crate::api::workspaces;
 use crate::components::{
+    datetime::DatetimeStr,
     drawer::{close_drawer, open_drawer, Drawer, DrawerBtn},
     skeleton::Skeleton,
     stat::Stat,
@@ -152,7 +153,11 @@ pub fn workspace() -> impl IntoView {
             Column::default("mandatory_dimensions".to_string()),
             Column::default("strict_mode".to_string()),
             Column::default("created_by".to_string()),
-            Column::default("created_at".to_string()),
+            Column::default_with_cell_formatter("created_at".to_string(), |value, _| {
+                view! {
+                    <DatetimeStr datetime=value.into() />
+                }
+            }),
             Column::default_with_cell_formatter(
                 "actions".to_string(),
                 actions_col_formatter,
@@ -228,15 +233,7 @@ pub fn workspace() -> impl IntoView {
                 let table_rows = workspaces
                     .data
                     .into_iter()
-                    .map(|workspace| {
-                        let mut ele_map = json!(workspace).as_object().unwrap().to_owned();
-                        ele_map
-                            .insert(
-                                "created_at".to_string(),
-                                json!(workspace.created_at.format("%v %T").to_string()),
-                            );
-                        ele_map
-                    })
+                    .map(|workspace| json!(workspace).as_object().unwrap().to_owned())
                     .collect::<Vec<Map<String, Value>>>();
                 let total_workspaces = workspaces.total_items.to_string();
                 let pagination_params = pagination_params_rws.get();


### PR DESCRIPTION
Show time related data in browser local time zone

### Note
In SSR, due to lack of user's timezone info, the data is returned as UTC time itself in the pre-rendered page in ISO 8601 format, which is immediately converted to user locale `time` or `date only` on page load via JS which triggers on `DOMContentLoaded` event
when CSR kicks in, it updates it to the same value again - no impact for end user


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Locale-aware datetime component for browser/server that displays dates/times per your regional settings.
  * Date input controls improved with better defaults and more robust parsing.

* **UI Improvements**
  * Consistent, localized timestamps across audit logs, lists, details, and tables.
  * Reduced display inconsistencies during page hydration for more stable date/time rendering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->