### PR TITLE
fix: copy package.json for sdk version access

### DIFF
--- a/clients/javascript/open-feature-provider/build-deps.js
+++ b/clients/javascript/open-feature-provider/build-deps.js
@@ -25,6 +25,9 @@ function copyDependencies() {
 
     // Copy built dependencies
     execSync('cp -r ../sdk/dist-cjs node_modules/superposition-sdk', { stdio: 'inherit' });
+    // Copy SDK package.json to node_modules/ for ../package.json resolution
+    execSync('cp ../sdk/package.json node_modules/', { stdio: 'inherit' });
+
     execSync('cp -r ../bindings/dist node_modules/superposition-bindings', { stdio: 'inherit' });
 
     console.log('Dependencies copied successfully!');

--- a/scripts/setup_provider_binaries.sh
+++ b/scripts/setup_provider_binaries.sh
@@ -9,12 +9,7 @@ if [ $in_nix == 0 ]; then
     echo "Inside nix shell, doing some stuff"
 fi
 
-if [[ $1 == "js"  ]]; then
-    if [[ "$OSTYPE" == "darwin"* && $in_nix != 0 ]]; then
-    	sed -i '' "s/import require\$\$1\$3 from '\.\.\/package\.json';/import require\$\$1\$3 from '..\/package.json' with {type: \"json\"};/" ./clients/javascript/open-feature-provider/dist/index.esm.js
-    else
-    	sed -i "s/import require\$\$1\$3 from '\.\.\/package\.json';/import require\$\$1\$3 from '..\/package.json' with {type: \"json\"};/" ./clients/javascript/open-feature-provider/dist/index.esm.js
-    fi
+if [[ $1 == "js" ]]; then
     mkdir -p clients/javascript/open-feature-provider/dist/native-lib
 fi
 


### PR DESCRIPTION
## Problem
package.json is not available for the superposition_sdk to include during build

## Solution
copy it during build-deps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build dependency resolution to improve SDK integration during the build process.
  * Streamlined JavaScript provider setup script for more efficient build configuration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->