### PR TITLE
feat(UI): allow variant ids as array for resolve/filter

### DIFF
--- a/crates/frontend/src/api.rs
+++ b/crates/frontend/src/api.rs
@@ -1263,7 +1263,7 @@ pub mod experiment_groups {
             change_reason: ChangeReason::try_from(change_reason)?,
             traffic_percentage: TrafficPercentage::try_from(traffic_percentage)?,
             member_experiment_ids,
-            context: Exp::<Condition>::try_from(conditions.as_context_json())
+            context: Exp::<Condition>::try_from(Map::from(conditions))
                 .map_err(|e| e.to_string())?,
         };
         let host = use_host_server();

--- a/crates/frontend/src/components/condition_pills.rs
+++ b/crates/frontend/src/components/condition_pills.rs
@@ -1,5 +1,5 @@
 use crate::{
-    logic::{Condition, Conditions, Operator},
+    logic::{Condition, Conditions},
     schema::HtmlDisplay,
 };
 
@@ -32,6 +32,7 @@ pub fn use_condition_collapser() -> WindowListenerHandle {
 pub fn ConditionExpression(
     #[prop(into)] id: String,
     #[prop(into)] list_id: String,
+    resolve_summary: bool,
     condition: Condition,
 ) -> impl IntoView {
     let id = store_value(id);
@@ -61,8 +62,12 @@ pub fn ConditionExpression(
                 .with_value(|v| {
                     (
                         v.variable.clone(),
-                        Operator::from(&v.expression),
-                        v.expression.to_value().html_display(),
+                        match v.variable.as_str() {
+                            "variantIds" if resolve_summary => "in",
+                            "variantIds" => "has",
+                            _ => "==",
+                        },
+                        v.value.html_display(),
                     )
                 });
             view! {
@@ -76,9 +81,7 @@ pub fn ConditionExpression(
                     }
                 >
                     <span class="font-medium context_condition text-gray-500">{dimension}</span>
-                    <span class="font-medium text-gray-650 context_condition">
-                        {operator.to_string()}
-                    </span>
+                    <span class="font-medium text-gray-650 context_condition">{operator}</span>
                     <span class=value_class>{operands}</span>
                 </li>
             }
@@ -92,6 +95,7 @@ pub fn Condition(
     #[prop(into)] conditions: Conditions,
     #[prop(into, default=String::new())] class: String,
     #[prop(default = true)] grouped_view: bool,
+    #[prop(default = false)] resolve_summary: bool,
 ) -> impl IntoView {
     let conditions = store_value(conditions);
 
@@ -116,6 +120,7 @@ pub fn Condition(
                                 condition=condition.clone()
                                 id=item_id
                                 list_id=id.clone()
+                                resolve_summary
                             />
                         }
                     })

--- a/crates/frontend/src/components/context_card.rs
+++ b/crates/frontend/src/components/context_card.rs
@@ -92,7 +92,7 @@ pub fn ContextCard(
     #[prop(into)] handle_clone: Callback<String, ()>,
     #[prop(into)] handle_delete: Callback<String, ()>,
 ) -> impl IntoView {
-    let conditions: Conditions = (&context).try_into().unwrap_or_default();
+    let conditions = Conditions::from_iter(context.value.clone().into_inner());
     let description = context.description.clone();
     let change_reason = context.change_reason.clone();
 

--- a/crates/frontend/src/components/context_form.rs
+++ b/crates/frontend/src/components/context_form.rs
@@ -2,15 +2,16 @@ use std::collections::{HashMap, HashSet};
 
 use leptos::*;
 use serde_json::{Map, Value};
+use strum_macros::Display;
 use superposition_types::api::functions::KeyType;
 use superposition_types::api::{
     dimension::DimensionResponse, functions::FunctionEnvironment,
 };
 
 use crate::components::form::label::Label;
-use crate::components::input::{Input, InputType};
+use crate::components::input::{Input, InputType, StringArrayInput};
 use crate::components::tooltip::{Tooltip, TooltipPosition};
-use crate::logic::{Condition, Conditions, Expression, Operator};
+use crate::logic::{Condition, Conditions};
 use crate::schema::EnumVariants;
 use crate::types::{OrganisationId, ValueComputeCallbacks, Workspace};
 use crate::utils::value_compute_fn_generator;
@@ -26,6 +27,23 @@ pub enum TooltipType {
     None,
 }
 
+#[derive(Clone, Copy, Display)]
+enum ResolveOperator {
+    #[strum(serialize = "==")]
+    Is,
+    #[strum(serialize = "in")]
+    In,
+}
+
+impl From<&str> for ResolveOperator {
+    fn from(value: &str) -> Self {
+        match value {
+            "variantIds" => Self::In,
+            _ => Self::Is,
+        }
+    }
+}
+
 #[component]
 pub fn ConditionInput(
     disabled: bool,
@@ -34,22 +52,19 @@ pub fn ConditionInput(
     input_type: InputType,
     schema_type: SchemaType,
     value_compute_callbacks: ValueComputeCallbacks,
-    #[prop(into)] on_remove: Callback<String, ()>,
-    #[prop(into)] on_value_change: Callback<Expression, ()>,
-    #[prop(into)] on_operator_change: Callback<Operator, ()>,
+    #[prop(into)] on_remove: Callback<()>,
+    #[prop(into)] on_value_change: Callback<Value>,
     #[prop(default = TooltipType::None)] tooltip: TooltipType,
 ) -> impl IntoView {
-    let (dimension, operator) = (
-        condition.variable.clone(),
-        Operator::from(&condition.expression),
-    );
+    let operator = ResolveOperator::from(condition.variable.as_str());
+    let dimension = condition.variable.clone();
 
     let value_compute_callback = value_compute_callbacks.get(&dimension).cloned();
 
     view! {
         <div class="flex gap-x-6">
             <div class="form-control">
-                <label class="label text-sm">
+                <label class="label font-medium text-sm">
                     <span class="label-text">Dimension</span>
                 </label>
                 <input
@@ -67,47 +82,68 @@ pub fn ConditionInput(
                 <select
                     disabled=true
                     value=operator.to_string()
-                    on:input=move |_event| { on_operator_change.call(Operator::Is) }
                     name="context-dimension-operator"
                     class="select select-bordered w-full max-w-xs text-sm rounded-lg h-10 px-4 appearance-none leading-tight focus:outline-none focus:shadow-outline"
                 >
-                    <option value="==" selected=true>
-                        {Operator::Is.to_string().to_uppercase()}
+                    <option value=operator.to_string() selected=true>
+                        {operator.to_string().to_uppercase()}
                     </option>
                 </select>
 
             </div>
         </div>
         <div class="form-control">
-            <label class="label text-sm">
-                <span class="label-text">Value</span>
+            <label class="w-fit label flex gap-1 text-sm">
+                <span class="label-text font-medium">Value</span>
+                <Show when=move || matches!(operator, ResolveOperator::In)>
+                    <span class="label-text font-light text-slate-400">
+                        "(Press enter to add option)"
+                    </span>
+                </Show>
             </label>
             <div class="flex gap-x-6 items-center">
-                <Input
-                    value=condition.expression.to_value().clone()
-                    schema_type=schema_type.clone()
-                    on_change=move |value: Value| on_value_change.call(Expression::Is(value))
-                    r#type=input_type.clone()
-                    disabled
-                    id=format!(
-                        "{}-{}",
-                        condition.variable.clone(),
-                        Operator::from(&condition.expression),
-                    )
-                    class="w-[450px]"
-                    name=""
-                    value_compute_function=value_compute_callback
-                />
-                <Show when=move || allow_remove>
+                {match operator {
+                    ResolveOperator::Is => {
+                        view! {
+                            <Input
+                                value=condition.value.clone()
+                                schema_type=schema_type.clone()
+                                on_change=move |value: Value| on_value_change.call(value)
+                                r#type=input_type.clone()
+                                disabled
+                                id=format!("{}-{}", condition.variable.clone(), operator)
+                                class="w-[450px]"
+                                name=""
+                                value_compute_function=value_compute_callback
+                            />
+                        }
+                    }
+                    ResolveOperator::In => {
+                        view! {
+                            <StringArrayInput
+                                options=condition
+                                    .value
+                                    .as_array()
+                                    .unwrap_or(&vec![])
+                                    .iter()
+                                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                    .collect()
+                                unique=true
+                                show_label=false
+                                on_change=Callback::new(move |value: Vec<String>| {
+                                    on_value_change
+                                        .call(
+                                            Value::Array(value.into_iter().map(Value::String).collect()),
+                                        )
+                                })
+                            />
+                        }
+                    }
+                }} <Show when=move || allow_remove>
                     <button
                         class="btn btn-ghost btn-circle btn-sm"
                         disabled=disabled
-                        on:click={
-                            let variable = condition.variable.clone();
-                            move |_| {
-                                on_remove.call(variable.clone());
-                            }
-                        }
+                        on:click=move |_| on_remove.call(())
                     >
                         <i class="ri-delete-bin-2-line text-2xl font-bold" />
                     </button>
@@ -153,7 +189,14 @@ pub fn ContextForm(
     let workspace = use_context::<Signal<Workspace>>().unwrap();
     let org_id = use_context::<Signal<OrganisationId>>().unwrap();
 
-    let dimensions = StoredValue::new(dimensions);
+    let dimensions = StoredValue::new(if resolve_mode {
+        dimensions
+    } else {
+        dimensions
+            .into_iter()
+            .filter(|dimension| dimension.dimension != "variantIds")
+            .collect::<Vec<_>>()
+    });
     let dimension_map = StoredValue::new(
         dimensions
             .get_value()
@@ -196,15 +239,22 @@ pub fn ContextForm(
         move |context: &mut Conditions, dimension: &DimensionResponse| {
             if !context.includes(&dimension.dimension) {
                 logging::log!(
-                    "Inserting dimension {:?} with schema {:?}",
+                    "Inserting dimension {} with schema {:?}",
                     dimension.dimension,
                     dimension.schema
                 );
-                context.push(Condition::new_with_default_expression(
-                    dimension.dimension.clone(),
+                let default_value = if dimension.dimension == "variantIds" {
+                    Value::Array(vec![])
+                } else {
                     SchemaType::try_from(&dimension.schema as &Map<String, Value>)
-                        .unwrap_or_default(),
-                ));
+                        .unwrap_or_default()
+                        .default_value()
+                };
+
+                context.push(Condition {
+                    variable: dimension.dimension.clone(),
+                    value: default_value,
+                });
             }
         };
 
@@ -230,8 +280,9 @@ pub fn ContextForm(
     let used_dimensions = Signal::derive(move || {
         context_rs
             .get()
-            .iter()
-            .map(|condition| condition.variable.clone())
+            .0
+            .into_iter()
+            .map(|condition| condition.variable)
             .collect::<HashSet<_>>()
     });
 
@@ -268,40 +319,21 @@ pub fn ContextForm(
     let on_select_dimension =
         Callback::new(move |selected_dimension: DimensionResponse| {
             let mut context = context_rs.get();
-            if !resolve_mode {
-                insert_dimension(&mut context, &selected_dimension);
-            } else {
-                context.push(Condition::new_with_default_expression(
-                    selected_dimension.dimension.clone(),
-                    SchemaType::try_from(
-                        &selected_dimension.schema as &Map<String, Value>,
-                    )
-                    .unwrap_or_default(),
-                ));
-            }
+            insert_dimension(&mut context, &selected_dimension);
             context_ws.update(|v| {
                 *v = context;
             });
         });
 
-    let on_operator_change =
-        Callback::new(move |(idx, expression): (usize, Expression)| {
-            context_ws.update(|v| {
-                if idx < v.len() {
-                    v[idx].expression = expression;
-                }
-            });
-        });
-
-    let on_value_change = Callback::new(move |(idx, expression): (usize, Expression)| {
+    let on_value_change = Callback::new(move |(idx, condition): (usize, Condition)| {
         context_ws.update(|v| {
             if idx < v.len() {
-                v[idx].expression = expression;
+                v[idx] = condition;
             }
         })
     });
 
-    let on_remove = Callback::new(move |(idx, _): (usize, String)| {
+    let on_remove = Callback::new(move |idx| {
         context_ws.update(|v| {
             v.remove(idx);
         });
@@ -357,10 +389,12 @@ pub fn ContextForm(
                                 "{}-{}-{}-{}",
                                 condition.variable,
                                 idx,
-                                condition.expression.to_operator(),
+                                ResolveOperator::from(condition.variable.as_str()),
                                 invalid_dimensions
                                     .with(|m| {
-                                        m.get(&condition.variable).cloned().unwrap_or_default()
+                                        m.get(condition.variable.as_str())
+                                            .cloned()
+                                            .unwrap_or_default()
                                     }),
                             )
                         }
@@ -394,21 +428,19 @@ pub fn ContextForm(
                                 !disabled && !is_mandatory
                             };
                             let input_type = InputType::from((schema_type.clone(), enum_variants));
-                            let on_remove = move |d_name| on_remove.call((idx, d_name));
-                            let on_value_change = move |expression| {
-                                on_value_change.call((idx, expression))
+                            let d_name = condition.variable.clone();
+                            let on_value_change = move |value| {
+                                on_value_change
+                                    .call((
+                                        idx,
+                                        Condition {
+                                            variable: d_name.clone(),
+                                            value,
+                                        },
+                                    ))
                             };
-                            let on_operator_change = {
-                                let schema_type = schema_type.clone();
-                                move |operator| {
-                                    on_operator_change
-                                        .call((
-                                            idx,
-                                            Expression::from((schema_type.clone(), operator)),
-                                        ))
-                                }
-                            };
-                            let tooltip = get_tool_tip_text(&condition.variable);
+                            let tooltip = get_tool_tip_text(&condition.variable.clone());
+
                             view! {
                                 <ConditionInput
                                     disabled
@@ -416,9 +448,8 @@ pub fn ContextForm(
                                     condition
                                     input_type
                                     schema_type
-                                    on_remove
+                                    on_remove=move |_| on_remove.call(idx)
                                     on_value_change
-                                    on_operator_change
                                     tooltip
                                     value_compute_callbacks=value_compute_callbacks.get()
                                 />
@@ -431,7 +462,7 @@ pub fn ContextForm(
                                         }
                                             .into_view()
                                     } else {
-                                        view! {}.into_view()
+                                        ().into_view()
                                     }
                                 }}
                             }

--- a/crates/frontend/src/components/experiment.rs
+++ b/crates/frontend/src/components/experiment.rs
@@ -310,8 +310,8 @@ where
 {
     let experiment = store_value(experiment);
     let metrics_load_err = RwSignal::new(false);
-    let contexts = experiment
-        .with_value(|v| Conditions::from_context_json(&v.context).unwrap_or_default());
+    let contexts =
+        experiment.with_value(|v| Conditions::from_iter(v.context.clone().into_inner()));
     let badge_class = format!(
         "badge text-white badge-xl {}",
         experiment.with_value(|v| badge_class(v.status))
@@ -371,7 +371,7 @@ where
                                     <div class="stat w-3/12">
                                         <div class="stat-title">{dimension}</div>
                                         <div class="stat-value text-base">
-                                            {condition.expression.to_value().html_display()}
+                                            {condition.value.html_display()}
                                         </div>
                                     </div>
                                 }

--- a/crates/frontend/src/components/experiment_form.rs
+++ b/crates/frontend/src/components/experiment_form.rs
@@ -133,7 +133,7 @@ pub fn ExperimentForm(
         };
 
     let fn_environment = Memo::new(move |_| {
-        let context = context_rs.get().as_context_json();
+        let context = context_rs.get().into();
         let overrides = variants_rs
             .get()
             .iter()

--- a/crates/frontend/src/components/experiment_form/utils.rs
+++ b/crates/frontend/src/components/experiment_form/utils.rs
@@ -1,4 +1,4 @@
-use serde_json::Value;
+use serde_json::{Map, Value};
 use superposition_types::{
     Condition, Exp,
     api::{
@@ -44,7 +44,7 @@ pub async fn create_experiment(
         name,
         experiment_type,
         variants: Result::<Vec<Variant>, String>::from_iter(variants)?,
-        context: Exp::<Condition>::try_from(conditions.as_context_json())?,
+        context: Exp::<Condition>::try_from(Map::from(conditions))?,
         metrics,
         description: Description::try_from(description)?,
         change_reason: ChangeReason::try_from(change_reason)?,

--- a/crates/frontend/src/components/experiment_group_form.rs
+++ b/crates/frontend/src/components/experiment_group_form.rs
@@ -191,7 +191,7 @@ pub fn ExperimentGroupForm(
     let loading_rws = create_rw_signal(false);
 
     let fn_environment = Memo::new(move |_| FunctionEnvironment {
-        context: context_rs.get().as_context_json(),
+        context: context_rs.get().into(),
         overrides: Map::new(),
     });
 

--- a/crates/frontend/src/components/variant_form.rs
+++ b/crates/frontend/src/components/variant_form.rs
@@ -95,7 +95,7 @@ where
         },
         |(context, workspace, org_id, auto_populate_control)| async move {
             if auto_populate_control {
-                let context = DimensionQuery::from(context.as_resolve_context());
+                let context = DimensionQuery::from(Map::from(context));
                 resolve_config(
                     &context,
                     &ResolveConfigQuery {
@@ -641,7 +641,7 @@ where
             let context_data = match context_data {
                 Some(data) => Ok(data),
                 None => get_context_from_condition(
-                    &context.as_context_json(),
+                    &context.clone().into(),
                     &workspace,
                     &org_id,
                 )
@@ -650,7 +650,7 @@ where
             };
             match context_data {
                 Ok((context_id, overrides)) => {
-                    let context = DimensionQuery::from(context.as_resolve_context());
+                    let context = DimensionQuery::from(Map::from(context));
                     let resolved_config = resolve_config(
                         &context,
                         &ResolveConfigQuery {

--- a/crates/frontend/src/pages/compare_overrides.rs
+++ b/crates/frontend/src/pages/compare_overrides.rs
@@ -16,7 +16,7 @@ use crate::{
     components::{
         alert::AlertType,
         button::Button,
-        condition_pills::Condition as ConditionComponent,
+        condition_pills::Condition,
         context_form::ContextForm,
         skeleton::{Skeleton, SkeletonVariant},
         table::{
@@ -70,10 +70,11 @@ fn table_columns(
                         }
                     />
                     <ConditionCollapseProvider>
-                        <ConditionComponent
+                        <Condition
                             conditions
                             id=column.get_value()
                             grouped_view=false
+                            resolve_summary=true
                             class="xl:w-[400px] h-fit"
                         />
                     </ConditionCollapseProvider>
@@ -185,7 +186,7 @@ pub fn CompareOverrides() -> impl IntoView {
     );
 
     let fn_environment = Memo::new(move |_| FunctionEnvironment {
-        context: context_rs.get().as_context_json(),
+        context: context_rs.get().into(),
         overrides: Map::new(),
     });
 
@@ -265,7 +266,7 @@ pub fn CompareOverrides() -> impl IntoView {
                                                 req_inprogress_ws.set(false);
                                                 return;
                                             }
-                                            let context = context.as_resolve_context();
+                                            let context = Map::from(context);
                                             let query = Value::Object(context.clone()).to_string();
                                             context_vec_rws
                                                 .update(|value| {

--- a/crates/frontend/src/pages/context_override.rs
+++ b/crates/frontend/src/pages/context_override.rs
@@ -108,7 +108,7 @@ fn Form(
     let update_request_rws = RwSignal::new(None);
 
     let fn_environment = Memo::new(move |_| FunctionEnvironment {
-        context: context_rs.get().as_context_json(),
+        context: context_rs.get().into(),
         overrides: Map::from_iter(overrides_rs.get()),
     });
 
@@ -249,10 +249,10 @@ fn use_context_data(
         |(workspace, org, context_id)| async move {
             get_context(&context_id, &workspace, &org)
                 .await
-                .and_then(|context| {
-                    Conditions::from_context_json(&context.value)
-                        .map(|condition| (context, condition))
-                        .map_err(String::from)
+                .map(|context| {
+                    let conditions =
+                        Conditions::from_iter(context.value.clone().into_inner());
+                    (context, conditions)
                 })
         },
     )
@@ -435,12 +435,7 @@ pub fn ContextOverride() -> impl IntoView {
             );
             PageResource {
                 contexts: contexts_result.unwrap_or_default(),
-                dimensions: dimensions_result
-                    .unwrap_or_default()
-                    .data
-                    .into_iter()
-                    .filter(|d| d.dimension != "variantIds")
-                    .collect(),
+                dimensions: dimensions_result.unwrap_or_default().data,
                 default_config: default_config_result.unwrap_or_default().data,
             }
         },

--- a/crates/frontend/src/pages/context_override/utils.rs
+++ b/crates/frontend/src/pages/context_override/utils.rs
@@ -18,7 +18,7 @@ pub fn context_payload(
     description: String,
     change_reason: String,
 ) -> Value {
-    let context = conditions.as_context_json();
+    let context = Map::from(conditions);
     let payload = json!({
         "override": overrides,
         "context": context,

--- a/crates/frontend/src/pages/experiment.rs
+++ b/crates/frontend/src/pages/experiment.rs
@@ -81,12 +81,7 @@ pub fn ExperimentPage() -> impl IntoView {
             // Construct the combined result, handling errors as needed
             CombinedResource {
                 experiment: experiments_result.ok(),
-                dimensions: dimensions_result
-                    .unwrap_or_default()
-                    .data
-                    .into_iter()
-                    .filter(|d| d.dimension != "variantIds")
-                    .collect(),
+                dimensions: dimensions_result.unwrap_or_default().data,
                 default_config: config_result.unwrap_or_default().data,
             }
         });
@@ -153,10 +148,9 @@ pub fn ExperimentPage() -> impl IntoView {
                                                         <ExperimentForm
                                                             edit_id=experiment_ef.id.clone()
                                                             name=experiment_ef.name
-                                                            context=Conditions::from_context_json(
-                                                                    &experiment_ef.context,
-                                                                )
-                                                                .unwrap_or_default()
+                                                            context=Conditions::from_iter(
+                                                                experiment_ef.context.into_inner(),
+                                                            )
                                                             variants=FromIterator::from_iter(
                                                                 experiment_ef.variants.into_inner(),
                                                             )

--- a/crates/frontend/src/pages/experiment_group_listing.rs
+++ b/crates/frontend/src/pages/experiment_group_listing.rs
@@ -21,7 +21,7 @@ use web_sys::MouseEvent;
 use crate::{
     api::{dimensions, experiment_groups},
     components::{
-        condition_pills::Condition as ConditionComponent,
+        condition_pills::Condition,
         datetime::DatetimeStr,
         drawer::{Drawer, DrawerBtn, close_drawer},
         experiment_group_form::{ChangeLogSummary, ChangeType, ExperimentGroupForm},
@@ -157,11 +157,10 @@ fn table_columns(
                     .and_then(|v| v.as_object().cloned())
                     .unwrap_or_default();
                 let id = get_row_string_fn(row, "id");
-                let conditions =
-                    Conditions::from_context_json(&context).unwrap_or_default();
+                let conditions = Conditions::from_iter(context);
 
                 view! {
-                    <ConditionComponent conditions grouped_view=false id class="w-[300px]"   />
+                    <Condition conditions grouped_view=false id class="w-[300px]" />
                 }
                 .into_view()
             },
@@ -263,10 +262,7 @@ pub fn ExperimentGroupListing() -> impl IntoView {
                 dimensions::list(&PaginationParams::all_entries(), &workspace, &org_id)
                     .await
                     .unwrap_or_default()
-                    .data
-                    .into_iter()
-                    .filter(|d| d.dimension != "variantIds")
-                    .collect();
+                    .data;
             CombinedResource {
                 experiment_groups,
                 dimensions,

--- a/crates/frontend/src/pages/experiment_groups.rs
+++ b/crates/frontend/src/pages/experiment_groups.rs
@@ -17,7 +17,7 @@ use crate::{
     components::{
         alert::AlertType,
         button::Button,
-        condition_pills::Condition as ConditionComponent,
+        condition_pills::Condition,
         delete_modal::DeleteModal,
         description::ContentDescription,
         drawer::PortalDrawer,
@@ -85,13 +85,11 @@ fn table_columns(
                     .get("context")
                     .and_then(|v| v.as_object().cloned())
                     .unwrap_or_default();
-                let conditions =
-                    Conditions::from_context_json(&context).unwrap_or_default();
+                let conditions = Conditions::from_iter(context);
                 let id = row.get("id").map_or(String::from(""), |value| {
                     value.as_str().unwrap_or("").to_string()
                 });
-                view! { <ConditionComponent conditions grouped_view=false id /> }
-                    .into_view()
+                view! { <Condition conditions grouped_view=false id /> }.into_view()
             },
             ColumnSortable::No,
             Expandable::Disabled,
@@ -123,17 +121,13 @@ fn table_columns(
 
 #[component]
 fn ExperimentGroupInfo(group: ExperimentGroup) -> impl IntoView {
-    let conditions = Conditions::from_context_json(&group.context).unwrap_or_default();
+    let conditions = Conditions::from_iter(group.context.into_inner());
 
     view! {
         <div class="-mt-5 card bg-base-100 max-w-screen shadow">
             <div class="card-body flex flex-row gap-2 flex-wrap">
                 <ConditionCollapseProvider>
-                    <ConditionComponent
-                        conditions
-                        id="experiment-group-context"
-                        class="h-fit w-[300px]"
-                    />
+                    <Condition conditions id="experiment-group-context" class="h-fit w-[300px]" />
                 </ConditionCollapseProvider>
             </div>
         </div>

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -94,12 +94,7 @@ pub fn ExperimentList() -> impl IntoView {
             // Construct the combined result, handling errors as needed
             CombinedResource {
                 experiments: experiments_result.unwrap_or_default(),
-                dimensions: dimensions_result
-                    .unwrap_or_default()
-                    .data
-                    .into_iter()
-                    .filter(|d| d.dimension != "variantIds")
-                    .collect(),
+                dimensions: dimensions_result.unwrap_or_default().data,
                 default_config: config_result.unwrap_or_default().data,
             }
         },

--- a/crates/frontend/src/pages/experiment_list/utils.rs
+++ b/crates/frontend/src/pages/experiment_list/utils.rs
@@ -12,7 +12,7 @@ use web_sys::MouseEvent;
 
 use crate::{
     components::{
-        condition_pills::Condition as ConditionComponent,
+        condition_pills::Condition,
         datetime::DatetimeStr,
         table::types::{Column, ColumnSortable, Expandable, default_column_formatter},
     },
@@ -145,12 +145,11 @@ pub fn experiment_table_columns(
                 let id = row.get("id").map_or(String::from(""), |value| {
                     value.as_str().unwrap_or("").to_string()
                 });
-                let conditions =
-                    Conditions::from_context_json(&context).unwrap_or_default();
+                let conditions = Conditions::from_iter(context);
 
                 view! {
                     <div class="w-[400px]">
-                        <ConditionComponent conditions grouped_view=false id  />
+                        <Condition conditions grouped_view=false id  />
                     </div>
                 }
                 .into_view()

--- a/crates/frontend/src/pages/home.rs
+++ b/crates/frontend/src/pages/home.rs
@@ -87,14 +87,14 @@ fn AllContextView(config: Config) -> impl IntoView {
             <ConditionCollapseProvider>
 
                 {contexts
-                    .iter()
+                    .into_iter()
                     .map(|context| {
                         let rows: Vec<_> = context
                             .override_with_keys
                             .iter()
                             .filter_map(|key| overrides.get(key).map(|o| rows(o, true)))
                             .collect();
-                        let conditions: Conditions = context.try_into().unwrap_or_default();
+                        let conditions = Conditions::from_iter(context.condition.into_inner());
                         view! {
                             <div class="card bg-base-100 shadow gap-4 p-6">
                                 <h3 class="card-title text-base timeline-box text-gray-800 bg-base-100 shadow-md m-0 w-max">
@@ -177,7 +177,7 @@ pub fn Home() -> impl IntoView {
     let (req_inprogess_rs, req_inprogress_ws) = create_signal(false);
 
     let fn_environment = Memo::new(move |_| FunctionEnvironment {
-        context: context_rs.get().as_context_json(),
+        context: context_rs.get().into(),
         overrides: Map::new(),
     });
 
@@ -262,7 +262,7 @@ pub fn Home() -> impl IntoView {
         let context_updated = context_rs.get();
         // resolve the context and get the config that would apply
         spawn_local(async move {
-            let context = DimensionQuery::from(context_updated.as_resolve_context());
+            let context = DimensionQuery::from(Map::from(context_updated));
             let mut config = resolve_config(
                 &context,
                 &ResolveConfigQuery {

--- a/crates/superposition_types/src/config.rs
+++ b/crates/superposition_types/src/config.rs
@@ -184,6 +184,10 @@ impl Condition {
         }
         Ok(true)
     }
+
+    pub fn into_inner(self) -> Map<String, Value> {
+        self.0
+    }
 }
 
 impl_try_from_map!(Cac, Condition, Condition::validate_data_for_cac);

--- a/crates/superposition_types/src/custom_query.rs
+++ b/crates/superposition_types/src/custom_query.rs
@@ -192,6 +192,15 @@ impl IsEmpty for QueryMap {
     }
 }
 
+impl IntoIterator for QueryMap {
+    type Item = (String, Value);
+    type IntoIter = <Map<String, Value> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
 impl From<Map<String, Value>> for QueryMap {
     fn from(value: Map<String, Value>) -> Self {
         Self(value)


### PR DESCRIPTION
## Change log
1. Removed jsonlogic related dead code form frontend
2. Added support to send array of variantIds from frontend for all endpoints which perform any type of resolve operation (be it partial or full)