### PR TITLE
refactor: remove unnecessary clone from eval logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9039,6 +9039,7 @@ dependencies = [
  "criterion",
  "itertools 0.10.5",
  "jsonschema 0.17.0",
+ "juspay_jsonlogic",
  "log",
  "num-bigint",
  "serde",

--- a/clients/haskell/superposition-bindings/lib/FFI/Superposition.hs
+++ b/clients/haskell/superposition-bindings/lib/FFI/Superposition.hs
@@ -244,7 +244,7 @@ getResolvedConfig params = do
         exp
         ebuf
   err <- peekCAString ebuf
-  traverse_ freeNonNull [dc, ctx, ovrs, di, qry, mergeS, pfltr, exp, ebuf]
+  traverse_ freeNonNull [dc, ctx, ovrs, di, qry, mergeS, pfltr, exclPfltr, exp, ebuf]
   pure $ case (res, err) of
     (Just cfg, []) -> Right cfg
     (Nothing, [])  -> Left "null pointer returned"

--- a/clients/java/bindings/src/main/kotlin/uniffi/superposition_client/superposition_client.kt
+++ b/clients/java/bindings/src/main/kotlin/uniffi/superposition_client/superposition_client.kt
@@ -794,9 +794,9 @@ internal interface UniffiForeignFutureCompleteVoid : com.sun.jna.Callback {
 // when the library is loaded.
 internal interface IntegrityCheckingUniffiLib : Library {
     // Integrity check functions only
-    fun uniffi_superposition_core_checksum_func_ffi_eval_config(
+    fun uniffi_superposition_core_checksum_func_ffi_eval(
 ): Short
-fun uniffi_superposition_core_checksum_func_ffi_eval_config_with_reasoning(
+fun uniffi_superposition_core_checksum_func_ffi_eval_config(
 ): Short
 fun uniffi_superposition_core_checksum_func_ffi_get_applicable_variants(
 ): Short
@@ -888,9 +888,9 @@ fun uniffi_superposition_core_fn_method_providercache_init_config(`ptr`: Pointer
 ): Unit
 fun uniffi_superposition_core_fn_method_providercache_init_experiments(`ptr`: Pointer,`experiments`: RustBuffer.ByValue,`experimentGroups`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
-fun uniffi_superposition_core_fn_func_ffi_eval_config(`defaultConfig`: RustBufferExtendedMap.ByValue,`contexts`: RustBuffer.ByValue,`overrides`: RustBuffer.ByValue,`dimensions`: RustBuffer.ByValue,`queryData`: RustBuffer.ByValue,`mergeStrategy`: RustBufferMergeStrategy.ByValue,`filterPrefixes`: RustBuffer.ByValue,`filterExcludePrefixes`: RustBuffer.ByValue,`experimentation`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+fun uniffi_superposition_core_fn_func_ffi_eval(`config`: RustBufferConfig.ByValue,`queryData`: RustBuffer.ByValue,`mergeStrategy`: RustBufferMergeStrategy.ByValue,`filterPrefixes`: RustBuffer.ByValue,`filterExcludePrefixes`: RustBuffer.ByValue,`experimentation`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
-fun uniffi_superposition_core_fn_func_ffi_eval_config_with_reasoning(`defaultConfig`: RustBufferExtendedMap.ByValue,`contexts`: RustBuffer.ByValue,`overrides`: RustBuffer.ByValue,`dimensions`: RustBuffer.ByValue,`queryData`: RustBuffer.ByValue,`mergeStrategy`: RustBufferMergeStrategy.ByValue,`filterPrefixes`: RustBuffer.ByValue,`filterExcludePrefixes`: RustBuffer.ByValue,`experimentation`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+fun uniffi_superposition_core_fn_func_ffi_eval_config(`defaultConfig`: RustBufferExtendedMap.ByValue,`contexts`: RustBuffer.ByValue,`overrides`: RustBuffer.ByValue,`dimensions`: RustBuffer.ByValue,`queryData`: RustBuffer.ByValue,`mergeStrategy`: RustBufferMergeStrategy.ByValue,`filterPrefixes`: RustBuffer.ByValue,`filterExcludePrefixes`: RustBuffer.ByValue,`experimentation`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_superposition_core_fn_func_ffi_get_applicable_variants(`eargs`: RustBuffer.ByValue,`dimensionsInfo`: RustBuffer.ByValue,`queryData`: RustBuffer.ByValue,`prefix`: RustBuffer.ByValue,`excludePrefix`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
@@ -1026,10 +1026,10 @@ private fun uniffiCheckContractApiVersion(lib: IntegrityCheckingUniffiLib) {
 }
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
-    if (lib.uniffi_superposition_core_checksum_func_ffi_eval_config() != 1530.toShort()) {
+    if (lib.uniffi_superposition_core_checksum_func_ffi_eval() != 43090.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_superposition_core_checksum_func_ffi_eval_config_with_reasoning() != 25261.toShort()) {
+    if (lib.uniffi_superposition_core_checksum_func_ffi_eval_config() != 1530.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_superposition_core_checksum_func_ffi_get_applicable_variants() != 63950.toShort()) {
@@ -2317,20 +2317,20 @@ public object FfiConverterMapStringTypeOverrides: FfiConverterRustBuffer<Map<kot
 
 
 
-    @Throws(OperationException::class) fun `ffiEvalConfig`(`defaultConfig`: ExtendedMap, `contexts`: List<Context>, `overrides`: Map<kotlin.String, Overrides>, `dimensions`: Map<kotlin.String, DimensionInfo>, `queryData`: Map<kotlin.String, kotlin.String>, `mergeStrategy`: MergeStrategy, `filterPrefixes`: List<kotlin.String>?, `filterExcludePrefixes`: List<kotlin.String>?, `experimentation`: ExperimentationArgs?): Map<kotlin.String, kotlin.String> {
+    @Throws(OperationException::class) fun `ffiEval`(`config`: Config, `queryData`: Map<kotlin.String, kotlin.String>, `mergeStrategy`: MergeStrategy, `filterPrefixes`: List<kotlin.String>?, `filterExcludePrefixes`: List<kotlin.String>?, `experimentation`: ExperimentationArgs?): Map<kotlin.String, kotlin.String> {
             return FfiConverterMapStringString.lift(
     uniffiRustCallWithError(OperationException) { _status ->
-    UniffiLib.INSTANCE.uniffi_superposition_core_fn_func_ffi_eval_config(
-        FfiConverterTypeExtendedMap.lower(`defaultConfig`),FfiConverterSequenceTypeContext.lower(`contexts`),FfiConverterMapStringTypeOverrides.lower(`overrides`),FfiConverterMapStringTypeDimensionInfo.lower(`dimensions`),FfiConverterMapStringString.lower(`queryData`),FfiConverterTypeMergeStrategy.lower(`mergeStrategy`),FfiConverterOptionalSequenceString.lower(`filterPrefixes`),FfiConverterOptionalSequenceString.lower(`filterExcludePrefixes`),FfiConverterOptionalTypeExperimentationArgs.lower(`experimentation`),_status)
+    UniffiLib.INSTANCE.uniffi_superposition_core_fn_func_ffi_eval(
+        FfiConverterTypeConfig.lower(`config`),FfiConverterMapStringString.lower(`queryData`),FfiConverterTypeMergeStrategy.lower(`mergeStrategy`),FfiConverterOptionalSequenceString.lower(`filterPrefixes`),FfiConverterOptionalSequenceString.lower(`filterExcludePrefixes`),FfiConverterOptionalTypeExperimentationArgs.lower(`experimentation`),_status)
 }
     )
     }
     
 
-    @Throws(OperationException::class) fun `ffiEvalConfigWithReasoning`(`defaultConfig`: ExtendedMap, `contexts`: List<Context>, `overrides`: Map<kotlin.String, Overrides>, `dimensions`: Map<kotlin.String, DimensionInfo>, `queryData`: Map<kotlin.String, kotlin.String>, `mergeStrategy`: MergeStrategy, `filterPrefixes`: List<kotlin.String>?, `filterExcludePrefixes`: List<kotlin.String>?, `experimentation`: ExperimentationArgs?): Map<kotlin.String, kotlin.String> {
+    @Throws(OperationException::class) fun `ffiEvalConfig`(`defaultConfig`: ExtendedMap, `contexts`: List<Context>, `overrides`: Map<kotlin.String, Overrides>, `dimensions`: Map<kotlin.String, DimensionInfo>, `queryData`: Map<kotlin.String, kotlin.String>, `mergeStrategy`: MergeStrategy, `filterPrefixes`: List<kotlin.String>?, `filterExcludePrefixes`: List<kotlin.String>?, `experimentation`: ExperimentationArgs?): Map<kotlin.String, kotlin.String> {
             return FfiConverterMapStringString.lift(
     uniffiRustCallWithError(OperationException) { _status ->
-    UniffiLib.INSTANCE.uniffi_superposition_core_fn_func_ffi_eval_config_with_reasoning(
+    UniffiLib.INSTANCE.uniffi_superposition_core_fn_func_ffi_eval_config(
         FfiConverterTypeExtendedMap.lower(`defaultConfig`),FfiConverterSequenceTypeContext.lower(`contexts`),FfiConverterMapStringTypeOverrides.lower(`overrides`),FfiConverterMapStringTypeDimensionInfo.lower(`dimensions`),FfiConverterMapStringString.lower(`queryData`),FfiConverterTypeMergeStrategy.lower(`mergeStrategy`),FfiConverterOptionalSequenceString.lower(`filterPrefixes`),FfiConverterOptionalSequenceString.lower(`filterExcludePrefixes`),FfiConverterOptionalTypeExperimentationArgs.lower(`experimentation`),_status)
 }
     )

--- a/clients/java/bindings/src/main/kotlin/uniffi/superposition_client/superposition_client.kt
+++ b/clients/java/bindings/src/main/kotlin/uniffi/superposition_client/superposition_client.kt
@@ -38,6 +38,7 @@ import uniffi.superposition_types.Config
 import uniffi.superposition_types.Context
 import uniffi.superposition_types.DimensionInfo
 import uniffi.superposition_types.ExperimentStatusType
+import uniffi.superposition_types.ExtendedMap
 import uniffi.superposition_types.FfiConverterTypeBucket
 import uniffi.superposition_types.FfiConverterTypeBuckets
 import uniffi.superposition_types.FfiConverterTypeCondition
@@ -45,6 +46,7 @@ import uniffi.superposition_types.FfiConverterTypeConfig
 import uniffi.superposition_types.FfiConverterTypeContext
 import uniffi.superposition_types.FfiConverterTypeDimensionInfo
 import uniffi.superposition_types.FfiConverterTypeExperimentStatusType
+import uniffi.superposition_types.FfiConverterTypeExtendedMap
 import uniffi.superposition_types.FfiConverterTypeGroupType
 import uniffi.superposition_types.FfiConverterTypeMergeStrategy
 import uniffi.superposition_types.FfiConverterTypeOverrides
@@ -62,6 +64,7 @@ import uniffi.superposition_types.RustBuffer as RustBufferConfig
 import uniffi.superposition_types.RustBuffer as RustBufferContext
 import uniffi.superposition_types.RustBuffer as RustBufferDimensionInfo
 import uniffi.superposition_types.RustBuffer as RustBufferExperimentStatusType
+import uniffi.superposition_types.RustBuffer as RustBufferExtendedMap
 import uniffi.superposition_types.RustBuffer as RustBufferGroupType
 import uniffi.superposition_types.RustBuffer as RustBufferMergeStrategy
 import uniffi.superposition_types.RustBuffer as RustBufferOverrides
@@ -885,9 +888,9 @@ fun uniffi_superposition_core_fn_method_providercache_init_config(`ptr`: Pointer
 ): Unit
 fun uniffi_superposition_core_fn_method_providercache_init_experiments(`ptr`: Pointer,`experiments`: RustBuffer.ByValue,`experimentGroups`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): Unit
-fun uniffi_superposition_core_fn_func_ffi_eval_config(`defaultConfig`: RustBuffer.ByValue,`contexts`: RustBuffer.ByValue,`overrides`: RustBuffer.ByValue,`dimensions`: RustBuffer.ByValue,`queryData`: RustBuffer.ByValue,`mergeStrategy`: RustBufferMergeStrategy.ByValue,`filterPrefixes`: RustBuffer.ByValue,`filterExcludePrefixes`: RustBuffer.ByValue,`experimentation`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+fun uniffi_superposition_core_fn_func_ffi_eval_config(`defaultConfig`: RustBufferExtendedMap.ByValue,`contexts`: RustBuffer.ByValue,`overrides`: RustBuffer.ByValue,`dimensions`: RustBuffer.ByValue,`queryData`: RustBuffer.ByValue,`mergeStrategy`: RustBufferMergeStrategy.ByValue,`filterPrefixes`: RustBuffer.ByValue,`filterExcludePrefixes`: RustBuffer.ByValue,`experimentation`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
-fun uniffi_superposition_core_fn_func_ffi_eval_config_with_reasoning(`defaultConfig`: RustBuffer.ByValue,`contexts`: RustBuffer.ByValue,`overrides`: RustBuffer.ByValue,`dimensions`: RustBuffer.ByValue,`queryData`: RustBuffer.ByValue,`mergeStrategy`: RustBufferMergeStrategy.ByValue,`filterPrefixes`: RustBuffer.ByValue,`filterExcludePrefixes`: RustBuffer.ByValue,`experimentation`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+fun uniffi_superposition_core_fn_func_ffi_eval_config_with_reasoning(`defaultConfig`: RustBufferExtendedMap.ByValue,`contexts`: RustBuffer.ByValue,`overrides`: RustBuffer.ByValue,`dimensions`: RustBuffer.ByValue,`queryData`: RustBuffer.ByValue,`mergeStrategy`: RustBufferMergeStrategy.ByValue,`filterPrefixes`: RustBuffer.ByValue,`filterExcludePrefixes`: RustBuffer.ByValue,`experimentation`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_superposition_core_fn_func_ffi_get_applicable_variants(`eargs`: RustBuffer.ByValue,`dimensionsInfo`: RustBuffer.ByValue,`queryData`: RustBuffer.ByValue,`prefix`: RustBuffer.ByValue,`excludePrefix`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
@@ -1023,10 +1026,10 @@ private fun uniffiCheckContractApiVersion(lib: IntegrityCheckingUniffiLib) {
 }
 @Suppress("UNUSED_PARAMETER")
 private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
-    if (lib.uniffi_superposition_core_checksum_func_ffi_eval_config() != 51777.toShort()) {
+    if (lib.uniffi_superposition_core_checksum_func_ffi_eval_config() != 1530.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_superposition_core_checksum_func_ffi_eval_config_with_reasoning() != 2696.toShort()) {
+    if (lib.uniffi_superposition_core_checksum_func_ffi_eval_config_with_reasoning() != 25261.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_superposition_core_checksum_func_ffi_get_applicable_variants() != 63950.toShort()) {
@@ -2312,21 +2315,23 @@ public object FfiConverterMapStringTypeOverrides: FfiConverterRustBuffer<Map<kot
 
 
 
-    @Throws(OperationException::class) fun `ffiEvalConfig`(`defaultConfig`: Map<kotlin.String, kotlin.String>, `contexts`: List<Context>, `overrides`: Map<kotlin.String, Overrides>, `dimensions`: Map<kotlin.String, DimensionInfo>, `queryData`: Map<kotlin.String, kotlin.String>, `mergeStrategy`: MergeStrategy, `filterPrefixes`: List<kotlin.String>?, `filterExcludePrefixes`: List<kotlin.String>?, `experimentation`: ExperimentationArgs?): Map<kotlin.String, kotlin.String> {
+
+
+    @Throws(OperationException::class) fun `ffiEvalConfig`(`defaultConfig`: ExtendedMap, `contexts`: List<Context>, `overrides`: Map<kotlin.String, Overrides>, `dimensions`: Map<kotlin.String, DimensionInfo>, `queryData`: Map<kotlin.String, kotlin.String>, `mergeStrategy`: MergeStrategy, `filterPrefixes`: List<kotlin.String>?, `filterExcludePrefixes`: List<kotlin.String>?, `experimentation`: ExperimentationArgs?): Map<kotlin.String, kotlin.String> {
             return FfiConverterMapStringString.lift(
     uniffiRustCallWithError(OperationException) { _status ->
     UniffiLib.INSTANCE.uniffi_superposition_core_fn_func_ffi_eval_config(
-        FfiConverterMapStringString.lower(`defaultConfig`),FfiConverterSequenceTypeContext.lower(`contexts`),FfiConverterMapStringTypeOverrides.lower(`overrides`),FfiConverterMapStringTypeDimensionInfo.lower(`dimensions`),FfiConverterMapStringString.lower(`queryData`),FfiConverterTypeMergeStrategy.lower(`mergeStrategy`),FfiConverterOptionalSequenceString.lower(`filterPrefixes`),FfiConverterOptionalSequenceString.lower(`filterExcludePrefixes`),FfiConverterOptionalTypeExperimentationArgs.lower(`experimentation`),_status)
+        FfiConverterTypeExtendedMap.lower(`defaultConfig`),FfiConverterSequenceTypeContext.lower(`contexts`),FfiConverterMapStringTypeOverrides.lower(`overrides`),FfiConverterMapStringTypeDimensionInfo.lower(`dimensions`),FfiConverterMapStringString.lower(`queryData`),FfiConverterTypeMergeStrategy.lower(`mergeStrategy`),FfiConverterOptionalSequenceString.lower(`filterPrefixes`),FfiConverterOptionalSequenceString.lower(`filterExcludePrefixes`),FfiConverterOptionalTypeExperimentationArgs.lower(`experimentation`),_status)
 }
     )
     }
     
 
-    @Throws(OperationException::class) fun `ffiEvalConfigWithReasoning`(`defaultConfig`: Map<kotlin.String, kotlin.String>, `contexts`: List<Context>, `overrides`: Map<kotlin.String, Overrides>, `dimensions`: Map<kotlin.String, DimensionInfo>, `queryData`: Map<kotlin.String, kotlin.String>, `mergeStrategy`: MergeStrategy, `filterPrefixes`: List<kotlin.String>?, `filterExcludePrefixes`: List<kotlin.String>?, `experimentation`: ExperimentationArgs?): Map<kotlin.String, kotlin.String> {
+    @Throws(OperationException::class) fun `ffiEvalConfigWithReasoning`(`defaultConfig`: ExtendedMap, `contexts`: List<Context>, `overrides`: Map<kotlin.String, Overrides>, `dimensions`: Map<kotlin.String, DimensionInfo>, `queryData`: Map<kotlin.String, kotlin.String>, `mergeStrategy`: MergeStrategy, `filterPrefixes`: List<kotlin.String>?, `filterExcludePrefixes`: List<kotlin.String>?, `experimentation`: ExperimentationArgs?): Map<kotlin.String, kotlin.String> {
             return FfiConverterMapStringString.lift(
     uniffiRustCallWithError(OperationException) { _status ->
     UniffiLib.INSTANCE.uniffi_superposition_core_fn_func_ffi_eval_config_with_reasoning(
-        FfiConverterMapStringString.lower(`defaultConfig`),FfiConverterSequenceTypeContext.lower(`contexts`),FfiConverterMapStringTypeOverrides.lower(`overrides`),FfiConverterMapStringTypeDimensionInfo.lower(`dimensions`),FfiConverterMapStringString.lower(`queryData`),FfiConverterTypeMergeStrategy.lower(`mergeStrategy`),FfiConverterOptionalSequenceString.lower(`filterPrefixes`),FfiConverterOptionalSequenceString.lower(`filterExcludePrefixes`),FfiConverterOptionalTypeExperimentationArgs.lower(`experimentation`),_status)
+        FfiConverterTypeExtendedMap.lower(`defaultConfig`),FfiConverterSequenceTypeContext.lower(`contexts`),FfiConverterMapStringTypeOverrides.lower(`overrides`),FfiConverterMapStringTypeDimensionInfo.lower(`dimensions`),FfiConverterMapStringString.lower(`queryData`),FfiConverterTypeMergeStrategy.lower(`mergeStrategy`),FfiConverterOptionalSequenceString.lower(`filterPrefixes`),FfiConverterOptionalSequenceString.lower(`filterExcludePrefixes`),FfiConverterOptionalTypeExperimentationArgs.lower(`experimentation`),_status)
 }
     )
     }

--- a/clients/javascript/bindings/native-resolver.ts
+++ b/clients/javascript/bindings/native-resolver.ts
@@ -19,14 +19,11 @@ export class NativeResolver {
             this.lib.core_get_resolved_config = this.lib.func(
                 "char* core_get_resolved_config(const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*)",
             );
-            this.lib.core_get_resolved_config_with_reasoning = this.lib.func(
-                "char* core_get_resolved_config_with_reasoning(const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*)",
-            );
             this.lib.core_free_string = this.lib.func(
                 "void core_free_string(char*)",
             );
             this.lib.core_get_applicable_variants = this.lib.func(
-                "char* core_get_applicable_variants(const char*, const char*, const char*, const char*, const char*, const char*)",
+                "char* core_get_applicable_variants(const char*, const char*, const char*, const char*, const char*, const char*, const char*, char*)",
             );
             this.lib.core_test_connection = this.lib.func(
                 "int core_test_connection()",
@@ -206,74 +203,6 @@ export class NativeResolver {
             console.error("Raw result string:", configStr);
             throw new Error(
                 `Failed to parse config evaluation result: ${parseError}`,
-            );
-        }
-    }
-
-    resolveConfigWithReasoning(
-        defaultConfigs: Record<string, any>,
-        contexts: any[],
-        overrides: Record<string, Record<string, any>>,
-        dimensions: Record<string, Record<string, any>>,
-        queryData: Record<string, any>,
-        mergeStrategy: "merge" | "replace" = "merge",
-        filterPrefixes?: string[],
-        filterExcludePrefixes?: string[],
-        experimentation?: any,
-    ): Record<string, any> {
-        if (!this.isAvailable) {
-            throw new Error(
-                "Native resolver is not available. Please ensure the native library is built and accessible.",
-            );
-        }
-
-        const filterPrefixesJson =
-            filterPrefixes && filterPrefixes.length > 0
-                ? JSON.stringify(filterPrefixes)
-                : null;
-        const filterExcludePrefixesJson =
-            filterExcludePrefixes && filterExcludePrefixes.length > 0
-                ? JSON.stringify(filterExcludePrefixes)
-                : null;
-        const experimentationJson = experimentation
-            ? JSON.stringify(experimentation)
-            : null;
-
-        const ebuf = Buffer.alloc(ERROR_BUFFER_SIZE);
-        const result = this.lib.core_get_resolved_config_with_reasoning(
-            JSON.stringify(defaultConfigs || {}),
-            JSON.stringify(contexts),
-            JSON.stringify(overrides),
-            JSON.stringify(dimensions),
-            JSON.stringify(queryData),
-            mergeStrategy,
-            filterPrefixesJson,
-            filterExcludePrefixesJson,
-            experimentationJson,
-            ebuf,
-        );
-
-        const err = ebuf.toString("utf8").split("\0")[0];
-        if (err.length !== 0) {
-            this.throwFFIError(err);
-        }
-
-        const configStr =
-            typeof result === "string"
-                ? result
-                : this.lib.decode(result, "string");
-
-        if (typeof result !== "string") {
-            this.lib.core_free_string(result);
-        }
-
-        try {
-            return JSON.parse(configStr);
-        } catch (parseError) {
-            console.error("Failed to parse reasoning result:", parseError);
-            console.error("Raw result string:", configStr);
-            throw new Error(
-                `Failed to parse reasoning evaluation result: ${parseError}`,
             );
         }
     }

--- a/clients/python/bindings/superposition_bindings/superposition_client.py
+++ b/clients/python/bindings/superposition_bindings/superposition_client.py
@@ -35,6 +35,7 @@ from .superposition_types import Config
 from .superposition_types import Context
 from .superposition_types import DimensionInfo
 from .superposition_types import ExperimentStatusType
+from .superposition_types import ExtendedMap
 from .superposition_types import GroupType
 from .superposition_types import MergeStrategy
 from .superposition_types import Overrides
@@ -47,6 +48,7 @@ from .superposition_types import _UniffiConverterTypeConfig
 from .superposition_types import _UniffiConverterTypeContext
 from .superposition_types import _UniffiConverterTypeDimensionInfo
 from .superposition_types import _UniffiConverterTypeExperimentStatusType
+from .superposition_types import _UniffiConverterTypeExtendedMap
 from .superposition_types import _UniffiConverterTypeGroupType
 from .superposition_types import _UniffiConverterTypeMergeStrategy
 from .superposition_types import _UniffiConverterTypeOverrides
@@ -59,6 +61,7 @@ from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferConfig
 from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferContext
 from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferDimensionInfo
 from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferExperimentStatusType
+from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferExtendedMap
 from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferGroupType
 from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferMergeStrategy
 from .superposition_types import _UniffiRustBuffer as _UniffiRustBufferOverrides
@@ -495,9 +498,9 @@ def _uniffi_check_contract_api_version(lib):
         raise InternalError("UniFFI contract version mismatch: try cleaning and rebuilding your project")
 
 def _uniffi_check_api_checksums(lib):
-    if lib.uniffi_superposition_core_checksum_func_ffi_eval_config() != 51777:
+    if lib.uniffi_superposition_core_checksum_func_ffi_eval_config() != 1530:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_superposition_core_checksum_func_ffi_eval_config_with_reasoning() != 2696:
+    if lib.uniffi_superposition_core_checksum_func_ffi_eval_config_with_reasoning() != 25261:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_superposition_core_checksum_func_ffi_get_applicable_variants() != 63950:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -694,7 +697,7 @@ _UniffiLib.uniffi_superposition_core_fn_method_providercache_init_experiments.ar
 )
 _UniffiLib.uniffi_superposition_core_fn_method_providercache_init_experiments.restype = None
 _UniffiLib.uniffi_superposition_core_fn_func_ffi_eval_config.argtypes = (
-    _UniffiRustBuffer,
+    _UniffiRustBufferExtendedMap,
     _UniffiRustBuffer,
     _UniffiRustBuffer,
     _UniffiRustBuffer,
@@ -707,7 +710,7 @@ _UniffiLib.uniffi_superposition_core_fn_func_ffi_eval_config.argtypes = (
 )
 _UniffiLib.uniffi_superposition_core_fn_func_ffi_eval_config.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_superposition_core_fn_func_ffi_eval_config_with_reasoning.argtypes = (
-    _UniffiRustBuffer,
+    _UniffiRustBufferExtendedMap,
     _UniffiRustBuffer,
     _UniffiRustBuffer,
     _UniffiRustBuffer,
@@ -1977,14 +1980,16 @@ class _UniffiConverterTypeProviderCache:
 
 # External type Condition: `from .superposition_types import Condition`
 
+# External type ExtendedMap: `from .superposition_types import ExtendedMap`
+
 # External type Overrides: `from .superposition_types import Overrides`
 
 # External type Variants: `from .superposition_types import Variants`
 
 # Async support
 
-def ffi_eval_config(default_config: "dict[str, str]",contexts: "typing.List[Context]",overrides: "dict[str, Overrides]",dimensions: "dict[str, DimensionInfo]",query_data: "dict[str, str]",merge_strategy: "MergeStrategy",filter_prefixes: "typing.Optional[typing.List[str]]",filter_exclude_prefixes: "typing.Optional[typing.List[str]]",experimentation: "typing.Optional[ExperimentationArgs]") -> "dict[str, str]":
-    _UniffiConverterMapStringString.check_lower(default_config)
+def ffi_eval_config(default_config: "ExtendedMap",contexts: "typing.List[Context]",overrides: "dict[str, Overrides]",dimensions: "dict[str, DimensionInfo]",query_data: "dict[str, str]",merge_strategy: "MergeStrategy",filter_prefixes: "typing.Optional[typing.List[str]]",filter_exclude_prefixes: "typing.Optional[typing.List[str]]",experimentation: "typing.Optional[ExperimentationArgs]") -> "dict[str, str]":
+    _UniffiConverterTypeExtendedMap.check_lower(default_config)
     
     _UniffiConverterSequenceTypeContext.check_lower(contexts)
     
@@ -2003,7 +2008,7 @@ def ffi_eval_config(default_config: "dict[str, str]",contexts: "typing.List[Cont
     _UniffiConverterOptionalTypeExperimentationArgs.check_lower(experimentation)
     
     return _UniffiConverterMapStringString.lift(_uniffi_rust_call_with_error(_UniffiConverterTypeOperationError,_UniffiLib.uniffi_superposition_core_fn_func_ffi_eval_config,
-        _UniffiConverterMapStringString.lower(default_config),
+        _UniffiConverterTypeExtendedMap.lower(default_config),
         _UniffiConverterSequenceTypeContext.lower(contexts),
         _UniffiConverterMapStringTypeOverrides.lower(overrides),
         _UniffiConverterMapStringTypeDimensionInfo.lower(dimensions),
@@ -2014,8 +2019,8 @@ def ffi_eval_config(default_config: "dict[str, str]",contexts: "typing.List[Cont
         _UniffiConverterOptionalTypeExperimentationArgs.lower(experimentation)))
 
 
-def ffi_eval_config_with_reasoning(default_config: "dict[str, str]",contexts: "typing.List[Context]",overrides: "dict[str, Overrides]",dimensions: "dict[str, DimensionInfo]",query_data: "dict[str, str]",merge_strategy: "MergeStrategy",filter_prefixes: "typing.Optional[typing.List[str]]",filter_exclude_prefixes: "typing.Optional[typing.List[str]]",experimentation: "typing.Optional[ExperimentationArgs]") -> "dict[str, str]":
-    _UniffiConverterMapStringString.check_lower(default_config)
+def ffi_eval_config_with_reasoning(default_config: "ExtendedMap",contexts: "typing.List[Context]",overrides: "dict[str, Overrides]",dimensions: "dict[str, DimensionInfo]",query_data: "dict[str, str]",merge_strategy: "MergeStrategy",filter_prefixes: "typing.Optional[typing.List[str]]",filter_exclude_prefixes: "typing.Optional[typing.List[str]]",experimentation: "typing.Optional[ExperimentationArgs]") -> "dict[str, str]":
+    _UniffiConverterTypeExtendedMap.check_lower(default_config)
     
     _UniffiConverterSequenceTypeContext.check_lower(contexts)
     
@@ -2034,7 +2039,7 @@ def ffi_eval_config_with_reasoning(default_config: "dict[str, str]",contexts: "t
     _UniffiConverterOptionalTypeExperimentationArgs.check_lower(experimentation)
     
     return _UniffiConverterMapStringString.lift(_uniffi_rust_call_with_error(_UniffiConverterTypeOperationError,_UniffiLib.uniffi_superposition_core_fn_func_ffi_eval_config_with_reasoning,
-        _UniffiConverterMapStringString.lower(default_config),
+        _UniffiConverterTypeExtendedMap.lower(default_config),
         _UniffiConverterSequenceTypeContext.lower(contexts),
         _UniffiConverterMapStringTypeOverrides.lower(overrides),
         _UniffiConverterMapStringTypeDimensionInfo.lower(dimensions),

--- a/clients/python/bindings/superposition_bindings/superposition_client.py
+++ b/clients/python/bindings/superposition_bindings/superposition_client.py
@@ -498,9 +498,9 @@ def _uniffi_check_contract_api_version(lib):
         raise InternalError("UniFFI contract version mismatch: try cleaning and rebuilding your project")
 
 def _uniffi_check_api_checksums(lib):
-    if lib.uniffi_superposition_core_checksum_func_ffi_eval_config() != 1530:
+    if lib.uniffi_superposition_core_checksum_func_ffi_eval() != 43090:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_superposition_core_checksum_func_ffi_eval_config_with_reasoning() != 25261:
+    if lib.uniffi_superposition_core_checksum_func_ffi_eval_config() != 1530:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_superposition_core_checksum_func_ffi_get_applicable_variants() != 63950:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -696,6 +696,16 @@ _UniffiLib.uniffi_superposition_core_fn_method_providercache_init_experiments.ar
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_superposition_core_fn_method_providercache_init_experiments.restype = None
+_UniffiLib.uniffi_superposition_core_fn_func_ffi_eval.argtypes = (
+    _UniffiRustBufferConfig,
+    _UniffiRustBuffer,
+    _UniffiRustBufferMergeStrategy,
+    _UniffiRustBuffer,
+    _UniffiRustBuffer,
+    _UniffiRustBuffer,
+    ctypes.POINTER(_UniffiRustCallStatus),
+)
+_UniffiLib.uniffi_superposition_core_fn_func_ffi_eval.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_superposition_core_fn_func_ffi_eval_config.argtypes = (
     _UniffiRustBufferExtendedMap,
     _UniffiRustBuffer,
@@ -709,19 +719,6 @@ _UniffiLib.uniffi_superposition_core_fn_func_ffi_eval_config.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_superposition_core_fn_func_ffi_eval_config.restype = _UniffiRustBuffer
-_UniffiLib.uniffi_superposition_core_fn_func_ffi_eval_config_with_reasoning.argtypes = (
-    _UniffiRustBufferExtendedMap,
-    _UniffiRustBuffer,
-    _UniffiRustBuffer,
-    _UniffiRustBuffer,
-    _UniffiRustBuffer,
-    _UniffiRustBufferMergeStrategy,
-    _UniffiRustBuffer,
-    _UniffiRustBuffer,
-    _UniffiRustBuffer,
-    ctypes.POINTER(_UniffiRustCallStatus),
-)
-_UniffiLib.uniffi_superposition_core_fn_func_ffi_eval_config_with_reasoning.restype = _UniffiRustBuffer
 _UniffiLib.uniffi_superposition_core_fn_func_ffi_get_applicable_variants.argtypes = (
     _UniffiRustBuffer,
     _UniffiRustBuffer,
@@ -1018,12 +1015,12 @@ _UniffiLib.ffi_superposition_core_rust_future_complete_void.argtypes = (
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.ffi_superposition_core_rust_future_complete_void.restype = None
+_UniffiLib.uniffi_superposition_core_checksum_func_ffi_eval.argtypes = (
+)
+_UniffiLib.uniffi_superposition_core_checksum_func_ffi_eval.restype = ctypes.c_uint16
 _UniffiLib.uniffi_superposition_core_checksum_func_ffi_eval_config.argtypes = (
 )
 _UniffiLib.uniffi_superposition_core_checksum_func_ffi_eval_config.restype = ctypes.c_uint16
-_UniffiLib.uniffi_superposition_core_checksum_func_ffi_eval_config_with_reasoning.argtypes = (
-)
-_UniffiLib.uniffi_superposition_core_checksum_func_ffi_eval_config_with_reasoning.restype = ctypes.c_uint16
 _UniffiLib.uniffi_superposition_core_checksum_func_ffi_get_applicable_variants.argtypes = (
 )
 _UniffiLib.uniffi_superposition_core_checksum_func_ffi_get_applicable_variants.restype = ctypes.c_uint16
@@ -1988,6 +1985,28 @@ class _UniffiConverterTypeProviderCache:
 
 # Async support
 
+def ffi_eval(config: "Config",query_data: "dict[str, str]",merge_strategy: "MergeStrategy",filter_prefixes: "typing.Optional[typing.List[str]]",filter_exclude_prefixes: "typing.Optional[typing.List[str]]",experimentation: "typing.Optional[ExperimentationArgs]") -> "dict[str, str]":
+    _UniffiConverterTypeConfig.check_lower(config)
+    
+    _UniffiConverterMapStringString.check_lower(query_data)
+    
+    _UniffiConverterTypeMergeStrategy.check_lower(merge_strategy)
+    
+    _UniffiConverterOptionalSequenceString.check_lower(filter_prefixes)
+    
+    _UniffiConverterOptionalSequenceString.check_lower(filter_exclude_prefixes)
+    
+    _UniffiConverterOptionalTypeExperimentationArgs.check_lower(experimentation)
+    
+    return _UniffiConverterMapStringString.lift(_uniffi_rust_call_with_error(_UniffiConverterTypeOperationError,_UniffiLib.uniffi_superposition_core_fn_func_ffi_eval,
+        _UniffiConverterTypeConfig.lower(config),
+        _UniffiConverterMapStringString.lower(query_data),
+        _UniffiConverterTypeMergeStrategy.lower(merge_strategy),
+        _UniffiConverterOptionalSequenceString.lower(filter_prefixes),
+        _UniffiConverterOptionalSequenceString.lower(filter_exclude_prefixes),
+        _UniffiConverterOptionalTypeExperimentationArgs.lower(experimentation)))
+
+
 def ffi_eval_config(default_config: "ExtendedMap",contexts: "typing.List[Context]",overrides: "dict[str, Overrides]",dimensions: "dict[str, DimensionInfo]",query_data: "dict[str, str]",merge_strategy: "MergeStrategy",filter_prefixes: "typing.Optional[typing.List[str]]",filter_exclude_prefixes: "typing.Optional[typing.List[str]]",experimentation: "typing.Optional[ExperimentationArgs]") -> "dict[str, str]":
     _UniffiConverterTypeExtendedMap.check_lower(default_config)
     
@@ -2008,37 +2027,6 @@ def ffi_eval_config(default_config: "ExtendedMap",contexts: "typing.List[Context
     _UniffiConverterOptionalTypeExperimentationArgs.check_lower(experimentation)
     
     return _UniffiConverterMapStringString.lift(_uniffi_rust_call_with_error(_UniffiConverterTypeOperationError,_UniffiLib.uniffi_superposition_core_fn_func_ffi_eval_config,
-        _UniffiConverterTypeExtendedMap.lower(default_config),
-        _UniffiConverterSequenceTypeContext.lower(contexts),
-        _UniffiConverterMapStringTypeOverrides.lower(overrides),
-        _UniffiConverterMapStringTypeDimensionInfo.lower(dimensions),
-        _UniffiConverterMapStringString.lower(query_data),
-        _UniffiConverterTypeMergeStrategy.lower(merge_strategy),
-        _UniffiConverterOptionalSequenceString.lower(filter_prefixes),
-        _UniffiConverterOptionalSequenceString.lower(filter_exclude_prefixes),
-        _UniffiConverterOptionalTypeExperimentationArgs.lower(experimentation)))
-
-
-def ffi_eval_config_with_reasoning(default_config: "ExtendedMap",contexts: "typing.List[Context]",overrides: "dict[str, Overrides]",dimensions: "dict[str, DimensionInfo]",query_data: "dict[str, str]",merge_strategy: "MergeStrategy",filter_prefixes: "typing.Optional[typing.List[str]]",filter_exclude_prefixes: "typing.Optional[typing.List[str]]",experimentation: "typing.Optional[ExperimentationArgs]") -> "dict[str, str]":
-    _UniffiConverterTypeExtendedMap.check_lower(default_config)
-    
-    _UniffiConverterSequenceTypeContext.check_lower(contexts)
-    
-    _UniffiConverterMapStringTypeOverrides.check_lower(overrides)
-    
-    _UniffiConverterMapStringTypeDimensionInfo.check_lower(dimensions)
-    
-    _UniffiConverterMapStringString.check_lower(query_data)
-    
-    _UniffiConverterTypeMergeStrategy.check_lower(merge_strategy)
-    
-    _UniffiConverterOptionalSequenceString.check_lower(filter_prefixes)
-    
-    _UniffiConverterOptionalSequenceString.check_lower(filter_exclude_prefixes)
-    
-    _UniffiConverterOptionalTypeExperimentationArgs.check_lower(experimentation)
-    
-    return _UniffiConverterMapStringString.lift(_uniffi_rust_call_with_error(_UniffiConverterTypeOperationError,_UniffiLib.uniffi_superposition_core_fn_func_ffi_eval_config_with_reasoning,
         _UniffiConverterTypeExtendedMap.lower(default_config),
         _UniffiConverterSequenceTypeContext.lower(contexts),
         _UniffiConverterMapStringTypeOverrides.lower(overrides),
@@ -2162,8 +2150,8 @@ __all__ = [
     "ExperimentationArgs",
     "FfiExperiment",
     "FfiExperimentGroup",
+    "ffi_eval",
     "ffi_eval_config",
-    "ffi_eval_config_with_reasoning",
     "ffi_get_applicable_variants",
     "ffi_parse_config_file_with_filters",
     "ffi_parse_json_config",

--- a/crates/cac_client/src/eval.rs
+++ b/crates/cac_client/src/eval.rs
@@ -1,8 +1,8 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 use serde_json::{json, Map, Value};
 use superposition_types::{
-    logic::evaluate_local_cohorts, Config, ExtendedMap, Overrides,
+    logic::evaluate_local_cohorts, Config, DimensionInfo, ExtendedMap, Overrides,
 };
 
 use crate::{Context, MergeStrategy};
@@ -24,41 +24,45 @@ pub fn merge(doc: &mut Value, patch: Value) {
     }
 }
 
-fn get_overrides<F: FnMut(Context)>(
+/// Merges the overrides of every context matching `query_data` into a single map,
+/// in context order, so that later contexts win.
+///
+/// Override ids are derived from the override's contents, so several contexts can
+/// share one and each must apply it at its own position. An override is therefore
+/// cloned only when more than one matching context needs it, and the last of those
+/// contexts moves it out of `overrides` rather than cloning.
+fn get_overrides(
     query_data: &Map<String, Value>,
-    contexts: Vec<Context>,
-    mut overrides: HashMap<String, Overrides>,
+    mut contexts: Vec<&Context>,
+    mut overrides: Cow<'_, HashMap<String, Overrides>>,
     merge_strategy: &MergeStrategy,
-    mut on_override_select: F,
-) -> Result<Map<String, Value>, String> {
-    let mut final_consumer_context: HashMap<String, String> = HashMap::new();
+) -> Map<String, Value> {
+    // borrow the keys instead of allocating two Strings per matching context
+    let mut final_consumer_context: HashMap<&str, &str> = HashMap::new();
 
-    let contexts = contexts
-        .into_iter()
-        .filter(|context| {
-            if !superposition_types::apply(&context.condition, query_data) {
-                return false;
-            }
-
-            final_consumer_context.insert(
-                context.override_with_keys.get_key().to_string(),
-                context.id.to_string(),
-            );
-            true
-        })
-        .collect::<Vec<_>>();
+    contexts.retain(|&context| {
+        if !superposition_types::apply(&context.condition, query_data) {
+            return false;
+        }
+        final_consumer_context.insert(
+            context.override_with_keys.get_key().as_str(),
+            context.id.as_str(),
+        );
+        true
+    });
 
     let mut required_overrides: Value = json!({});
 
     for context in contexts {
         let override_key = context.override_with_keys.get_key();
-        // the last matching context needing an override moves it out, the rest clone
-        let overriden_value =
-            if final_consumer_context.get(override_key.as_str()) == Some(&context.id) {
-                overrides.remove(override_key)
-            } else {
-                overrides.get(override_key).cloned()
-            };
+        let is_last = final_consumer_context.get(override_key.as_str())
+            == Some(&context.id.as_str());
+
+        // move it out only when we own the map *and* this is its last consumer
+        let overriden_value = match (&mut overrides, is_last) {
+            (Cow::Owned(map), true) => map.remove(override_key).map(Cow::Owned),
+            (map, _) => map.get(override_key).map(Cow::Borrowed),
+        };
 
         let Some(overriden_value) = overriden_value else {
             continue;
@@ -67,31 +71,28 @@ fn get_overrides<F: FnMut(Context)>(
         match merge_strategy {
             MergeStrategy::REPLACE => {
                 if let Some(doc) = required_overrides.as_object_mut() {
-                    for (key, value) in overriden_value.into_inner() {
+                    for (key, value) in overriden_value.into_owned().into_inner() {
                         doc.insert(key, value);
                     }
                 }
             }
-            MergeStrategy::MERGE => {
-                merge(
-                    &mut required_overrides,
-                    Value::Object(overriden_value.into_inner()),
-                );
-            }
+            MergeStrategy::MERGE => merge(
+                &mut required_overrides,
+                Value::Object(overriden_value.into_owned().into_inner()),
+            ),
         }
-        on_override_select(context)
     }
 
     match required_overrides {
-        Value::Object(map) => Ok(map),
-        _ => Err("Failed to create overrides map".to_string()),
+        Value::Object(map) => map,
+        _ => Map::new(),
     }
 }
 
 fn merge_overrides_on_default_config(
     mut default_config: ExtendedMap,
     overrides: Map<String, Value>,
-    merge_strategy: &MergeStrategy,
+    merge_strategy: MergeStrategy,
 ) -> ExtendedMap {
     overrides.into_iter().for_each(|(key, val)| {
         if let Some(og_val) = default_config.get_mut(&key) {
@@ -102,60 +103,60 @@ fn merge_overrides_on_default_config(
                 MergeStrategy::MERGE => merge(og_val, val),
             }
         } else {
-            log::error!("CAC: found non-default_config key: {key} in overrides");
+            log::error!("Config: found non-default_config key: {key} in overrides");
         }
     });
     default_config
 }
 
+/// To be used when you have full ownership of the `Config` struct and
+/// want to evaluate it with a given set of dimensions.
 pub fn eval_cac(
     config: Config,
     query_data: Map<String, Value>,
     merge_strategy: MergeStrategy,
-) -> Result<Map<String, Value>, String> {
+) -> Map<String, Value> {
     let modified_query_data = evaluate_local_cohorts(&config.dimensions, query_data);
-    let overrides: Map<String, Value> = get_overrides(
+
+    let overrides_map: Map<String, Value> = get_overrides(
         &modified_query_data,
-        config.contexts,
-        config.overrides,
-        &merge_strategy,
-        drop,
-    )?;
-    let overriden_config = merge_overrides_on_default_config(
-        config.default_configs,
-        overrides,
+        config.contexts.iter().collect(),
+        Cow::Owned(config.overrides),
         &merge_strategy,
     );
-    Ok(overriden_config.into_inner())
+
+    // Apply overrides to default config
+    let result = merge_overrides_on_default_config(
+        config.default_configs,
+        overrides_map,
+        merge_strategy,
+    );
+
+    result.into_inner()
 }
 
-pub fn eval_cac_with_reasoning(
-    config: Config,
+/// To be used when the ownership of the `Config` struct is `not available`
+/// and you want to evaluate it with a given set of dimensions.
+pub fn eval(
+    default_configs: ExtendedMap,
+    contexts: &[Context],
+    overrides: &HashMap<String, Overrides>,
+    dimensions: &HashMap<String, DimensionInfo>,
     query_data: Map<String, Value>,
     merge_strategy: MergeStrategy,
-) -> Result<Map<String, Value>, String> {
-    let mut reasoning: Vec<Value> = vec![];
+) -> Map<String, Value> {
+    let modified_query_data = evaluate_local_cohorts(dimensions, query_data);
 
-    let modified_query_data = evaluate_local_cohorts(&config.dimensions, query_data);
-
-    let applied_overrides: Map<String, Value> = get_overrides(
+    let overrides_map = get_overrides(
         &modified_query_data,
-        config.contexts,
-        config.overrides,
-        &merge_strategy,
-        |context| {
-            reasoning.push(json!({
-                "context": context.condition,
-                "override": context.override_with_keys
-            }))
-        },
-    )?;
-
-    let mut overriden_config = merge_overrides_on_default_config(
-        config.default_configs,
-        applied_overrides,
+        contexts.iter().collect(),
+        Cow::Borrowed(overrides),
         &merge_strategy,
     );
-    overriden_config.insert("metadata".into(), json!(reasoning));
-    Ok(overriden_config.into_inner())
+
+    // Apply overrides to default config
+    let result =
+        merge_overrides_on_default_config(default_configs, overrides_map, merge_strategy);
+
+    result.into_inner()
 }

--- a/crates/cac_client/src/eval.rs
+++ b/crates/cac_client/src/eval.rs
@@ -7,20 +7,14 @@ use superposition_types::{
 
 use crate::{Context, MergeStrategy};
 
-pub fn merge(doc: &mut Value, patch: Value) {
-    if !patch.is_object() {
-        *doc = patch;
-        return;
-    }
-
-    if !doc.is_object() {
-        *doc = Value::Object(Map::new());
-    }
-
-    if let (Some(map), Value::Object(obj)) = (doc.as_object_mut(), patch) {
-        for (key, value) in obj {
-            merge(map.entry(key.as_str()).or_insert(Value::Null), value);
+fn merge(doc: &mut Value, patch: Value) {
+    match (doc, patch) {
+        (Value::Object(map), Value::Object(obj)) => {
+            for (key, value) in obj {
+                merge(map.entry(key).or_insert(Value::Null), value);
+            }
         }
+        (doc, patch) => *doc = patch,
     }
 }
 
@@ -89,7 +83,7 @@ fn get_overrides(
     }
 }
 
-fn merge_overrides_on_default_config(
+fn apply_overrides_on_default_config(
     mut default_config: ExtendedMap,
     overrides: Map<String, Value>,
     merge_strategy: MergeStrategy,
@@ -126,7 +120,7 @@ pub fn eval_cac(
     );
 
     // Apply overrides to default config
-    let result = merge_overrides_on_default_config(
+    let result = apply_overrides_on_default_config(
         config.default_configs,
         overrides_map,
         merge_strategy,
@@ -156,7 +150,7 @@ pub fn eval(
 
     // Apply overrides to default config
     let result =
-        merge_overrides_on_default_config(default_configs, overrides_map, merge_strategy);
+        apply_overrides_on_default_config(default_configs, overrides_map, merge_strategy);
 
     result.into_inner()
 }

--- a/crates/cac_client/src/eval.rs
+++ b/crates/cac_client/src/eval.rs
@@ -1,158 +1,161 @@
 use std::collections::HashMap;
 
 use serde_json::{json, Map, Value};
-use superposition_types::{logic::evaluate_local_cohorts, Config, Overrides};
+use superposition_types::{
+    logic::evaluate_local_cohorts, Config, ExtendedMap, Overrides,
+};
 
-use crate::{utils::core::MapError, Context, MergeStrategy};
+use crate::{Context, MergeStrategy};
 
-pub fn merge(doc: &mut Value, patch: &Value) {
+pub fn merge(doc: &mut Value, patch: Value) {
     if !patch.is_object() {
-        *doc = patch.clone();
+        *doc = patch;
         return;
     }
 
     if !doc.is_object() {
         *doc = Value::Object(Map::new());
     }
-    let map = doc.as_object_mut().unwrap();
-    for (key, value) in patch.as_object().unwrap() {
-        merge(map.entry(key.as_str()).or_insert(Value::Null), value);
-    }
-}
 
-fn replace_top_level(
-    doc: &mut Map<String, Value>,
-    patch: &Value,
-    mut on_override: impl FnMut(),
-    override_key: &String,
-) {
-    match patch.as_object() {
-        Some(patch_map) => {
-            for (key, value) in patch_map {
-                doc.insert(key.clone(), value.clone());
-            }
-            on_override();
-        }
-        None => {
-            log::error!("CAC: found non-object override key: {override_key} in overrides")
+    if let (Some(map), Value::Object(obj)) = (doc.as_object_mut(), patch) {
+        for (key, value) in obj {
+            merge(map.entry(key.as_str()).or_insert(Value::Null), value);
         }
     }
 }
 
-fn get_overrides(
+fn get_overrides<F: FnMut(Context)>(
     query_data: &Map<String, Value>,
-    contexts: &[Context],
-    overrides: &HashMap<String, Overrides>,
+    contexts: Vec<Context>,
+    mut overrides: HashMap<String, Overrides>,
     merge_strategy: &MergeStrategy,
-    mut on_override_select: Option<&mut dyn FnMut(Context)>,
-) -> serde_json::Result<Value> {
+    mut on_override_select: F,
+) -> Result<Map<String, Value>, String> {
+    let mut final_consumer_context: HashMap<String, String> = HashMap::new();
+
+    let contexts = contexts
+        .into_iter()
+        .filter(|context| {
+            if !superposition_types::apply(&context.condition, query_data) {
+                return false;
+            }
+
+            final_consumer_context.insert(
+                context.override_with_keys.get_key().to_string(),
+                context.id.to_string(),
+            );
+            true
+        })
+        .collect::<Vec<_>>();
+
     let mut required_overrides: Value = json!({});
-    let mut on_override_select = |context: Context| {
-        if let Some(ref mut func) = on_override_select {
-            func(context)
-        }
-    };
 
     for context in contexts {
-        let valid_context = superposition_types::apply(&context.condition, query_data);
+        let override_key = context.override_with_keys.get_key();
+        // the last matching context needing an override moves it out, the rest clone
+        let overriden_value =
+            if final_consumer_context.get(override_key.as_str()) == Some(&context.id) {
+                overrides.remove(override_key)
+            } else {
+                overrides.get(override_key).cloned()
+            };
 
-        if valid_context {
-            let override_key = context.override_with_keys.get_key();
-            if let Some(overriden_value) = overrides.get(override_key) {
-                match merge_strategy {
-                    MergeStrategy::REPLACE => replace_top_level(
-                        required_overrides.as_object_mut().unwrap(),
-                        &Value::Object(overriden_value.clone().into()),
-                        || on_override_select(context.clone()),
-                        override_key,
-                    ),
-                    MergeStrategy::MERGE => {
-                        merge(
-                            &mut required_overrides,
-                            &Value::Object(overriden_value.clone().into()),
-                        );
-                        on_override_select(context.clone())
+        let Some(overriden_value) = overriden_value else {
+            continue;
+        };
+
+        match merge_strategy {
+            MergeStrategy::REPLACE => {
+                if let Some(doc) = required_overrides.as_object_mut() {
+                    for (key, value) in overriden_value.into_inner() {
+                        doc.insert(key, value);
                     }
                 }
             }
+            MergeStrategy::MERGE => {
+                merge(
+                    &mut required_overrides,
+                    Value::Object(overriden_value.into_inner()),
+                );
+            }
         }
+        on_override_select(context)
     }
 
-    Ok(required_overrides)
+    match required_overrides {
+        Value::Object(map) => Ok(map),
+        _ => Err("Failed to create overrides map".to_string()),
+    }
 }
 
 fn merge_overrides_on_default_config(
-    default_config: &mut Map<String, Value>,
+    mut default_config: ExtendedMap,
     overrides: Map<String, Value>,
     merge_strategy: &MergeStrategy,
-) {
+) -> ExtendedMap {
     overrides.into_iter().for_each(|(key, val)| {
         if let Some(og_val) = default_config.get_mut(&key) {
             match merge_strategy {
                 MergeStrategy::REPLACE => {
-                    let _ = default_config.insert(key.clone(), val.clone());
+                    default_config.insert(key, val);
                 }
-                MergeStrategy::MERGE => merge(og_val, &val),
+                MergeStrategy::MERGE => merge(og_val, val),
             }
         } else {
             log::error!("CAC: found non-default_config key: {key} in overrides");
         }
-    })
+    });
+    default_config
 }
 
 pub fn eval_cac(
-    config: &Config,
-    query_data: &Map<String, Value>,
+    config: Config,
+    query_data: Map<String, Value>,
     merge_strategy: MergeStrategy,
 ) -> Result<Map<String, Value>, String> {
-    let mut default_config = (*config.default_configs).clone();
-    let on_override_select: Option<&mut dyn FnMut(Context)> = None;
     let modified_query_data = evaluate_local_cohorts(&config.dimensions, query_data);
     let overrides: Map<String, Value> = get_overrides(
         &modified_query_data,
-        &config.contexts,
-        &config.overrides,
+        config.contexts,
+        config.overrides,
         &merge_strategy,
-        on_override_select,
-    )
-    .and_then(serde_json::from_value)
-    .map_err_to_string()?;
-    merge_overrides_on_default_config(&mut default_config, overrides, &merge_strategy);
-    let overriden_config = default_config;
-    Ok(overriden_config)
+        drop,
+    )?;
+    let overriden_config = merge_overrides_on_default_config(
+        config.default_configs,
+        overrides,
+        &merge_strategy,
+    );
+    Ok(overriden_config.into_inner())
 }
 
 pub fn eval_cac_with_reasoning(
-    config: &Config,
-    query_data: &Map<String, Value>,
+    config: Config,
+    query_data: Map<String, Value>,
     merge_strategy: MergeStrategy,
 ) -> Result<Map<String, Value>, String> {
-    let mut default_config = (*config.default_configs).clone();
     let mut reasoning: Vec<Value> = vec![];
 
     let modified_query_data = evaluate_local_cohorts(&config.dimensions, query_data);
 
     let applied_overrides: Map<String, Value> = get_overrides(
         &modified_query_data,
-        &config.contexts,
-        &config.overrides,
+        config.contexts,
+        config.overrides,
         &merge_strategy,
-        Some(&mut |context| {
+        |context| {
             reasoning.push(json!({
                 "context": context.condition,
                 "override": context.override_with_keys
             }))
-        }),
-    )
-    .and_then(serde_json::from_value)
-    .map_err_to_string()?;
+        },
+    )?;
 
-    merge_overrides_on_default_config(
-        &mut default_config,
+    let mut overriden_config = merge_overrides_on_default_config(
+        config.default_configs,
         applied_overrides,
         &merge_strategy,
     );
-    let mut overriden_config = default_config;
     overriden_config.insert("metadata".into(), json!(reasoning));
-    Ok(overriden_config)
+    Ok(overriden_config.into_inner())
 }

--- a/crates/cac_client/src/interface.rs
+++ b/crates/cac_client/src/interface.rs
@@ -261,22 +261,18 @@ pub extern "C" fn cac_get_config(
 
     CAC_RUNTIME.block_on(async move {
         unsafe {
-            unwrap_safe!(
-                (*client)
-                    .get_full_config_state_with_filter(
-                        filters,
-                        prefix_list,
-                        exclude_prefix_list
-                    )
-                    .await
-                    .map(|config| {
-                        rstring_to_cstring(
-                            serde_json::to_value(config).unwrap().to_string(),
-                        )
-                        .into_raw()
-                    }),
-                std::ptr::null_mut()
-            )
+            let config = (*client)
+                .get_full_config_state_with_filter(
+                    filters,
+                    prefix_list,
+                    exclude_prefix_list,
+                )
+                .await;
+
+            let config =
+                unwrap_safe!(serde_json::to_value(config), return std::ptr::null());
+
+            rstring_to_cstring(config.to_string()).into_raw()
         }
     })
 }

--- a/crates/cac_client/src/lib.rs
+++ b/crates/cac_client/src/lib.rs
@@ -302,4 +302,3 @@ pub static CLIENT_FACTORY: Lazy<ClientFactory> =
 
 pub use eval::eval;
 pub use eval::eval_cac;
-pub use eval::merge;

--- a/crates/cac_client/src/lib.rs
+++ b/crates/cac_client/src/lib.rs
@@ -158,15 +158,12 @@ impl Client {
         query_data: Option<Map<String, Value>>,
         prefix: Option<Vec<String>>,
         exclude_prefix: Option<Vec<String>>,
-    ) -> Result<Config, String> {
-        let cac = self.config.read().await;
-        let filtered_config = cac.to_owned().filter(
-            query_data.as_ref(),
+    ) -> Config {
+        self.config.read().await.to_owned().filter(
+            query_data,
             prefix.map(PrefixList::from_iter).as_ref(),
             exclude_prefix.map(PrefixList::from_iter).as_ref(),
-        );
-
-        Ok(filtered_config)
+        )
     }
 
     pub async fn get_last_modified(&self) -> DateTime<Utc> {
@@ -207,7 +204,7 @@ impl Client {
             if !keys.is_empty() || !exclude_prefix.is_empty() {
                 config = config.filter_by_prefix(&keys, &exclude_prefix);
             }
-            let evaled_cac = eval::eval_cac(&config, &query_data, merge_strategy)?;
+            let evaled_cac = eval::eval_cac(config, query_data, merge_strategy)?;
             self.config_cache.insert(hash_key, evaled_cac.clone());
             Ok(evaled_cac)
         }

--- a/crates/cac_client/src/lib.rs
+++ b/crates/cac_client/src/lib.rs
@@ -18,7 +18,7 @@ use mini_moka::sync::Cache;
 use reqwest::{RequestBuilder, Response, StatusCode};
 use serde_json::{Map, Value};
 pub use superposition_types::api::config::MergeStrategy;
-use superposition_types::{Config, Context, ExtendedMap, PrefixList};
+use superposition_types::{Config, ConfigFilter, Context, ExtendedMap, PrefixList};
 use tokio::sync::RwLock;
 use utils::{core::MapError, json_to_sorted_string};
 
@@ -204,7 +204,7 @@ impl Client {
             if !keys.is_empty() || !exclude_prefix.is_empty() {
                 config = config.filter_by_prefix(&keys, &exclude_prefix);
             }
-            let evaled_cac = eval::eval_cac(config, query_data, merge_strategy)?;
+            let evaled_cac = eval::eval_cac(config, query_data, merge_strategy);
             self.config_cache.insert(hash_key, evaled_cac.clone());
             Ok(evaled_cac)
         }
@@ -300,6 +300,6 @@ use once_cell::sync::Lazy;
 pub static CLIENT_FACTORY: Lazy<ClientFactory> =
     Lazy::new(|| ClientFactory(RwLock::new(HashMap::new())));
 
+pub use eval::eval;
 pub use eval::eval_cac;
-pub use eval::eval_cac_with_reasoning;
 pub use eval::merge;

--- a/crates/context_aware_config/src/api/audit_log/handlers.rs
+++ b/crates/context_aware_config/src/api/audit_log/handlers.rs
@@ -53,8 +53,10 @@ async fn list_handler(
     } else {
         let dimensions_info =
             fetch_dimensions_info_map(&mut conn, &workspace_context.schema_name)?;
-        let evaluated_context =
-            evaluate_local_cohorts_skip_unresolved(&dimensions_info, &dimension_params);
+        let evaluated_context = evaluate_local_cohorts_skip_unresolved(
+            &dimensions_info,
+            dimension_params.into_inner(),
+        );
         Some(serde_json::to_string(&evaluated_context).map_err(|err| {
             unexpected_error!("failed to serialize audit context filter: {}", err)
         })?)

--- a/crates/context_aware_config/src/api/config/handlers.rs
+++ b/crates/context_aware_config/src/api/config/handlers.rs
@@ -22,8 +22,8 @@ use superposition_core::{
 use superposition_derives::{authorized, declare_resource};
 use superposition_macros::{bad_argument, unexpected_error};
 use superposition_types::{
-    Cac, Condition, Config, Context, DBConnection, DimensionInfo, InternalUserContext,
-    OverrideWithKeys, Overrides, PaginatedResponse, User,
+    Cac, Condition, Config, ConfigFilter, Context, DBConnection, DimensionInfo,
+    InternalUserContext, OverrideWithKeys, Overrides, PaginatedResponse, User,
     api::{
         config::{
             ConfigQuery, ContextPayload, ExplainKeyQuery, ExplainResolveQuery,

--- a/crates/context_aware_config/src/api/config/handlers.rs
+++ b/crates/context_aware_config/src/api/config/handlers.rs
@@ -564,7 +564,7 @@ async fn get_handler(
         body.map_or_else(QueryMap::default, |body| body.into_inner().context.into())
     };
     if !context.is_empty() {
-        config = config.filter_by_dimensions(&context);
+        config = config.filter_by_dimensions(context.into_inner());
     }
     AppHeader::add_last_modified(max_created_at, is_smithy, &mut response);
     AppHeader::add_config_version(&Some(version), &mut response);
@@ -764,7 +764,7 @@ async fn explain_resolve_handler(
         })?;
 
         explain_resolved_config(
-            &config,
+            config,
             query_data,
             merge_strategy,
             &mut conn,

--- a/crates/context_aware_config/src/api/config/helpers.rs
+++ b/crates/context_aware_config/src/api/config/helpers.rs
@@ -290,18 +290,20 @@ fn prepare_remote_query_data(
 }
 
 fn evaluate_resolved_config(
-    config: &Config,
-    query_data: &QueryMap,
+    config: Config,
+    query_data: QueryMap,
     merge_strategy: MergeStrategy,
     show_reason: bool,
 ) -> superposition::Result<Map<String, Value>> {
     if show_reason {
-        eval_cac_with_reasoning(config, query_data, merge_strategy).map_err(|err| {
-            log::error!("failed to eval cac with err: {}", err);
-            unexpected_error!("cac eval failed")
-        })
+        eval_cac_with_reasoning(config, query_data.into_inner(), merge_strategy).map_err(
+            |err| {
+                log::error!("failed to eval cac with err: {}", err);
+                unexpected_error!("cac eval failed")
+            },
+        )
     } else {
-        eval_cac(config, query_data, merge_strategy).map_err(|err| {
+        eval_cac(config, query_data.into_inner(), merge_strategy).map_err(|err| {
             log::error!("failed to eval cac with err: {}", err);
             unexpected_error!("cac eval failed")
         })
@@ -394,7 +396,7 @@ pub fn resolve(
     )?;
     let merge_strategy = merge_strategy.into_inner();
 
-    evaluate_resolved_config(&config, &query_data, merge_strategy, show_reason)
+    evaluate_resolved_config(config, query_data, merge_strategy, show_reason)
 }
 
 pub fn resolve_detailed(
@@ -421,9 +423,9 @@ pub fn resolve_detailed(
     let merge_strategy = merge_strategy.into_inner();
 
     let resolved_config = evaluate_resolved_config(
-        &resolution_config,
-        &context_data,
-        merge_strategy.clone(),
+        resolution_config,
+        context_data,
+        merge_strategy,
         show_reason,
     )?;
     let keys = resolved_config.keys().cloned().collect::<Vec<_>>();
@@ -435,7 +437,7 @@ pub fn resolve_detailed(
 
 #[allow(clippy::too_many_arguments)]
 pub fn explain_resolved_config(
-    config: &Config,
+    mut config: Config,
     context_data: QueryMap,
     merge_strategy: Header<MergeStrategy>,
     conn: &mut DBConnection,
@@ -444,11 +446,10 @@ pub fn explain_resolved_config(
     workspace_context: &WorkspaceContext,
     master_encryption_key: &Option<EncryptionKey>,
 ) -> superposition::Result<Explanation> {
-    let mut explanation_config = config.clone();
-    apply_context_id_filter(&mut explanation_config, &resolve_options.context_id)?;
+    apply_context_id_filter(&mut config, &resolve_options.context_id)?;
 
     let context_data = prepare_remote_query_data(
-        &explanation_config,
+        &config,
         context_data,
         conn,
         resolve_options.resolve_remote,
@@ -457,7 +458,7 @@ pub fn explain_resolved_config(
     )?;
     let merge_strategy = merge_strategy.into_inner();
 
-    let mut current_value = explanation_config
+    let mut current_value = config
         .default_configs
         .get(&explain_key.key)
         .cloned()
@@ -465,24 +466,25 @@ pub fn explain_resolved_config(
             bad_argument!("default config key {} not found", explain_key.key)
         })?;
     let context_data =
-        evaluate_local_cohorts(&explanation_config.dimensions, &context_data);
+        evaluate_local_cohorts(&config.dimensions, context_data.into_inner());
     let mut timeline = Vec::new();
 
-    for context in &explanation_config.contexts {
+    for context in config.contexts {
         if !superposition_types::apply(&context.condition, &context_data) {
             continue;
         }
 
-        let override_id = context.override_with_keys.get_key().clone();
+        let override_id = context.override_with_keys.get_key();
         let value_before = current_value.clone();
 
-        if let Some(override_value) = explanation_config
+        if let Some(override_value) = config
             .overrides
-            .get(&override_id)
+            .get(override_id)
             .and_then(|overrides| overrides.get(&explain_key.key))
+            .cloned()
         {
-            match &merge_strategy {
-                MergeStrategy::REPLACE => current_value = override_value.clone(),
+            match merge_strategy {
+                MergeStrategy::REPLACE => current_value = override_value,
                 MergeStrategy::MERGE => {
                     superposition_core::merge(&mut current_value, override_value)
                 }
@@ -495,9 +497,9 @@ pub fn explain_resolved_config(
         })?;
 
         timeline.push(ExplanationTimelineItem {
-            context_id: context.id.clone(),
+            context_id: context.id,
             condition,
-            override_id,
+            override_id: override_id.to_string(),
             value_before,
             value_after: current_value.clone(),
         });

--- a/crates/context_aware_config/src/api/config/helpers.rs
+++ b/crates/context_aware_config/src/api/config/helpers.rs
@@ -4,7 +4,7 @@ use actix_web::{
     HttpRequest,
     web::{Data, Header, Json},
 };
-use cac_client::{eval_cac, eval_cac_with_reasoning};
+use cac_client::eval_cac;
 use chrono::{DateTime, Utc};
 use diesel::{ExpressionMethods, QueryDsl, RunQueryDsl, dsl::max};
 use serde_json::{Map, Value};
@@ -18,7 +18,7 @@ use service_utils::{
 };
 use superposition_macros::{bad_argument, db_error, unexpected_error};
 use superposition_types::{
-    Config, DBConnection, PrefixList,
+    Config, ConfigFilter, DBConnection, PrefixList,
     api::config::{
         ContextPayload, DetailedResolvedConfigValue, DetailedResolvedConfiguration,
         ExplainKeyQuery, ExplainResolveQuery, Explanation, ExplanationTimelineItem,
@@ -293,21 +293,9 @@ fn evaluate_resolved_config(
     config: Config,
     query_data: QueryMap,
     merge_strategy: MergeStrategy,
-    show_reason: bool,
-) -> superposition::Result<Map<String, Value>> {
-    if show_reason {
-        eval_cac_with_reasoning(config, query_data.into_inner(), merge_strategy).map_err(
-            |err| {
-                log::error!("failed to eval cac with err: {}", err);
-                unexpected_error!("cac eval failed")
-            },
-        )
-    } else {
-        eval_cac(config, query_data.into_inner(), merge_strategy).map_err(|err| {
-            log::error!("failed to eval cac with err: {}", err);
-            unexpected_error!("cac eval failed")
-        })
-    }
+    _show_reason: bool, // TODO: Remove this
+) -> Map<String, Value> {
+    eval_cac(config, query_data.into_inner(), merge_strategy)
 }
 
 fn fetch_default_config_metadata(
@@ -396,7 +384,12 @@ pub fn resolve(
     )?;
     let merge_strategy = merge_strategy.into_inner();
 
-    evaluate_resolved_config(config, query_data, merge_strategy, show_reason)
+    Ok(evaluate_resolved_config(
+        config,
+        query_data,
+        merge_strategy,
+        show_reason,
+    ))
 }
 
 pub fn resolve_detailed(
@@ -427,7 +420,7 @@ pub fn resolve_detailed(
         context_data,
         merge_strategy,
         show_reason,
-    )?;
+    );
     let keys = resolved_config.keys().cloned().collect::<Vec<_>>();
     let metadata =
         fetch_default_config_metadata(conn, &workspace_context.schema_name, &keys)?;

--- a/crates/context_aware_config/src/api/context/handlers.rs
+++ b/crates/context_aware_config/src/api/context/handlers.rs
@@ -627,10 +627,10 @@ async fn list_handler(
             let dimensions_info =
                 fetch_dimensions_info_map(&mut conn, &workspace_context.schema_name)?;
 
-            let original_req_keys = dimension_params.keys().collect::<Vec<_>>();
+            let original_req_keys = dimension_params.keys().cloned().collect::<Vec<_>>();
             let evaluated_params = evaluate_local_cohorts_skip_unresolved(
                 &dimensions_info,
-                &dimension_params,
+                dimension_params.into_inner(),
             );
 
             let strategy = filter_params.dimension_match_strategy.unwrap_or_default();
@@ -649,7 +649,7 @@ async fn list_handler(
                 DimensionMatchStrategy::NonConflicting => eval_filtered,
                 _ => Context::filter_by_dimension(
                     eval_filtered,
-                    &original_req_keys,
+                    &original_req_keys.iter().collect::<Vec<_>>(),
                     &dimensions_info,
                 ),
             }

--- a/crates/context_aware_config/src/api/context/handlers.rs
+++ b/crates/context_aware_config/src/api/context/handlers.rs
@@ -605,21 +605,14 @@ async fn list_handler(
         let exclude_prefix_list = PrefixList::from(filter_params.exclude_prefix);
 
         if !prefix_list.is_empty() || !exclude_prefix_list.is_empty() {
-            all_contexts = all_contexts
-                .into_iter()
-                .filter_map(|mut context| {
-                    Context::filter_keys_by_prefix(
-                        &context,
-                        &prefix_list,
-                        &exclude_prefix_list,
-                    )
-                    .map(|filtered_overrides_map| {
-                        context.override_ = filtered_overrides_map.into_inner();
-                        context
-                    })
-                    .ok()
-                })
-                .collect()
+            all_contexts.retain_mut(|context| {
+                Context::filter_keys_by_prefix(
+                    context,
+                    &prefix_list,
+                    &exclude_prefix_list,
+                )
+                .is_ok()
+            })
         }
         let eval_filter_contexts = if dimension_params.is_empty() {
             all_contexts

--- a/crates/context_aware_config/src/api/context/handlers.rs
+++ b/crates/context_aware_config/src/api/context/handlers.rs
@@ -617,35 +617,37 @@ async fn list_handler(
         let eval_filter_contexts = if dimension_params.is_empty() {
             all_contexts
         } else {
-            let dimensions_info =
-                fetch_dimensions_info_map(&mut conn, &workspace_context.schema_name)?;
-
-            let original_req_keys = dimension_params.keys().cloned().collect::<Vec<_>>();
-
             let strategy = filter_params.dimension_match_strategy.unwrap_or_default();
-
-            let eval_filtered = match strategy {
+            match strategy {
                 DimensionMatchStrategy::Exact => {
                     Context::filter_exact_match(all_contexts, &dimension_params)
                 }
                 DimensionMatchStrategy::Subset
                 | DimensionMatchStrategy::NonConflicting => {
+                    let dimensions_info = fetch_dimensions_info_map(
+                        &mut conn,
+                        &workspace_context.schema_name,
+                    )?;
+                    let original_req_keys =
+                        dimension_params.keys().cloned().collect::<Vec<_>>();
+
                     let evaluated_params = evaluate_local_cohorts_skip_unresolved(
                         &dimensions_info,
                         dimension_params.into_inner(),
                     );
-                    Context::filter_by_eval(all_contexts, &evaluated_params)
-                }
-            };
+                    let eval_filtered =
+                        Context::filter_by_eval(all_contexts, &evaluated_params);
 
-            match strategy {
-                DimensionMatchStrategy::NonConflicting
-                | DimensionMatchStrategy::Exact => eval_filtered,
-                DimensionMatchStrategy::Subset => Context::filter_by_dimension(
-                    eval_filtered,
-                    &original_req_keys.iter().collect::<Vec<_>>(),
-                    &dimensions_info,
-                ),
+                    if matches!(strategy, DimensionMatchStrategy::Subset) {
+                        Context::filter_by_dimension(
+                            eval_filtered,
+                            &original_req_keys.iter().collect::<Vec<_>>(),
+                            &dimensions_info,
+                        )
+                    } else {
+                        eval_filtered
+                    }
+                }
             }
         };
 

--- a/crates/context_aware_config/src/api/context/handlers.rs
+++ b/crates/context_aware_config/src/api/context/handlers.rs
@@ -621,26 +621,27 @@ async fn list_handler(
                 fetch_dimensions_info_map(&mut conn, &workspace_context.schema_name)?;
 
             let original_req_keys = dimension_params.keys().cloned().collect::<Vec<_>>();
-            let evaluated_params = evaluate_local_cohorts_skip_unresolved(
-                &dimensions_info,
-                dimension_params.into_inner(),
-            );
 
             let strategy = filter_params.dimension_match_strategy.unwrap_or_default();
 
             let eval_filtered = match strategy {
                 DimensionMatchStrategy::Exact => {
-                    Context::filter_exact_match(all_contexts, &evaluated_params)
+                    Context::filter_exact_match(all_contexts, &dimension_params)
                 }
                 DimensionMatchStrategy::Subset
                 | DimensionMatchStrategy::NonConflicting => {
+                    let evaluated_params = evaluate_local_cohorts_skip_unresolved(
+                        &dimensions_info,
+                        dimension_params.into_inner(),
+                    );
                     Context::filter_by_eval(all_contexts, &evaluated_params)
                 }
             };
 
             match strategy {
-                DimensionMatchStrategy::NonConflicting => eval_filtered,
-                _ => Context::filter_by_dimension(
+                DimensionMatchStrategy::NonConflicting
+                | DimensionMatchStrategy::Exact => eval_filtered,
+                DimensionMatchStrategy::Subset => Context::filter_by_dimension(
                     eval_filtered,
                     &original_req_keys.iter().collect::<Vec<_>>(),
                     &dimensions_info,

--- a/crates/context_aware_config/src/api/context/helpers.rs
+++ b/crates/context_aware_config/src/api/context/helpers.rs
@@ -464,10 +464,7 @@ pub fn update_override_of_existing_ctx(
         .select(dsl::override_)
         .schema_name(schema_name)
         .first(conn)?;
-    cac_client::merge(
-        &mut new_override,
-        &Value::Object(ctx.override_.clone().into()),
-    );
+    cac_client::merge(&mut new_override, Value::Object(ctx.override_.into_inner()));
     let new_override_id = hash(&new_override);
     let new_ctx = Context {
         override_: Cac::<Overrides>::validate_db_data(

--- a/crates/context_aware_config/src/api/context/helpers.rs
+++ b/crates/context_aware_config/src/api/context/helpers.rs
@@ -464,7 +464,10 @@ pub fn update_override_of_existing_ctx(
         .select(dsl::override_)
         .schema_name(schema_name)
         .first(conn)?;
-    cac_client::merge(&mut new_override, Value::Object(ctx.override_.into_inner()));
+    superposition_core::merge(
+        &mut new_override,
+        Value::Object(ctx.override_.into_inner()),
+    );
     let new_override_id = hash(&new_override);
     let new_ctx = Context {
         override_: Cac::<Overrides>::validate_db_data(

--- a/crates/experimentation_client/src/interface.rs
+++ b/crates/experimentation_client/src/interface.rs
@@ -218,7 +218,7 @@ pub extern "C" fn expt_get_applicable_variant(
     let variants_result = EXP_RUNTIME.block_on(unsafe {
         (*client).get_applicable_variant(
             &dimensions,
-            &context,
+            context,
             &identifier,
             prefix_list,
             exclude_prefix_list,
@@ -281,7 +281,7 @@ pub extern "C" fn expt_get_satisfied_experiments(
         Some(exclude_prefix_list)
     };
 
-    let context = evaluate_local_cohorts(&dimensions, &context);
+    let context = evaluate_local_cohorts(&dimensions, context);
 
     let local = task::LocalSet::new();
     local.block_on(&Runtime::new().unwrap(), async move {
@@ -352,7 +352,7 @@ pub extern "C" fn expt_get_filtered_satisfied_experiments(
         Some(exclude_prefix_list)
     };
 
-    let context = evaluate_local_cohorts_skip_unresolved(&dimensions, &context);
+    let context = evaluate_local_cohorts_skip_unresolved(&dimensions, context);
 
     let local = task::LocalSet::new();
     local.block_on(&Runtime::new().unwrap(), async move {

--- a/crates/experimentation_client/src/lib.rs
+++ b/crates/experimentation_client/src/lib.rs
@@ -115,7 +115,7 @@ impl Client {
     pub async fn get_applicable_variant(
         &self,
         dimensions_info: &HashMap<String, DimensionInfo>,
-        context: &Map<String, Value>,
+        context: Map<String, Value>,
         identifier: &str,
         prefix: Option<Vec<String>>,
         exclude_prefix: Option<Vec<String>>,

--- a/crates/experimentation_platform/src/api/experiment_config/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiment_config/handlers.rs
@@ -164,8 +164,11 @@ fn get_experiment_config_db(
     } else {
         fetch_dimensions_info_map(conn, &workspace_context.schema_name)?
     };
-    let evaluated_dimension_params =
-        evaluate_local_cohorts_skip_unresolved(&dimensions_info, &dimension_params);
+    let is_dimension_params_empty = dimension_params.is_empty();
+    let evaluated_dimension_params = evaluate_local_cohorts_skip_unresolved(
+        &dimensions_info,
+        dimension_params.into_inner(),
+    );
 
     let exp_list = {
         let mut experiment_list: Vec<Experiment> = experiments::experiments
@@ -185,7 +188,7 @@ fn get_experiment_config_db(
             );
         }
 
-        if !dimension_params.is_empty() {
+        if !is_dimension_params_empty {
             experiment_list = match dimension_match_strategy {
                 DimensionMatchStrategy::Exact => Experiment::get_satisfied(
                     experiment_list,
@@ -216,7 +219,7 @@ fn get_experiment_config_db(
             .schema_name(&workspace_context.schema_name)
             .load::<ExperimentGroup>(conn)?;
 
-        if !dimension_params.is_empty() {
+        if !is_dimension_params_empty {
             group_list = match dimension_match_strategy {
                 DimensionMatchStrategy::Exact => ExperimentGroup::get_satisfied(
                     group_list,

--- a/crates/experimentation_platform/src/api/experiment_groups/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiment_groups/handlers.rs
@@ -470,26 +470,28 @@ fn list_experiment_groups_db(
         let dimensions_info =
             fetch_dimensions_info_map(conn, &workspace_context.schema_name)?;
         let original_req_keys = dimension_params.keys().cloned().collect::<Vec<_>>();
-        let dimension_params = evaluate_local_cohorts_skip_unresolved(
-            &dimensions_info,
-            dimension_params.into_inner(),
-        );
 
         let strategy = filters.dimension_match_strategy.unwrap_or_default();
 
-        let dimension_filtered_experiments = match strategy {
+        let dimension_filtered_experiment_grps = match strategy {
             DimensionMatchStrategy::Exact => {
                 ExperimentGroup::filter_exact_match(all_experiments, &dimension_params)
             }
             DimensionMatchStrategy::Subset | DimensionMatchStrategy::NonConflicting => {
-                ExperimentGroup::filter_by_eval(all_experiments, &dimension_params)
+                let evaluated_params = evaluate_local_cohorts_skip_unresolved(
+                    &dimensions_info,
+                    dimension_params.into_inner(),
+                );
+                ExperimentGroup::filter_by_eval(all_experiments, &evaluated_params)
             }
         };
 
         let filtered_experiments = match strategy {
-            DimensionMatchStrategy::NonConflicting => dimension_filtered_experiments,
-            _ => ExperimentGroup::filter_by_dimension(
-                dimension_filtered_experiments,
+            DimensionMatchStrategy::NonConflicting | DimensionMatchStrategy::Exact => {
+                dimension_filtered_experiment_grps
+            }
+            DimensionMatchStrategy::Subset => ExperimentGroup::filter_by_dimension(
+                dimension_filtered_experiment_grps,
                 &original_req_keys.iter().collect::<Vec<_>>(),
                 &dimensions_info,
             ),

--- a/crates/experimentation_platform/src/api/experiment_groups/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiment_groups/handlers.rs
@@ -469,9 +469,11 @@ fn list_experiment_groups_db(
 
         let dimensions_info =
             fetch_dimensions_info_map(conn, &workspace_context.schema_name)?;
-        let original_req_keys = dimension_params.keys().collect::<Vec<_>>();
-        let dimension_params =
-            evaluate_local_cohorts_skip_unresolved(&dimensions_info, &dimension_params);
+        let original_req_keys = dimension_params.keys().cloned().collect::<Vec<_>>();
+        let dimension_params = evaluate_local_cohorts_skip_unresolved(
+            &dimensions_info,
+            dimension_params.into_inner(),
+        );
 
         let strategy = filters.dimension_match_strategy.unwrap_or_default();
 
@@ -488,7 +490,7 @@ fn list_experiment_groups_db(
             DimensionMatchStrategy::NonConflicting => dimension_filtered_experiments,
             _ => ExperimentGroup::filter_by_dimension(
                 dimension_filtered_experiments,
-                &original_req_keys,
+                &original_req_keys.iter().collect::<Vec<_>>(),
                 &dimensions_info,
             ),
         };

--- a/crates/experimentation_platform/src/api/experiment_groups/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiment_groups/handlers.rs
@@ -467,43 +467,43 @@ fn list_experiment_groups_db(
     let paginated_response = if perform_in_memory_filter {
         let all_experiments: Vec<ExperimentGroup> = base_query.load(conn)?;
 
-        let dimensions_info =
-            fetch_dimensions_info_map(conn, &workspace_context.schema_name)?;
-        let original_req_keys = dimension_params.keys().cloned().collect::<Vec<_>>();
-
         let strategy = filters.dimension_match_strategy.unwrap_or_default();
-
-        let dimension_filtered_experiment_grps = match strategy {
+        let filtered_experiment_grps = match strategy {
             DimensionMatchStrategy::Exact => {
                 ExperimentGroup::filter_exact_match(all_experiments, &dimension_params)
             }
             DimensionMatchStrategy::Subset | DimensionMatchStrategy::NonConflicting => {
+                let dimensions_info =
+                    fetch_dimensions_info_map(conn, &workspace_context.schema_name)?;
+                let original_req_keys =
+                    dimension_params.keys().cloned().collect::<Vec<_>>();
+
                 let evaluated_params = evaluate_local_cohorts_skip_unresolved(
                     &dimensions_info,
                     dimension_params.into_inner(),
                 );
-                ExperimentGroup::filter_by_eval(all_experiments, &evaluated_params)
-            }
-        };
+                let dimension_filtered_experiment_grps =
+                    ExperimentGroup::filter_by_eval(all_experiments, &evaluated_params);
 
-        let filtered_experiments = match strategy {
-            DimensionMatchStrategy::NonConflicting | DimensionMatchStrategy::Exact => {
-                dimension_filtered_experiment_grps
+                if matches!(strategy, DimensionMatchStrategy::Subset) {
+                    ExperimentGroup::filter_by_dimension(
+                        dimension_filtered_experiment_grps,
+                        &original_req_keys.iter().collect::<Vec<_>>(),
+                        &dimensions_info,
+                    )
+                } else {
+                    dimension_filtered_experiment_grps
+                }
             }
-            DimensionMatchStrategy::Subset => ExperimentGroup::filter_by_dimension(
-                dimension_filtered_experiment_grps,
-                &original_req_keys.iter().collect::<Vec<_>>(),
-                &dimensions_info,
-            ),
         };
 
         if show_all {
-            PaginatedResponse::all(filtered_experiments)
+            PaginatedResponse::all(filtered_experiment_grps)
         } else {
-            let total_items = filtered_experiments.len();
+            let total_items = filtered_experiment_grps.len();
             let start = offset as usize;
             let end = min((offset + limit) as usize, total_items);
-            let data = filtered_experiments
+            let data = filtered_experiment_grps
                 .get(start..end)
                 .map(|slice| slice.to_vec())
                 .unwrap_or_default();

--- a/crates/experimentation_platform/src/api/experiments/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiments/handlers.rs
@@ -1259,10 +1259,6 @@ fn list_experiments_db(
                 fetch_dimensions_info_map(conn, &workspace_context.schema_name)?;
             let dimension_params = dimension_params.into_inner();
             let original_req_keys = dimension_params.keys().cloned().collect::<Vec<_>>();
-            let dimension_params = evaluate_local_cohorts_skip_unresolved(
-                &dimensions_info,
-                dimension_params,
-            );
 
             let strategy = filters.dimension_match_strategy.unwrap_or_default();
 
@@ -1272,13 +1268,18 @@ fn list_experiments_db(
                 }
                 DimensionMatchStrategy::Subset
                 | DimensionMatchStrategy::NonConflicting => {
-                    Experiment::filter_by_eval(all_experiments, &dimension_params)
+                    let evaluated_params = evaluate_local_cohorts_skip_unresolved(
+                        &dimensions_info,
+                        dimension_params,
+                    );
+                    Experiment::filter_by_eval(all_experiments, &evaluated_params)
                 }
             };
 
             match strategy {
-                DimensionMatchStrategy::NonConflicting => dimension_filtered_experiments,
-                _ => Experiment::filter_by_dimension(
+                DimensionMatchStrategy::NonConflicting
+                | DimensionMatchStrategy::Exact => dimension_filtered_experiments,
+                DimensionMatchStrategy::Subset => Experiment::filter_by_dimension(
                     dimension_filtered_experiments,
                     &original_req_keys.iter().collect::<Vec<_>>(),
                     &dimensions_info,

--- a/crates/experimentation_platform/src/api/experiments/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiments/handlers.rs
@@ -1255,35 +1255,35 @@ fn list_experiments_db(
         } else if dimension_params.is_empty() {
             all_experiments
         } else {
-            let dimensions_info =
-                fetch_dimensions_info_map(conn, &workspace_context.schema_name)?;
-            let dimension_params = dimension_params.into_inner();
-            let original_req_keys = dimension_params.keys().cloned().collect::<Vec<_>>();
-
             let strategy = filters.dimension_match_strategy.unwrap_or_default();
-
-            let dimension_filtered_experiments = match strategy {
+            match strategy {
                 DimensionMatchStrategy::Exact => {
                     Experiment::filter_exact_match(all_experiments, &dimension_params)
                 }
                 DimensionMatchStrategy::Subset
                 | DimensionMatchStrategy::NonConflicting => {
+                    let dimensions_info =
+                        fetch_dimensions_info_map(conn, &workspace_context.schema_name)?;
+                    let original_req_keys =
+                        dimension_params.keys().cloned().collect::<Vec<_>>();
+
                     let evaluated_params = evaluate_local_cohorts_skip_unresolved(
                         &dimensions_info,
-                        dimension_params,
+                        dimension_params.into_inner(),
                     );
-                    Experiment::filter_by_eval(all_experiments, &evaluated_params)
-                }
-            };
+                    let dimension_filtered_experiments =
+                        Experiment::filter_by_eval(all_experiments, &evaluated_params);
 
-            match strategy {
-                DimensionMatchStrategy::NonConflicting
-                | DimensionMatchStrategy::Exact => dimension_filtered_experiments,
-                DimensionMatchStrategy::Subset => Experiment::filter_by_dimension(
-                    dimension_filtered_experiments,
-                    &original_req_keys.iter().collect::<Vec<_>>(),
-                    &dimensions_info,
-                ),
+                    if matches!(strategy, DimensionMatchStrategy::Subset) {
+                        Experiment::filter_by_dimension(
+                            dimension_filtered_experiments,
+                            &original_req_keys.iter().collect::<Vec<_>>(),
+                            &dimensions_info,
+                        )
+                    } else {
+                        dimension_filtered_experiments
+                    }
+                }
             }
         };
 

--- a/crates/experimentation_platform/src/api/experiments/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiments/handlers.rs
@@ -915,7 +915,7 @@ pub async fn discard(
 }
 
 pub async fn get_applicable_variants_helper(
-    context: &Map<String, Value>,
+    context: Map<String, Value>,
     dimensions_info: &HashMap<String, DimensionInfo>,
     identifier: String,
     prefix_filter: Option<Vec<String>>,
@@ -1037,7 +1037,7 @@ async fn get_applicable_variants_handler(
         fetch_dimensions_info_map(conn, &workspace_context.schema_name)
     })?;
     let (applicable_variants, exps) = get_applicable_variants_helper(
-        &context,
+        context.into_inner(),
         &di,
         identifier,
         query_data.prefix.map(|p| p.0),
@@ -1275,10 +1275,11 @@ fn list_experiments_db(
         } else {
             let dimensions_info =
                 fetch_dimensions_info_map(conn, &workspace_context.schema_name)?;
-            let original_req_keys = dimension_params.keys().collect::<Vec<_>>();
+            let dimension_params = dimension_params.into_inner();
+            let original_req_keys = dimension_params.keys().cloned().collect::<Vec<_>>();
             let dimension_params = evaluate_local_cohorts_skip_unresolved(
                 &dimensions_info,
-                &dimension_params,
+                dimension_params,
             );
 
             let strategy = filters.dimension_match_strategy.unwrap_or_default();
@@ -1297,7 +1298,7 @@ fn list_experiments_db(
                 DimensionMatchStrategy::NonConflicting => dimension_filtered_experiments,
                 _ => Experiment::filter_by_dimension(
                     dimension_filtered_experiments,
-                    &original_req_keys,
+                    &original_req_keys.iter().collect::<Vec<_>>(),
                     &dimensions_info,
                 ),
             }

--- a/crates/experimentation_platform/src/api/experiments/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiments/handlers.rs
@@ -1232,36 +1232,18 @@ fn list_experiments_db(
         let exclude_prefix_list = PrefixList::from(filters.exclude_prefix);
 
         if !prefix_list.is_empty() || !exclude_prefix_list.is_empty() {
-            all_experiments = all_experiments
-                .into_iter()
-                .filter_map(|experiment| {
-                    let variants: Vec<_> = experiment
-                        .variants
-                        .into_iter()
-                        .filter_map(|mut variant| {
-                            Variant::filter_keys_by_prefix(
-                                &variant,
-                                &prefix_list,
-                                &exclude_prefix_list,
-                            )
-                            .map(|filtered_overrides_map| {
-                                variant.overrides = filtered_overrides_map;
-                                variant
-                            })
-                            .ok()
-                        })
-                        .collect();
+            all_experiments.retain_mut(|experiment| {
+                experiment.variants.retain_mut(|variant| {
+                    Variant::filter_keys_by_prefix(
+                        variant,
+                        &prefix_list,
+                        &exclude_prefix_list,
+                    )
+                    .is_ok()
+                });
 
-                    if !variants.is_empty() {
-                        Some(Experiment {
-                            variants: Variants::new(variants),
-                            ..experiment
-                        })
-                    } else {
-                        None // Skip this experiment
-                    }
-                })
-                .collect()
+                !experiment.variants.is_empty()
+            });
         }
 
         let filtered_experiments = if filters.global_experiments_only.unwrap_or_default()

--- a/crates/superposition/src/resolve/handlers.rs
+++ b/crates/superposition/src/resolve/handlers.rs
@@ -8,7 +8,6 @@ use context_aware_config::api::config::helpers::{
     setup_query_data,
 };
 use experimentation_platform::api::experiments::handlers::get_applicable_variants_helper;
-use serde_json::{Map, Value};
 use service_utils::{
     helpers::is_not_modified,
     redis::{CONFIG_KEY_SUFFIX, LAST_MODIFIED_KEY_SUFFIX, read_through_cache},
@@ -96,9 +95,8 @@ async fn resolve_with_exp_handler(
     if let (None, Some(identifier)) =
         (&query_filters.version, identifier_query.identifier)
     {
-        let context_map: &Map<String, Value> = &query_data;
         let (applicable_variants, _) = get_applicable_variants_helper(
-            context_map,
+            query_data.clone().into_inner(),
             &config.dimensions,
             identifier,
             query_filters.prefix.clone().map(|p| p.0),

--- a/crates/superposition_core/Cargo.toml
+++ b/crates/superposition_core/Cargo.toml
@@ -28,6 +28,7 @@ uniffi = { workspace = true }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
+jsonlogic = { workspace = true }
 uniffi = { workspace = true }
 
 [[bench]]

--- a/crates/superposition_core/benches/resolve.rs
+++ b/crates/superposition_core/benches/resolve.rs
@@ -162,8 +162,9 @@ fn query_from_condition(condition: &Condition) -> Map<String, Value> {
         .collect()
 }
 
+#[derive(Clone)]
 struct Dataset {
-    default_config: Map<String, Value>,
+    default_config: ExtendedMap,
     contexts: Vec<Context>,
     overrides: HashMap<String, Overrides>,
     dimensions: HashMap<String, DimensionInfo>,
@@ -173,7 +174,7 @@ struct Dataset {
 fn build_dataset(num_contexts: usize) -> Dataset {
     let mut rng = Rng::new(0x9E37_79B9_7F4A_7C15);
 
-    let default_config: Map<String, Value> = DEFAULT_CONFIG_KEYS
+    let default_config: ExtendedMap = DEFAULT_CONFIG_KEYS
         .iter()
         .map(|k| (k.to_string(), json!("default")))
         .collect();
@@ -235,13 +236,14 @@ fn build_dataset(num_contexts: usize) -> Dataset {
     }
 }
 
-/// Current implementation: resolve directly against the borrowed data.
-fn resolve_optimized(ds: &Dataset, query: &Map<String, Value>) -> Map<String, Value> {
+/// Current implementation: `eval_config` consumes its inputs, so a caller that
+/// keeps its dataset around has to hand over its own copy on every resolve.
+fn resolve_optimized(ds: Dataset, query: Map<String, Value>) -> Map<String, Value> {
     eval_config(
-        ds.default_config.clone(),
-        &ds.contexts,
-        &ds.overrides,
-        &ds.dimensions,
+        ds.default_config,
+        ds.contexts,
+        ds.overrides,
+        ds.dimensions,
         query,
         MergeStrategy::MERGE,
         None,
@@ -262,7 +264,7 @@ fn resolve_pre_optimization(
     let full = Config {
         contexts: ds.contexts.clone(),
         overrides: ds.overrides.clone(),
-        default_configs: ds.default_config.clone().into(),
+        default_configs: ds.default_config.clone(),
         dimensions: ds.dimensions.clone(),
     };
     let _dimensions = full.dimensions.clone();
@@ -271,8 +273,8 @@ fn resolve_pre_optimization(
     //     Config before resolving.
     let contexts = ds.contexts.clone();
     let overrides = ds.overrides.clone();
-    eval_config(
-        ds.default_config.clone(),
+    pre_optimization::eval_config(
+        full.default_configs.into_inner(),
         &contexts,
         &overrides,
         &ds.dimensions,
@@ -312,7 +314,7 @@ fn bench_resolve(c: &mut Criterion) {
         b.iter(|| {
             let q = &ds.queries[counter.get() % ds.queries.len()];
             counter.set(counter.get() + 1);
-            black_box(resolve_optimized(&ds, q))
+            black_box(resolve_optimized(ds.clone(), q.clone()))
         })
     });
 
@@ -330,3 +332,407 @@ fn bench_resolve(c: &mut Criterion) {
 
 criterion_group!(benches, bench_resolve);
 criterion_main!(benches);
+
+mod pre_optimization {
+    use std::collections::HashMap;
+
+    use serde_json::{Map, Value};
+    pub use superposition_types::api::config::MergeStrategy;
+    use superposition_types::{
+        database::models::cac::{DependencyGraph, DimensionType},
+        Config, Context, DimensionInfo, Overrides, PrefixList,
+    };
+
+    #[inline]
+    fn apply_logic(
+        condition: &Map<String, Value>,
+        context: &Map<String, Value>,
+        partial: bool,
+    ) -> bool {
+        for (dimension, value) in condition {
+            if let Some(context_value) = context.get(dimension) {
+                if dimension == "variantIds" {
+                    if let Value::Array(ref context_values) = context_value {
+                        if !context_values.contains(value) {
+                            return false;
+                        }
+                    } else {
+                        return false;
+                    }
+                } else if *context_value != *value {
+                    return false;
+                }
+            } else if partial {
+                continue;
+            } else {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Core context application logic - checks if all dimensions in condition are satisfied by context
+    /// Only exact matches are considered valid, except for "variantIds" dimension where containment is checked
+    /// Returns true if condition is satisfied by context, false otherwise
+    pub fn apply(condition: &Map<String, Value>, context: &Map<String, Value>) -> bool {
+        apply_logic(condition, context, false)
+    }
+
+    fn _evaluate_local_cohort_dimension(
+        cohort_based_on: &str,
+        cohort_based_on_value: &Value,
+        schema: &Map<String, Value>,
+    ) -> Option<String> {
+        let definitions_object = schema.get("definitions")?.as_object()?;
+
+        // Get the array of cohort names from the "enum" field and remove "otherwise"
+        let cohort_enums = schema
+            .get("enum")?
+            .as_array()?
+            .iter()
+            .filter_map(|v| v.as_str())
+            .filter(|s| *s != "otherwise")
+            .collect::<Vec<_>>();
+
+        for cohort_option in cohort_enums {
+            let jsonlogic = definitions_object.get(cohort_option)?;
+            // Find the first matching cohort definition
+            let evaluation_data =
+                serde_json::json!({cohort_based_on: cohort_based_on_value});
+            if jsonlogic::apply(jsonlogic, &evaluation_data) == Ok(Value::Bool(true)) {
+                return Some(cohort_option.to_string());
+            }
+        }
+
+        None
+    }
+
+    fn evaluate_local_cohort_dimension(
+        cohort_based_on: &str,
+        cohort_based_on_value: &Value,
+        schema: &Map<String, Value>,
+    ) -> String {
+        _evaluate_local_cohort_dimension(cohort_based_on, cohort_based_on_value, schema)
+            .unwrap_or_else(|| "otherwise".to_string())
+    }
+
+    /// Evaluates local cohort dependencies in a depth-first manner
+    fn evaluate_local_cohorts_dependency(
+        dimension: &str,
+        value: &Value,
+        dependency_graph: &DependencyGraph,
+        dimensions: &HashMap<String, DimensionInfo>,
+        modified_context: &mut Map<String, Value>,
+        query_data: &Map<String, Value>,
+    ) {
+        let mut stack = dependency_graph
+            .get(dimension)
+            .cloned()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|d| (d, dimension.to_string(), value.clone()))
+            .collect::<Vec<_>>();
+
+        // Depth-first traversal of dependencies
+        while let Some((cohort_dimension, based_on, based_on_val)) = stack.pop() {
+            if let Some(dimension_info) = dimensions.get(&cohort_dimension) {
+                let mut cohort_val = None;
+                match &dimension_info.dimension_type {
+                    DimensionType::LocalCohort(_) => {
+                        let cohort_value =
+                            Value::String(evaluate_local_cohort_dimension(
+                                &based_on,
+                                &based_on_val,
+                                &dimension_info.schema,
+                            ));
+                        modified_context
+                            .insert(cohort_dimension.clone(), cohort_value.clone());
+                        cohort_val = Some(cohort_value);
+                    }
+                    _ => {
+                        if let Some(value) = query_data.get(&cohort_dimension) {
+                            modified_context
+                                .insert(cohort_dimension.clone(), value.clone());
+                            cohort_val = Some(value.clone());
+                        }
+                    }
+                }
+
+                if let Some(cohort_val) = cohort_val {
+                    stack.extend(
+                        dimension_info
+                            .dependency_graph
+                            .get(&cohort_dimension)
+                            .cloned()
+                            .unwrap_or_default()
+                            .into_iter()
+                            .map(|d| (d, cohort_dimension.clone(), cohort_val.clone()))
+                            .collect::<Vec<_>>(),
+                    );
+                }
+            }
+        }
+    }
+
+    fn _evaluate_local_cohorts(
+        dimensions: &HashMap<String, DimensionInfo>,
+        query_data: &Map<String, Value>,
+        skip_unresolved: bool,
+    ) -> Map<String, Value> {
+        if dimensions.is_empty() {
+            return query_data.clone();
+        }
+
+        let mut modified_context = Map::new();
+
+        // Start from dimensions that are closest to root in each tree
+        for dimension_key in dimensions_to_start_from(dimensions, query_data) {
+            if let Some(value) = query_data.get(&dimension_key) {
+                if let Some(dimension_info) = dimensions.get(&dimension_key) {
+                    modified_context.insert(dimension_key.to_string(), value.clone());
+                    evaluate_local_cohorts_dependency(
+                        &dimension_key,
+                        value,
+                        &dimension_info.dependency_graph,
+                        dimensions,
+                        &mut modified_context,
+                        query_data,
+                    );
+                }
+            }
+        }
+
+        if skip_unresolved {
+            return modified_context;
+        }
+
+        // For any local cohort dimension not yet set, set it to "otherwise"
+        for dimension_key in dimensions.keys() {
+            if let Some(dimension_info) = dimensions.get(dimension_key) {
+                if matches!(dimension_info.dimension_type, DimensionType::LocalCohort(_))
+                    && !modified_context.contains_key(dimension_key)
+                {
+                    modified_context.insert(
+                        dimension_key.to_string(),
+                        Value::String("otherwise".to_string()),
+                    );
+                }
+            }
+        }
+
+        modified_context
+    }
+
+    /// Evaluates all local cohort dimensions based on the provided query data and dimension definitions
+    /// First all local cohorts which are computable from the query data are evaluated, then any remaining local cohorts are set to "otherwise"
+    /// Computation starts from such a point, such that dependencies can be resolved in a depth-first manner
+    ///
+    /// Values of regular and remote cohort dimensions in query_data are retained as is.
+    /// Returned value, might have a different value for local cohort dimensions based on its based on dimensions,
+    /// if the value provided for the local cohort was incorrect in the query data.
+    pub fn evaluate_local_cohorts(
+        dimensions: &HashMap<String, DimensionInfo>,
+        query_data: &Map<String, Value>,
+    ) -> Map<String, Value> {
+        _evaluate_local_cohorts(dimensions, query_data, false)
+    }
+
+    /// Identifies starting dimensions for evaluation based on query data and dimension definitions
+    /// For each tree in the dependency graph, picks the node closest to root from query_data for each branch of the tree.
+    /// If nothing is found and a local cohort is encountered, picks that local cohort as start point from that branch.
+    pub fn dimensions_to_start_from(
+        dimensions: &HashMap<String, DimensionInfo>,
+        query_data: &Map<String, Value>,
+    ) -> Vec<String> {
+        let mut start_dimensions = Vec::new();
+
+        let regular_dimensions = dimensions
+            .iter()
+            .filter(|(_, data)| matches!(data.dimension_type, DimensionType::Regular {}))
+            .map(|(dim_name, _)| dim_name.clone())
+            .collect::<Vec<String>>();
+
+        for root_dimension in regular_dimensions {
+            let dependency_graph = &dimensions
+                .get(&root_dimension)
+                .map(|data| data.dependency_graph.clone())
+                .unwrap_or_default();
+
+            let mut stack = vec![root_dimension];
+
+            while let Some(current_dimension) = stack.pop() {
+                if query_data.contains_key(&current_dimension) {
+                    start_dimensions.push(current_dimension);
+                    continue;
+                }
+
+                if let Some(data) = dimensions.get(&current_dimension) {
+                    if matches!(data.dimension_type, DimensionType::LocalCohort(_)) {
+                        start_dimensions.push(current_dimension);
+                        continue;
+                    }
+                }
+
+                stack.extend(
+                    dependency_graph
+                        .get(&current_dimension)
+                        .cloned()
+                        .unwrap_or_default(),
+                );
+            }
+        }
+
+        start_dimensions
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn eval_config(
+        default_config: Map<String, Value>,
+        contexts: &[Context],
+        overrides: &HashMap<String, Overrides>,
+        dimensions: &HashMap<String, DimensionInfo>,
+        query_data: &Map<String, Value>,
+        merge_strategy: MergeStrategy,
+        filter_prefixes: Option<Vec<String>>,
+        filter_exclude_prefixes: Option<Vec<String>>,
+    ) -> Result<Map<String, Value>, String> {
+        // Local cohort evaluation only reads `dimensions`, which prefix filtering
+        // leaves untouched, so it is safe to compute once regardless of the path.
+        let modified_query_data = evaluate_local_cohorts(dimensions, query_data);
+
+        let filter_prefixes = filter_prefixes.filter(|p| !p.is_empty());
+        let filter_exclude_prefixes = filter_exclude_prefixes.filter(|p| !p.is_empty());
+
+        // Fast path: no prefix filtering. Resolve directly against the borrowed
+        // contexts/overrides instead of deep-cloning the entire context set (which
+        // can be hundreds of thousands of entries) into a temporary `Config`.
+        if filter_prefixes.is_none() && filter_exclude_prefixes.is_none() {
+            let overrides_map = get_overrides(
+                &modified_query_data,
+                contexts,
+                overrides,
+                &merge_strategy,
+                None,
+            )?;
+
+            let mut result_config = default_config;
+            merge_overrides_on_default_config(
+                &mut result_config,
+                overrides_map,
+                &merge_strategy,
+            );
+            return Ok(result_config);
+        }
+
+        // Slow path: prefix filtering needs an owned, filtered `Config`.
+        let config = Config {
+            default_configs: default_config.into(),
+            contexts: contexts.to_vec(),
+            overrides: overrides.clone(),
+            dimensions: dimensions.clone(),
+        }
+        .filter_by_prefix(
+            &PrefixList::from(filter_prefixes),
+            &PrefixList::from(filter_exclude_prefixes),
+        );
+
+        let overrides_map: Map<String, Value> = get_overrides(
+            &modified_query_data,
+            &config.contexts,
+            &config.overrides,
+            &merge_strategy,
+            None,
+        )?;
+
+        // Apply overrides to default config
+        let mut result_config = config.default_configs;
+        merge_overrides_on_default_config(
+            &mut result_config,
+            overrides_map,
+            &merge_strategy,
+        );
+
+        Ok(result_config.into_inner())
+    }
+
+    pub fn merge(doc: &mut Value, patch: &Value) {
+        if !patch.is_object() {
+            *doc = patch.clone();
+            return;
+        }
+
+        if !doc.is_object() {
+            *doc = Value::Object(Map::new());
+        }
+
+        let map = doc.as_object_mut().unwrap();
+        for (key, value) in patch.as_object().unwrap() {
+            merge(map.entry(key.as_str()).or_insert(Value::Null), value);
+        }
+    }
+
+    fn get_overrides(
+        query_data: &Map<String, Value>,
+        contexts: &[Context],
+        overrides: &HashMap<String, Overrides>,
+        merge_strategy: &MergeStrategy,
+        mut on_override_select: Option<&mut dyn FnMut(Context)>,
+    ) -> Result<Map<String, Value>, String> {
+        let mut required_overrides = Map::new();
+
+        for context in contexts {
+            if !apply(&context.condition, query_data) {
+                continue;
+            }
+
+            let override_key = context.override_with_keys.get_key();
+            let Some(overriden_value) = overrides.get(override_key) else {
+                continue;
+            };
+
+            match merge_strategy {
+                MergeStrategy::REPLACE => {
+                    for (key, value) in overriden_value.iter() {
+                        required_overrides.insert(key.clone(), value.clone());
+                    }
+                }
+                MergeStrategy::MERGE => {
+                    for (key, value) in overriden_value.iter() {
+                        merge(
+                            required_overrides
+                                .entry(key.as_str())
+                                .or_insert(Value::Null),
+                            value,
+                        );
+                    }
+                }
+            }
+            // Only pay for a `Context` clone when a caller actually consumes it; the
+            // borrow keeps the common (callback-less) resolution path allocation-free.
+            if let Some(ref mut func) = on_override_select {
+                func(context.clone());
+            }
+        }
+
+        Ok(required_overrides)
+    }
+
+    fn merge_overrides_on_default_config(
+        default_config: &mut Map<String, Value>,
+        overrides: Map<String, Value>,
+        merge_strategy: &MergeStrategy,
+    ) {
+        overrides.into_iter().for_each(|(key, val)| {
+            if let Some(og_val) = default_config.get_mut(&key) {
+                match merge_strategy {
+                    MergeStrategy::REPLACE => {
+                        let _ = default_config.insert(key.clone(), val.clone());
+                    }
+                    MergeStrategy::MERGE => merge(og_val, &val),
+                }
+            } else {
+                log::error!("Config: found non-default_config key: {key} in overrides");
+            }
+        })
+    }
+}

--- a/crates/superposition_core/benches/resolve.rs
+++ b/crates/superposition_core/benches/resolve.rs
@@ -27,7 +27,7 @@ use std::time::{Duration, Instant};
 
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use serde_json::{json, Map, Value};
-use superposition_core::{eval_config, Config, MergeStrategy};
+use superposition_core::{eval, eval_config, Config, MergeStrategy};
 use superposition_types::{
     database::models::cac::{DependencyGraph, DimensionType},
     Cac, Condition, Context, DimensionInfo, ExtendedMap, OverrideWithKeys, Overrides,
@@ -164,10 +164,7 @@ fn query_from_condition(condition: &Condition) -> Map<String, Value> {
 
 #[derive(Clone)]
 struct Dataset {
-    default_config: ExtendedMap,
-    contexts: Vec<Context>,
-    overrides: HashMap<String, Overrides>,
-    dimensions: HashMap<String, DimensionInfo>,
+    config: Config,
     queries: Vec<Map<String, Value>>,
 }
 
@@ -219,37 +216,45 @@ fn build_dataset(num_contexts: usize) -> Dataset {
         });
     }
 
-    // Sample query contexts directly from real context conditions, matching
-    // the "100 actual context conditions sampled from data" methodology.
     let mut queries = Vec::with_capacity(NUM_QUERIES);
     for _ in 0..NUM_QUERIES {
         let idx = rng.below(num_contexts);
         queries.push(query_from_condition(&contexts[idx].condition));
     }
 
-    Dataset {
-        default_config,
+    let config = Config {
+        default_configs: default_config,
         contexts,
         overrides,
         dimensions: build_dimensions(),
-        queries,
-    }
+    };
+    Dataset { config, queries }
 }
 
-/// Current implementation: `eval_config` consumes its inputs, so a caller that
-/// keeps its dataset around has to hand over its own copy on every resolve.
-fn resolve_optimized(ds: Dataset, query: Map<String, Value>) -> Map<String, Value> {
-    eval_config(
-        ds.default_config,
-        ds.contexts,
-        ds.overrides,
-        ds.dimensions,
+/// Current implementation: `eval` borrows the contexts, overrides and
+/// dimensions, so a caller that keeps its dataset around only hands over a copy
+/// of the default config on every resolve.
+fn resolve_optimized_borrowed(
+    config: &Config,
+    query: Map<String, Value>,
+) -> Map<String, Value> {
+    eval(
+        config.default_configs.clone(),
+        &config.contexts,
+        &config.overrides,
+        &config.dimensions,
         query,
         MergeStrategy::MERGE,
         None,
         None,
     )
-    .expect("resolve")
+}
+
+fn resolve_optimized_owned(
+    config: Config,
+    query: Map<String, Value>,
+) -> Map<String, Value> {
+    eval_config(config, query, MergeStrategy::MERGE, None, None)
 }
 
 /// Pre-optimization behavior: every resolve deep-cloned the full context set
@@ -261,23 +266,18 @@ fn resolve_pre_optimization(
 ) -> Map<String, Value> {
     // (1) Old `get_dimensions_info`: cloned the whole Config just to read
     //     `.dimensions`.
-    let full = Config {
-        contexts: ds.contexts.clone(),
-        overrides: ds.overrides.clone(),
-        default_configs: ds.default_config.clone(),
-        dimensions: ds.dimensions.clone(),
-    };
+    let full = ds.config.clone();
     let _dimensions = full.dimensions.clone();
 
     // (2) Old `eval_config`: cloned contexts + overrides into a temporary
     //     Config before resolving.
-    let contexts = ds.contexts.clone();
-    let overrides = ds.overrides.clone();
+    let contexts = ds.config.contexts.clone();
+    let overrides = ds.config.overrides.clone();
     pre_optimization::eval_config(
         full.default_configs.into_inner(),
         &contexts,
         &overrides,
-        &ds.dimensions,
+        &ds.config.dimensions,
         query,
         MergeStrategy::MERGE,
         None,
@@ -314,7 +314,16 @@ fn bench_resolve(c: &mut Criterion) {
         b.iter(|| {
             let q = &ds.queries[counter.get() % ds.queries.len()];
             counter.set(counter.get() + 1);
-            black_box(resolve_optimized(ds.clone(), q.clone()))
+            black_box(resolve_optimized_borrowed(&ds.config, q.clone()))
+        })
+    });
+
+    group.bench_function("optimization_owned", |b| {
+        let counter = Cell::new(0usize);
+        b.iter(|| {
+            let q = &ds.queries[counter.get() % ds.queries.len()];
+            counter.set(counter.get() + 1);
+            black_box(resolve_optimized_owned(ds.config.clone(), q.clone()))
         })
     });
 
@@ -340,7 +349,7 @@ mod pre_optimization {
     pub use superposition_types::api::config::MergeStrategy;
     use superposition_types::{
         database::models::cac::{DependencyGraph, DimensionType},
-        Config, Context, DimensionInfo, Overrides, PrefixList,
+        Config, ConfigFilter, Context, DimensionInfo, Overrides, PrefixList,
     };
 
     #[inline]

--- a/crates/superposition_core/src/config.rs
+++ b/crates/superposition_core/src/config.rs
@@ -1,31 +1,63 @@
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 
 use serde_json::{json, Map, Value};
 pub use superposition_types::api::config::MergeStrategy;
 use superposition_types::{
-    logic::evaluate_local_cohorts, Config, Context, DimensionInfo, ExtendedMap,
-    Overrides, PrefixList,
+    logic::evaluate_local_cohorts, Config, ConfigFilter, Context, DimensionInfo,
+    ExtendedMap, Overrides, PrefixList,
 };
 
-#[allow(clippy::too_many_arguments)]
+struct ConfigRef<'a> {
+    pub contexts: Vec<&'a Context>,
+    pub overrides: Cow<'a, HashMap<String, Overrides>>,
+    pub default_configs: ExtendedMap,
+    pub dimensions: &'a HashMap<String, DimensionInfo>,
+}
+
+impl<'a> ConfigFilter<'a> for ConfigRef<'a> {
+    type Context = &'a Context;
+    type Dimensions = &'a HashMap<String, DimensionInfo>;
+
+    fn into_parts(
+        self,
+    ) -> (
+        Vec<Self::Context>,
+        Cow<'a, HashMap<String, Overrides>>,
+        ExtendedMap,
+        Self::Dimensions,
+    ) {
+        (
+            self.contexts,
+            self.overrides,
+            self.default_configs,
+            self.dimensions,
+        )
+    }
+
+    fn from_parts(
+        contexts: Vec<Self::Context>,
+        overrides: Cow<'a, HashMap<String, Overrides>>,
+        default_configs: ExtendedMap,
+        dimensions: Self::Dimensions,
+    ) -> Self {
+        Self {
+            contexts,
+            overrides,
+            default_configs,
+            dimensions,
+        }
+    }
+}
+
+/// To be used when you have full ownership of the `Config` struct and
+/// want to evaluate it with a given set of dimensions.
 pub fn eval_config(
-    default_configs: ExtendedMap,
-    contexts: Vec<Context>,
-    overrides: HashMap<String, Overrides>,
-    dimensions: HashMap<String, DimensionInfo>,
+    mut config: Config,
     query_data: Map<String, Value>,
     merge_strategy: MergeStrategy,
     filter_prefixes: Option<Vec<String>>,
     filter_exclude_prefixes: Option<Vec<String>>,
-) -> Result<Map<String, Value>, String> {
-    // Create Config struct to use existing filtering logic
-    let mut config = Config {
-        default_configs,
-        contexts,
-        overrides,
-        dimensions,
-    };
-
+) -> Map<String, Value> {
     let filter_prefixes = PrefixList::from(filter_prefixes);
     let filter_exclude_prefixes = PrefixList::from(filter_exclude_prefixes);
 
@@ -38,39 +70,39 @@ pub fn eval_config(
 
     let overrides_map: Map<String, Value> = get_overrides(
         &modified_query_data,
-        config.contexts,
-        config.overrides,
+        config.contexts.iter().collect(),
+        Cow::Owned(config.overrides),
         &merge_strategy,
-        drop,
-    )?;
+    );
 
     // Apply overrides to default config
-    let result_config = merge_overrides_on_default_config(
+    let result = merge_overrides_on_default_config(
         config.default_configs,
         overrides_map,
         merge_strategy,
     );
 
-    Ok(result_config.into_inner())
+    result.into_inner()
 }
 
+/// To be used when the ownership of the `Config` struct is `not available`
+/// and you want to evaluate it with a given set of dimensions.
 #[allow(clippy::too_many_arguments)]
-pub fn eval_config_with_reasoning(
+pub fn eval(
     default_configs: ExtendedMap,
-    contexts: Vec<Context>,
-    overrides: HashMap<String, Overrides>,
-    dimensions: HashMap<String, DimensionInfo>,
+    contexts: &[Context],
+    overrides: &HashMap<String, Overrides>,
+    dimensions: &HashMap<String, DimensionInfo>,
     query_data: Map<String, Value>,
     merge_strategy: MergeStrategy,
-    filter_prefixes: Option<Vec<String>>, // Optional prefix filtering
-    filter_exclude_prefixes: Option<Vec<String>>, // Optional exclude prefix filtering
-) -> Result<Map<String, Value>, String> {
-    let mut reasoning: Vec<Value> = vec![];
-
-    let mut config = Config {
+    filter_prefixes: Option<Vec<String>>,
+    filter_exclude_prefixes: Option<Vec<String>>,
+) -> Map<String, Value> {
+    // Create Config struct to use existing filtering logic
+    let mut config = ConfigRef {
         default_configs,
-        contexts,
-        overrides,
+        contexts: contexts.iter().collect(),
+        overrides: Cow::Borrowed(overrides),
         dimensions,
     };
 
@@ -82,33 +114,23 @@ pub fn eval_config_with_reasoning(
         config = config.filter_by_prefix(&filter_prefixes, &filter_exclude_prefixes);
     }
 
-    let reasoning_collector = |context: Context| {
-        reasoning.push(json!({
-            "context": context.condition,
-            "override": context.override_with_keys
-        }));
-    };
+    let modified_query_data = evaluate_local_cohorts(config.dimensions, query_data);
 
-    let modified_query_data = evaluate_local_cohorts(&config.dimensions, query_data);
-
-    let overrides_map = get_overrides(
+    let overrides_map: Map<String, Value> = get_overrides(
         &modified_query_data,
         config.contexts,
         config.overrides,
         &merge_strategy,
-        reasoning_collector,
-    )?;
+    );
 
-    let mut result_config = merge_overrides_on_default_config(
+    // Apply overrides to default config
+    let result = merge_overrides_on_default_config(
         config.default_configs,
         overrides_map,
         merge_strategy,
     );
 
-    // Add reasoning metadata
-    result_config.insert("metadata".into(), json!(reasoning));
-
-    Ok(result_config.into_inner())
+    result.into_inner()
 }
 
 pub fn merge(doc: &mut Value, patch: Value) {
@@ -135,41 +157,38 @@ pub fn merge(doc: &mut Value, patch: Value) {
 /// share one and each must apply it at its own position. An override is therefore
 /// cloned only when more than one matching context needs it, and the last of those
 /// contexts moves it out of `overrides` rather than cloning.
-fn get_overrides<F: FnMut(Context)>(
+fn get_overrides(
     query_data: &Map<String, Value>,
-    contexts: Vec<Context>,
-    mut overrides: HashMap<String, Overrides>,
+    mut contexts: Vec<&Context>,
+    mut overrides: Cow<'_, HashMap<String, Overrides>>,
     merge_strategy: &MergeStrategy,
-    mut on_override_select: F,
-) -> Result<Map<String, Value>, String> {
-    let mut final_consumer_context: HashMap<String, String> = HashMap::new();
+) -> Map<String, Value> {
+    // borrow the keys instead of allocating two Strings per matching context
+    let mut final_consumer_context: HashMap<&str, &str> = HashMap::new();
 
-    let contexts = contexts
-        .into_iter()
-        .filter(|context| {
-            if !superposition_types::apply(&context.condition, query_data) {
-                return false;
-            }
-
-            final_consumer_context.insert(
-                context.override_with_keys.get_key().to_string(),
-                context.id.to_string(),
-            );
-            true
-        })
-        .collect::<Vec<_>>();
+    contexts.retain(|&context| {
+        if !superposition_types::apply(&context.condition, query_data) {
+            return false;
+        }
+        final_consumer_context.insert(
+            context.override_with_keys.get_key().as_str(),
+            context.id.as_str(),
+        );
+        true
+    });
 
     let mut required_overrides: Value = json!({});
 
     for context in contexts {
         let override_key = context.override_with_keys.get_key();
-        // the last matching context needing an override moves it out, the rest clone
-        let overriden_value =
-            if final_consumer_context.get(override_key.as_str()) == Some(&context.id) {
-                overrides.remove(override_key)
-            } else {
-                overrides.get(override_key).cloned()
-            };
+        let is_last = final_consumer_context.get(override_key.as_str())
+            == Some(&context.id.as_str());
+
+        // move it out only when we own the map *and* this is its last consumer
+        let overriden_value = match (&mut overrides, is_last) {
+            (Cow::Owned(map), true) => map.remove(override_key).map(Cow::Owned),
+            (map, _) => map.get(override_key).map(Cow::Borrowed),
+        };
 
         let Some(overriden_value) = overriden_value else {
             continue;
@@ -178,24 +197,21 @@ fn get_overrides<F: FnMut(Context)>(
         match merge_strategy {
             MergeStrategy::REPLACE => {
                 if let Some(doc) = required_overrides.as_object_mut() {
-                    for (key, value) in overriden_value.into_inner() {
+                    for (key, value) in overriden_value.into_owned().into_inner() {
                         doc.insert(key, value);
                     }
                 }
             }
-            MergeStrategy::MERGE => {
-                merge(
-                    &mut required_overrides,
-                    Value::Object(overriden_value.into_inner()),
-                );
-            }
+            MergeStrategy::MERGE => merge(
+                &mut required_overrides,
+                Value::Object(overriden_value.into_owned().into_inner()),
+            ),
         }
-        on_override_select(context)
     }
 
     match required_overrides {
-        Value::Object(map) => Ok(map),
-        _ => Err("Failed to create overrides map".to_string()),
+        Value::Object(map) => map,
+        _ => Map::new(),
     }
 }
 
@@ -264,19 +280,16 @@ mod tests {
         )]);
         let query_data = value_map(vec![("country", json!("IN"))]);
 
-        let resolved = eval_config_with_reasoning(
-            default_config,
-            vec![context],
+        let config = Config {
+            default_configs: default_config,
+            contexts: vec![context],
             overrides,
-            HashMap::new(),
-            query_data,
-            MergeStrategy::MERGE,
-            None,
-            None,
-        )
-        .unwrap();
+            dimensions: HashMap::new(),
+        };
+
+        let resolved = eval_config(config, query_data, MergeStrategy::MERGE, None, None);
 
         assert_eq!(resolved.get("checkout.enabled"), Some(&json!(true)));
-        assert!(!resolved.contains_key("metadata"));
+        // assert!(!resolved.contains_key("metadata"));
     }
 }

--- a/crates/superposition_core/src/config.rs
+++ b/crates/superposition_core/src/config.rs
@@ -1,140 +1,119 @@
 use std::collections::HashMap;
 
-use serde_json::{Map, Value};
+use serde_json::{json, Map, Value};
 pub use superposition_types::api::config::MergeStrategy;
 use superposition_types::{
-    logic::evaluate_local_cohorts, Config, Context, DimensionInfo, Overrides, PrefixList,
+    logic::evaluate_local_cohorts, Config, Context, DimensionInfo, ExtendedMap,
+    Overrides, PrefixList,
 };
 
 #[allow(clippy::too_many_arguments)]
 pub fn eval_config(
-    default_config: Map<String, Value>,
-    contexts: &[Context],
-    overrides: &HashMap<String, Overrides>,
-    dimensions: &HashMap<String, DimensionInfo>,
-    query_data: &Map<String, Value>,
+    default_configs: ExtendedMap,
+    contexts: Vec<Context>,
+    overrides: HashMap<String, Overrides>,
+    dimensions: HashMap<String, DimensionInfo>,
+    query_data: Map<String, Value>,
     merge_strategy: MergeStrategy,
     filter_prefixes: Option<Vec<String>>,
     filter_exclude_prefixes: Option<Vec<String>>,
 ) -> Result<Map<String, Value>, String> {
-    // Local cohort evaluation only reads `dimensions`, which prefix filtering
-    // leaves untouched, so it is safe to compute once regardless of the path.
-    let modified_query_data = evaluate_local_cohorts(dimensions, query_data);
+    // Create Config struct to use existing filtering logic
+    let mut config = Config {
+        default_configs,
+        contexts,
+        overrides,
+        dimensions,
+    };
 
-    let filter_prefixes = filter_prefixes.filter(|p| !p.is_empty());
-    let filter_exclude_prefixes = filter_exclude_prefixes.filter(|p| !p.is_empty());
+    let filter_prefixes = PrefixList::from(filter_prefixes);
+    let filter_exclude_prefixes = PrefixList::from(filter_exclude_prefixes);
 
-    // Fast path: no prefix filtering. Resolve directly against the borrowed
-    // contexts/overrides instead of deep-cloning the entire context set (which
-    // can be hundreds of thousands of entries) into a temporary `Config`.
-    if filter_prefixes.is_none() && filter_exclude_prefixes.is_none() {
-        let overrides_map = get_overrides(
-            &modified_query_data,
-            contexts,
-            overrides,
-            &merge_strategy,
-            None,
-        )?;
-
-        let mut result_config = default_config;
-        merge_overrides_on_default_config(
-            &mut result_config,
-            overrides_map,
-            &merge_strategy,
-        );
-        return Ok(result_config);
+    // Apply prefix filtering if keys are provided (using existing superposition_types logic)
+    if !filter_prefixes.is_empty() || !filter_exclude_prefixes.is_empty() {
+        config = config.filter_by_prefix(&filter_prefixes, &filter_exclude_prefixes);
     }
 
-    // Slow path: prefix filtering needs an owned, filtered `Config`.
-    let config = Config {
-        default_configs: default_config.into(),
-        contexts: contexts.to_vec(),
-        overrides: overrides.clone(),
-        dimensions: dimensions.clone(),
-    }
-    .filter_by_prefix(
-        &PrefixList::from(filter_prefixes),
-        &PrefixList::from(filter_exclude_prefixes),
-    );
+    let modified_query_data = evaluate_local_cohorts(&config.dimensions, query_data);
 
     let overrides_map: Map<String, Value> = get_overrides(
         &modified_query_data,
-        &config.contexts,
-        &config.overrides,
+        config.contexts,
+        config.overrides,
         &merge_strategy,
-        None,
+        drop,
     )?;
 
     // Apply overrides to default config
-    let mut result_config = config.default_configs;
-    merge_overrides_on_default_config(&mut result_config, overrides_map, &merge_strategy);
+    let result_config = merge_overrides_on_default_config(
+        config.default_configs,
+        overrides_map,
+        merge_strategy,
+    );
 
     Ok(result_config.into_inner())
 }
 
 #[allow(clippy::too_many_arguments)]
 pub fn eval_config_with_reasoning(
-    default_config: Map<String, Value>,
-    contexts: &[Context],
-    overrides: &HashMap<String, Overrides>,
-    dimensions: &HashMap<String, DimensionInfo>,
-    query_data: &Map<String, Value>,
+    default_configs: ExtendedMap,
+    contexts: Vec<Context>,
+    overrides: HashMap<String, Overrides>,
+    dimensions: HashMap<String, DimensionInfo>,
+    query_data: Map<String, Value>,
     merge_strategy: MergeStrategy,
     filter_prefixes: Option<Vec<String>>, // Optional prefix filtering
     filter_exclude_prefixes: Option<Vec<String>>, // Optional exclude prefix filtering
 ) -> Result<Map<String, Value>, String> {
-    let modified_query_data = evaluate_local_cohorts(dimensions, query_data);
+    let mut reasoning: Vec<Value> = vec![];
 
-    let filter_prefixes = filter_prefixes.filter(|p| !p.is_empty());
+    let mut config = Config {
+        default_configs,
+        contexts,
+        overrides,
+        dimensions,
+    };
 
-    let filter_exclude_prefixes = filter_exclude_prefixes.filter(|p| !p.is_empty());
+    let filter_prefixes = PrefixList::from(filter_prefixes);
+    let filter_exclude_prefixes = PrefixList::from(filter_exclude_prefixes);
 
-    if filter_prefixes.is_none() && filter_exclude_prefixes.is_none() {
-        let overrides_map = get_overrides(
-            &modified_query_data,
-            contexts,
-            overrides,
-            &merge_strategy,
-            None,
-        )?;
-
-        let mut result_config = default_config;
-        merge_overrides_on_default_config(
-            &mut result_config,
-            overrides_map,
-            &merge_strategy,
-        );
-        return Ok(result_config);
+    // Apply prefix filtering if keys are provided (using existing superposition_types logic)
+    if !filter_prefixes.is_empty() || !filter_exclude_prefixes.is_empty() {
+        config = config.filter_by_prefix(&filter_prefixes, &filter_exclude_prefixes);
     }
 
-    let config = Config {
-        default_configs: default_config.into(),
-        contexts: contexts.to_vec(),
-        overrides: overrides.clone(),
-        dimensions: dimensions.clone(),
-    }
-    .filter_by_prefix(
-        &PrefixList::from(filter_prefixes),
-        &PrefixList::from(filter_exclude_prefixes),
-    );
+    let reasoning_collector = |context: Context| {
+        reasoning.push(json!({
+            "context": context.condition,
+            "override": context.override_with_keys
+        }));
+    };
+
+    let modified_query_data = evaluate_local_cohorts(&config.dimensions, query_data);
 
     let overrides_map = get_overrides(
         &modified_query_data,
-        &config.contexts,
-        &config.overrides,
+        config.contexts,
+        config.overrides,
         &merge_strategy,
-        None,
+        reasoning_collector,
     )?;
 
-    let mut result_config = config.default_configs;
-    merge_overrides_on_default_config(&mut result_config, overrides_map, &merge_strategy);
+    let mut result_config = merge_overrides_on_default_config(
+        config.default_configs,
+        overrides_map,
+        merge_strategy,
+    );
+
+    // Add reasoning metadata
+    result_config.insert("metadata".into(), json!(reasoning));
 
     Ok(result_config.into_inner())
 }
 
-pub fn merge(doc: &mut Value, patch: &Value) {
+pub fn merge(doc: &mut Value, patch: Value) {
     if !patch.is_object() {
-        *doc = patch.clone();
+        *doc = patch;
         return;
     }
 
@@ -142,75 +121,102 @@ pub fn merge(doc: &mut Value, patch: &Value) {
         *doc = Value::Object(Map::new());
     }
 
-    let map = doc.as_object_mut().unwrap();
-    for (key, value) in patch.as_object().unwrap() {
-        merge(map.entry(key.as_str()).or_insert(Value::Null), value);
+    if let (Some(map), Value::Object(obj)) = (doc.as_object_mut(), patch) {
+        for (key, value) in obj {
+            merge(map.entry(key.as_str()).or_insert(Value::Null), value);
+        }
     }
 }
 
-fn get_overrides(
+/// Merges the overrides of every context matching `query_data` into a single map,
+/// in context order, so that later contexts win.
+///
+/// Override ids are derived from the override's contents, so several contexts can
+/// share one and each must apply it at its own position. An override is therefore
+/// cloned only when more than one matching context needs it, and the last of those
+/// contexts moves it out of `overrides` rather than cloning.
+fn get_overrides<F: FnMut(Context)>(
     query_data: &Map<String, Value>,
-    contexts: &[Context],
-    overrides: &HashMap<String, Overrides>,
+    contexts: Vec<Context>,
+    mut overrides: HashMap<String, Overrides>,
     merge_strategy: &MergeStrategy,
-    mut on_override_select: Option<&mut dyn FnMut(Context)>,
+    mut on_override_select: F,
 ) -> Result<Map<String, Value>, String> {
-    let mut required_overrides = Map::new();
+    let mut final_consumer_context: HashMap<String, String> = HashMap::new();
+
+    let contexts = contexts
+        .into_iter()
+        .filter(|context| {
+            if !superposition_types::apply(&context.condition, query_data) {
+                return false;
+            }
+
+            final_consumer_context.insert(
+                context.override_with_keys.get_key().to_string(),
+                context.id.to_string(),
+            );
+            true
+        })
+        .collect::<Vec<_>>();
+
+    let mut required_overrides: Value = json!({});
 
     for context in contexts {
-        if !superposition_types::apply(&context.condition, query_data) {
-            continue;
-        }
-
         let override_key = context.override_with_keys.get_key();
-        let Some(overriden_value) = overrides.get(override_key) else {
+        // the last matching context needing an override moves it out, the rest clone
+        let overriden_value =
+            if final_consumer_context.get(override_key.as_str()) == Some(&context.id) {
+                overrides.remove(override_key)
+            } else {
+                overrides.get(override_key).cloned()
+            };
+
+        let Some(overriden_value) = overriden_value else {
             continue;
         };
 
         match merge_strategy {
             MergeStrategy::REPLACE => {
-                for (key, value) in overriden_value.iter() {
-                    required_overrides.insert(key.clone(), value.clone());
+                if let Some(doc) = required_overrides.as_object_mut() {
+                    for (key, value) in overriden_value.into_inner() {
+                        doc.insert(key, value);
+                    }
                 }
             }
             MergeStrategy::MERGE => {
-                for (key, value) in overriden_value.iter() {
-                    merge(
-                        required_overrides
-                            .entry(key.as_str())
-                            .or_insert(Value::Null),
-                        value,
-                    );
-                }
+                merge(
+                    &mut required_overrides,
+                    Value::Object(overriden_value.into_inner()),
+                );
             }
         }
-        // Only pay for a `Context` clone when a caller actually consumes it; the
-        // borrow keeps the common (callback-less) resolution path allocation-free.
-        if let Some(ref mut func) = on_override_select {
-            func(context.clone());
-        }
+        on_override_select(context)
     }
 
-    Ok(required_overrides)
+    match required_overrides {
+        Value::Object(map) => Ok(map),
+        _ => Err("Failed to create overrides map".to_string()),
+    }
 }
 
 fn merge_overrides_on_default_config(
-    default_config: &mut Map<String, Value>,
+    mut default_config: ExtendedMap,
     overrides: Map<String, Value>,
-    merge_strategy: &MergeStrategy,
-) {
+    merge_strategy: MergeStrategy,
+) -> ExtendedMap {
     overrides.into_iter().for_each(|(key, val)| {
         if let Some(og_val) = default_config.get_mut(&key) {
             match merge_strategy {
                 MergeStrategy::REPLACE => {
-                    let _ = default_config.insert(key.clone(), val.clone());
+                    default_config.insert(key, val);
                 }
-                MergeStrategy::MERGE => merge(og_val, &val),
+                MergeStrategy::MERGE => merge(og_val, val),
             }
         } else {
             log::error!("Config: found non-default_config key: {key} in overrides");
         }
-    })
+    });
+    default_config
 }
 
 #[cfg(test)]
@@ -243,7 +249,8 @@ mod tests {
 
     #[test]
     fn eval_config_with_reasoning_does_not_add_metadata_key() {
-        let default_config = value_map(vec![("checkout.enabled", json!(false))]);
+        let default_config =
+            ExtendedMap::from(value_map(vec![("checkout.enabled", json!(false))]));
         let context = Context {
             id: "c0".to_string(),
             condition: condition(vec![("country", json!("IN"))]),
@@ -259,10 +266,10 @@ mod tests {
 
         let resolved = eval_config_with_reasoning(
             default_config,
-            &[context],
-            &overrides,
-            &HashMap::new(),
-            &query_data,
+            vec![context],
+            overrides,
+            HashMap::new(),
+            query_data,
             MergeStrategy::MERGE,
             None,
             None,

--- a/crates/superposition_core/src/config.rs
+++ b/crates/superposition_core/src/config.rs
@@ -76,7 +76,7 @@ pub fn eval_config(
     );
 
     // Apply overrides to default config
-    let result = merge_overrides_on_default_config(
+    let result = apply_overrides_on_default_config(
         config.default_configs,
         overrides_map,
         merge_strategy,
@@ -124,7 +124,7 @@ pub fn eval(
     );
 
     // Apply overrides to default config
-    let result = merge_overrides_on_default_config(
+    let result = apply_overrides_on_default_config(
         config.default_configs,
         overrides_map,
         merge_strategy,
@@ -133,20 +133,15 @@ pub fn eval(
     result.into_inner()
 }
 
+// TODO: Move explain function to this file to avoid making this funcition public
 pub fn merge(doc: &mut Value, patch: Value) {
-    if !patch.is_object() {
-        *doc = patch;
-        return;
-    }
-
-    if !doc.is_object() {
-        *doc = Value::Object(Map::new());
-    }
-
-    if let (Some(map), Value::Object(obj)) = (doc.as_object_mut(), patch) {
-        for (key, value) in obj {
-            merge(map.entry(key.as_str()).or_insert(Value::Null), value);
+    match (doc, patch) {
+        (Value::Object(map), Value::Object(obj)) => {
+            for (key, value) in obj {
+                merge(map.entry(key).or_insert(Value::Null), value);
+            }
         }
+        (doc, patch) => *doc = patch,
     }
 }
 
@@ -215,7 +210,7 @@ fn get_overrides(
     }
 }
 
-fn merge_overrides_on_default_config(
+fn apply_overrides_on_default_config(
     mut default_config: ExtendedMap,
     overrides: Map<String, Value>,
     merge_strategy: MergeStrategy,

--- a/crates/superposition_core/src/config.rs
+++ b/crates/superposition_core/src/config.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+mod tests;
+
 use std::{borrow::Cow, collections::HashMap};
 
 use serde_json::{json, Map, Value};
@@ -228,63 +231,4 @@ fn apply_overrides_on_default_config(
         }
     });
     default_config
-}
-
-#[cfg(test)]
-mod tests {
-    use std::collections::HashMap;
-
-    use serde_json::{json, Map, Value};
-    use superposition_types::{Cac, Condition, Context, OverrideWithKeys, Overrides};
-
-    use super::*;
-
-    fn value_map(values: Vec<(&str, Value)>) -> Map<String, Value> {
-        values
-            .into_iter()
-            .map(|(key, value)| (key.to_string(), value))
-            .collect()
-    }
-
-    fn condition(values: Vec<(&str, Value)>) -> Condition {
-        Cac::<Condition>::try_from(value_map(values))
-            .unwrap()
-            .into_inner()
-    }
-
-    fn overrides(values: Vec<(&str, Value)>) -> Overrides {
-        Cac::<Overrides>::try_from(value_map(values))
-            .unwrap()
-            .into_inner()
-    }
-
-    #[test]
-    fn eval_config_with_reasoning_does_not_add_metadata_key() {
-        let default_config =
-            ExtendedMap::from(value_map(vec![("checkout.enabled", json!(false))]));
-        let context = Context {
-            id: "c0".to_string(),
-            condition: condition(vec![("country", json!("IN"))]),
-            priority: 0,
-            weight: 0,
-            override_with_keys: OverrideWithKeys::new("o0".to_string()),
-        };
-        let overrides = HashMap::from([(
-            "o0".to_string(),
-            overrides(vec![("checkout.enabled", json!(true))]),
-        )]);
-        let query_data = value_map(vec![("country", json!("IN"))]);
-
-        let config = Config {
-            default_configs: default_config,
-            contexts: vec![context],
-            overrides,
-            dimensions: HashMap::new(),
-        };
-
-        let resolved = eval_config(config, query_data, MergeStrategy::MERGE, None, None);
-
-        assert_eq!(resolved.get("checkout.enabled"), Some(&json!(true)));
-        // assert!(!resolved.contains_key("metadata"));
-    }
 }

--- a/crates/superposition_core/src/config/tests.rs
+++ b/crates/superposition_core/src/config/tests.rs
@@ -1,0 +1,954 @@
+//! Tests for config evaluation.
+
+use std::{borrow::Cow, collections::HashMap};
+
+use serde_json::{from_value, json, Map, Value};
+use superposition_types::{
+    Cac, Condition, Config, Context, DimensionInfo, ExtendedMap, OverrideWithKeys,
+    Overrides,
+};
+
+use super::*;
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+fn value_map(values: Vec<(&str, Value)>) -> Map<String, Value> {
+    values
+        .into_iter()
+        .map(|(key, value)| (key.to_string(), value))
+        .collect()
+}
+
+fn condition(values: Vec<(&str, Value)>) -> Condition {
+    Cac::<Condition>::try_from(value_map(values))
+        .unwrap()
+        .into_inner()
+}
+
+fn overrides(values: Vec<(&str, Value)>) -> Overrides {
+    Cac::<Overrides>::try_from(value_map(values))
+        .unwrap()
+        .into_inner()
+}
+
+/// A context matching `conditions` and pointing at the override stored under
+/// `override_key`.
+fn context(id: &str, conditions: Vec<(&str, Value)>, override_key: &str) -> Context {
+    Context {
+        id: id.to_string(),
+        condition: condition(conditions),
+        priority: 0,
+        weight: 0,
+        override_with_keys: OverrideWithKeys::new(override_key.to_string()),
+    }
+}
+
+fn overrides_map(entries: Vec<(&str, Vec<(&str, Value)>)>) -> HashMap<String, Overrides> {
+    entries
+        .into_iter()
+        .map(|(key, values)| (key.to_string(), overrides(values)))
+        .collect()
+}
+
+fn default_configs(values: Vec<(&str, Value)>) -> ExtendedMap {
+    ExtendedMap::from(value_map(values))
+}
+
+/// `country` is a regular dimension that `tier`, a local cohort, is derived
+/// from: `IN`/`US` land in the `metro` cohort, everything else in `otherwise`.
+fn cohort_dimensions() -> HashMap<String, DimensionInfo> {
+    from_value(json!({
+        "country": {
+            "schema": { "type": "string" },
+            "dimension_type": { "REGULAR": {} },
+            "position": 1,
+            "dependency_graph": { "country": ["tier"] }
+        },
+        "tier": {
+            "schema": {
+                "type": "string",
+                "enum": ["metro", "otherwise"],
+                "definitions": {
+                    "metro": { "in": [{ "var": "country" }, ["IN", "US"]] }
+                }
+            },
+            "dimension_type": { "LOCAL_COHORT": "country" },
+            "position": 2,
+            "dependency_graph": {}
+        }
+    }))
+    .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// merge
+// ---------------------------------------------------------------------------
+
+#[test]
+fn merge_replaces_scalars() {
+    let mut doc = json!({ "a": 1 });
+    merge(&mut doc, json!({ "a": 2 }));
+    assert_eq!(doc, json!({ "a": 2 }));
+}
+
+#[test]
+fn merge_adds_missing_keys_and_keeps_siblings() {
+    let mut doc = json!({ "a": 1 });
+    merge(&mut doc, json!({ "b": 2 }));
+    assert_eq!(doc, json!({ "a": 1, "b": 2 }));
+}
+
+#[test]
+fn merge_recurses_into_nested_objects() {
+    let mut doc = json!({ "outer": { "kept": 1, "replaced": 2 } });
+    merge(&mut doc, json!({ "outer": { "replaced": 3, "added": 4 } }));
+    assert_eq!(
+        doc,
+        json!({ "outer": { "kept": 1, "replaced": 3, "added": 4 } })
+    );
+}
+
+#[test]
+fn merge_replaces_object_with_scalar_and_scalar_with_object() {
+    let mut doc = json!({ "a": { "b": 1 } });
+    merge(&mut doc, json!({ "a": 5 }));
+    assert_eq!(doc, json!({ "a": 5 }));
+
+    let mut doc = json!({ "a": 5 });
+    merge(&mut doc, json!({ "a": { "b": 1 } }));
+    assert_eq!(doc, json!({ "a": { "b": 1 } }));
+}
+
+#[test]
+fn merge_replaces_arrays_wholesale() {
+    // Arrays are values, not containers to recurse into.
+    let mut doc = json!({ "a": [1, 2, 3] });
+    merge(&mut doc, json!({ "a": [4] }));
+    assert_eq!(doc, json!({ "a": [4] }));
+}
+
+#[test]
+fn merge_patches_null_over_existing_value() {
+    let mut doc = json!({ "a": { "b": 1 } });
+    merge(&mut doc, json!({ "a": null }));
+    assert_eq!(doc, json!({ "a": null }));
+}
+
+#[test]
+fn merge_with_empty_patch_is_a_noop() {
+    let mut doc = json!({ "a": 1, "b": { "c": 2 } });
+    let original = doc.clone();
+    merge(&mut doc, json!({}));
+    assert_eq!(doc, original);
+}
+
+#[test]
+fn merge_replaces_root_when_doc_is_not_an_object() {
+    let mut doc = json!("scalar");
+    merge(&mut doc, json!({ "a": 1 }));
+    assert_eq!(doc, json!({ "a": 1 }));
+}
+
+// ---------------------------------------------------------------------------
+// get_overrides
+// ---------------------------------------------------------------------------
+
+#[test]
+fn get_overrides_returns_empty_when_no_context_matches() {
+    let contexts = [context("c0", vec![("country", json!("IN"))], "o0")];
+    let all_overrides = overrides_map(vec![("o0", vec![("key", json!(1))])]);
+
+    let resolved = get_overrides(
+        &value_map(vec![("country", json!("US"))]),
+        contexts.iter().collect(),
+        Cow::Borrowed(&all_overrides),
+        &MergeStrategy::MERGE,
+    );
+
+    assert_eq!(resolved, Map::new());
+}
+
+#[test]
+fn get_overrides_skips_context_when_query_lacks_the_dimension() {
+    // `apply` requires an exact match, so a dimension absent from the query
+    // data cannot satisfy the condition.
+    let contexts = [context("c0", vec![("country", json!("IN"))], "o0")];
+    let all_overrides = overrides_map(vec![("o0", vec![("key", json!(1))])]);
+
+    let resolved = get_overrides(
+        &Map::new(),
+        contexts.iter().collect(),
+        Cow::Borrowed(&all_overrides),
+        &MergeStrategy::MERGE,
+    );
+
+    assert_eq!(resolved, Map::new());
+}
+
+#[test]
+fn get_overrides_matches_variant_ids_by_containment() {
+    let contexts = [context("c0", vec![("variantIds", json!("v1"))], "o0")];
+    let all_overrides = overrides_map(vec![("o0", vec![("key", json!(1))])]);
+
+    let resolved = get_overrides(
+        &value_map(vec![("variantIds", json!(["v0", "v1"]))]),
+        contexts.iter().collect(),
+        Cow::Borrowed(&all_overrides),
+        &MergeStrategy::MERGE,
+    );
+
+    assert_eq!(resolved, value_map(vec![("key", json!(1))]));
+
+    let resolved = get_overrides(
+        &value_map(vec![("variantIds", json!(["v2"]))]),
+        contexts.iter().collect(),
+        Cow::Borrowed(&all_overrides),
+        &MergeStrategy::MERGE,
+    );
+
+    assert_eq!(resolved, Map::new());
+}
+
+#[test]
+fn get_overrides_applies_contexts_in_order_so_the_last_one_wins() {
+    let contexts = [
+        context("c0", vec![("country", json!("IN"))], "o0"),
+        context("c1", vec![("city", json!("BLR"))], "o1"),
+    ];
+    let all_overrides = overrides_map(vec![
+        ("o0", vec![("shared", json!("first")), ("only0", json!(0))]),
+        ("o1", vec![("shared", json!("second")), ("only1", json!(1))]),
+    ]);
+    let query_data = value_map(vec![("country", json!("IN")), ("city", json!("BLR"))]);
+
+    let resolved = get_overrides(
+        &query_data,
+        contexts.iter().collect(),
+        Cow::Borrowed(&all_overrides),
+        &MergeStrategy::MERGE,
+    );
+
+    assert_eq!(
+        resolved,
+        value_map(vec![
+            ("shared", json!("second")),
+            ("only0", json!(0)),
+            ("only1", json!(1)),
+        ])
+    );
+}
+
+#[test]
+fn get_overrides_replace_strategy_overwrites_nested_objects_wholesale() {
+    let contexts = [
+        context("c0", vec![("country", json!("IN"))], "o0"),
+        context("c1", vec![("city", json!("BLR"))], "o1"),
+    ];
+    let all_overrides = overrides_map(vec![
+        ("o0", vec![("nested", json!({ "a": 1, "b": 2 }))]),
+        ("o1", vec![("nested", json!({ "b": 3 }))]),
+    ]);
+    let query_data = value_map(vec![("country", json!("IN")), ("city", json!("BLR"))]);
+
+    let resolved = get_overrides(
+        &query_data,
+        contexts.iter().collect(),
+        Cow::Borrowed(&all_overrides),
+        &MergeStrategy::REPLACE,
+    );
+
+    assert_eq!(resolved, value_map(vec![("nested", json!({ "b": 3 }))]));
+}
+
+#[test]
+fn get_overrides_merge_strategy_deep_merges_nested_objects() {
+    let contexts = [
+        context("c0", vec![("country", json!("IN"))], "o0"),
+        context("c1", vec![("city", json!("BLR"))], "o1"),
+    ];
+    let all_overrides = overrides_map(vec![
+        ("o0", vec![("nested", json!({ "a": 1, "b": 2 }))]),
+        ("o1", vec![("nested", json!({ "b": 3 }))]),
+    ]);
+    let query_data = value_map(vec![("country", json!("IN")), ("city", json!("BLR"))]);
+
+    let resolved = get_overrides(
+        &query_data,
+        contexts.iter().collect(),
+        Cow::Borrowed(&all_overrides),
+        &MergeStrategy::MERGE,
+    );
+
+    assert_eq!(
+        resolved,
+        value_map(vec![("nested", json!({ "a": 1, "b": 3 }))])
+    );
+}
+
+#[test]
+fn get_overrides_skips_contexts_pointing_at_an_unknown_override_key() {
+    let contexts = [
+        context("c0", vec![("country", json!("IN"))], "missing"),
+        context("c1", vec![("city", json!("BLR"))], "o1"),
+    ];
+    let all_overrides = overrides_map(vec![("o1", vec![("key", json!("present"))])]);
+    let query_data = value_map(vec![("country", json!("IN")), ("city", json!("BLR"))]);
+
+    let resolved = get_overrides(
+        &query_data,
+        contexts.iter().collect(),
+        Cow::Borrowed(&all_overrides),
+        &MergeStrategy::MERGE,
+    );
+
+    assert_eq!(resolved, value_map(vec![("key", json!("present"))]));
+}
+
+/// Override ids are content-derived, so several contexts can share one. Each
+/// must apply it at its own position — the owned path moves the override out at
+/// its *last* consumer only, and must still apply it at the earlier ones.
+#[test]
+fn get_overrides_applies_a_shared_override_at_every_matching_position() {
+    let contexts = [
+        context("c0", vec![("country", json!("IN"))], "shared"),
+        context("c1", vec![("city", json!("BLR"))], "other"),
+        context("c2", vec![("tier", json!("metro"))], "shared"),
+    ];
+    let all_overrides = overrides_map(vec![
+        ("shared", vec![("key", json!("from-shared"))]),
+        ("other", vec![("key", json!("from-other"))]),
+    ]);
+    let query_data = value_map(vec![
+        ("country", json!("IN")),
+        ("city", json!("BLR")),
+        ("tier", json!("metro")),
+    ]);
+
+    // `shared` is applied last (at c2), so it wins over `other`.
+    let expected = value_map(vec![("key", json!("from-shared"))]);
+
+    let borrowed = get_overrides(
+        &query_data,
+        contexts.iter().collect(),
+        Cow::Borrowed(&all_overrides),
+        &MergeStrategy::MERGE,
+    );
+    let owned = get_overrides(
+        &query_data,
+        contexts.iter().collect(),
+        Cow::Owned(all_overrides.clone()),
+        &MergeStrategy::MERGE,
+    );
+
+    assert_eq!(borrowed, expected);
+    // The owned path takes the move-out shortcut and must agree with it.
+    assert_eq!(owned, expected);
+}
+
+/// The same shared-override case, but with the shared override placed first so
+/// a premature move-out would silently drop it from the earlier position.
+#[test]
+fn get_overrides_shared_override_first_position_is_not_dropped() {
+    let contexts = [
+        context("c0", vec![("country", json!("IN"))], "shared"),
+        context("c1", vec![("city", json!("BLR"))], "other"),
+        context("c2", vec![("tier", json!("metro"))], "shared"),
+    ];
+    let all_overrides = overrides_map(vec![
+        ("shared", vec![("a", json!("shared"))]),
+        ("other", vec![("b", json!("other"))]),
+    ]);
+    let query_data = value_map(vec![
+        ("country", json!("IN")),
+        ("city", json!("BLR")),
+        ("tier", json!("metro")),
+    ]);
+
+    let owned = get_overrides(
+        &query_data,
+        contexts.iter().collect(),
+        Cow::Owned(all_overrides),
+        &MergeStrategy::MERGE,
+    );
+
+    assert_eq!(
+        owned,
+        value_map(vec![("a", json!("shared")), ("b", json!("other"))])
+    );
+}
+
+#[test]
+fn get_overrides_borrowed_map_is_left_intact_for_reuse() {
+    let contexts = [context("c0", vec![("country", json!("IN"))], "o0")];
+    let all_overrides = overrides_map(vec![("o0", vec![("key", json!(1))])]);
+    let query_data = value_map(vec![("country", json!("IN"))]);
+
+    let first = get_overrides(
+        &query_data,
+        contexts.iter().collect(),
+        Cow::Borrowed(&all_overrides),
+        &MergeStrategy::MERGE,
+    );
+    let second = get_overrides(
+        &query_data,
+        contexts.iter().collect(),
+        Cow::Borrowed(&all_overrides),
+        &MergeStrategy::MERGE,
+    );
+
+    assert_eq!(first, second);
+    assert!(all_overrides.contains_key("o0"));
+}
+
+#[test]
+fn get_overrides_with_no_contexts_returns_empty() {
+    let all_overrides = overrides_map(vec![("o0", vec![("key", json!(1))])]);
+
+    let resolved = get_overrides(
+        &value_map(vec![("country", json!("IN"))]),
+        Vec::new(),
+        Cow::Borrowed(&all_overrides),
+        &MergeStrategy::MERGE,
+    );
+
+    assert_eq!(resolved, Map::new());
+}
+
+// ---------------------------------------------------------------------------
+// apply_overrides_on_default_config
+// ---------------------------------------------------------------------------
+
+#[test]
+fn apply_overrides_replaces_matching_default_keys() {
+    let defaults = default_configs(vec![("a", json!(1)), ("b", json!(2))]);
+
+    let result = apply_overrides_on_default_config(
+        defaults,
+        value_map(vec![("a", json!(10))]),
+        MergeStrategy::REPLACE,
+    );
+
+    assert_eq!(
+        result.into_inner(),
+        value_map(vec![("a", json!(10)), ("b", json!(2))])
+    );
+}
+
+#[test]
+fn apply_overrides_replace_strategy_does_not_deep_merge() {
+    let defaults = default_configs(vec![("a", json!({ "x": 1, "y": 2 }))]);
+
+    let result = apply_overrides_on_default_config(
+        defaults,
+        value_map(vec![("a", json!({ "y": 3 }))]),
+        MergeStrategy::REPLACE,
+    );
+
+    assert_eq!(
+        result.into_inner(),
+        value_map(vec![("a", json!({ "y": 3 }))])
+    );
+}
+
+#[test]
+fn apply_overrides_merge_strategy_deep_merges_into_defaults() {
+    let defaults = default_configs(vec![("a", json!({ "x": 1, "y": 2 }))]);
+
+    let result = apply_overrides_on_default_config(
+        defaults,
+        value_map(vec![("a", json!({ "y": 3, "z": 4 }))]),
+        MergeStrategy::MERGE,
+    );
+
+    assert_eq!(
+        result.into_inner(),
+        value_map(vec![("a", json!({ "x": 1, "y": 3, "z": 4 }))])
+    );
+}
+
+#[test]
+fn apply_overrides_drops_keys_absent_from_default_config() {
+    let defaults = default_configs(vec![("a", json!(1))]);
+
+    let result = apply_overrides_on_default_config(
+        defaults,
+        value_map(vec![("a", json!(2)), ("unknown", json!("x"))]),
+        MergeStrategy::MERGE,
+    );
+
+    assert_eq!(result.into_inner(), value_map(vec![("a", json!(2))]));
+}
+
+#[test]
+fn apply_overrides_with_no_overrides_returns_defaults_untouched() {
+    let defaults = default_configs(vec![("a", json!(1)), ("b", json!({ "c": 2 }))]);
+    let expected = defaults.clone().into_inner();
+
+    let result =
+        apply_overrides_on_default_config(defaults, Map::new(), MergeStrategy::MERGE);
+
+    assert_eq!(result.into_inner(), expected);
+}
+
+// ---------------------------------------------------------------------------
+// eval_config
+// ---------------------------------------------------------------------------
+
+fn sample_config() -> Config {
+    Config {
+        default_configs: default_configs(vec![
+            ("checkout.enabled", json!(false)),
+            ("checkout.limits", json!({ "min": 1, "max": 10 })),
+            ("search.enabled", json!(false)),
+        ]),
+        contexts: vec![
+            context("c0", vec![("country", json!("IN"))], "o0"),
+            context("c1", vec![("city", json!("BLR"))], "o1"),
+        ],
+        overrides: overrides_map(vec![
+            (
+                "o0",
+                vec![
+                    ("checkout.enabled", json!(true)),
+                    ("checkout.limits", json!({ "max": 20 })),
+                ],
+            ),
+            ("o1", vec![("search.enabled", json!(true))]),
+        ]),
+        dimensions: HashMap::new(),
+    }
+}
+
+#[test]
+fn eval_config_applies_matching_overrides() {
+    let resolved = eval_config(
+        sample_config(),
+        value_map(vec![("country", json!("IN"))]),
+        MergeStrategy::MERGE,
+        None,
+        None,
+    );
+
+    assert_eq!(
+        resolved,
+        value_map(vec![
+            ("checkout.enabled", json!(true)),
+            ("checkout.limits", json!({ "min": 1, "max": 20 })),
+            ("search.enabled", json!(false)),
+        ])
+    );
+}
+
+#[test]
+fn eval_config_replace_strategy_overwrites_nested_defaults() {
+    let resolved = eval_config(
+        sample_config(),
+        value_map(vec![("country", json!("IN"))]),
+        MergeStrategy::REPLACE,
+        None,
+        None,
+    );
+
+    assert_eq!(
+        resolved,
+        value_map(vec![
+            ("checkout.enabled", json!(true)),
+            ("checkout.limits", json!({ "max": 20 })),
+            ("search.enabled", json!(false)),
+        ])
+    );
+}
+
+#[test]
+fn eval_config_without_matching_context_returns_defaults() {
+    let config = sample_config();
+    let expected = config.default_configs.clone().into_inner();
+
+    let resolved = eval_config(
+        config,
+        value_map(vec![("country", json!("US"))]),
+        MergeStrategy::MERGE,
+        None,
+        None,
+    );
+
+    assert_eq!(resolved, expected);
+}
+
+#[test]
+fn eval_config_with_empty_query_data_returns_defaults() {
+    let config = sample_config();
+    let expected = config.default_configs.clone().into_inner();
+
+    let resolved = eval_config(config, Map::new(), MergeStrategy::MERGE, None, None);
+
+    assert_eq!(resolved, expected);
+}
+
+#[test]
+fn eval_config_filters_keys_by_include_prefix() {
+    let resolved = eval_config(
+        sample_config(),
+        value_map(vec![("country", json!("IN")), ("city", json!("BLR"))]),
+        MergeStrategy::MERGE,
+        Some(vec!["checkout.".to_string()]),
+        None,
+    );
+
+    // `search.*` is filtered out of the defaults, and the context whose
+    // override only touched `search.*` no longer contributes anything.
+    assert_eq!(
+        resolved,
+        value_map(vec![
+            ("checkout.enabled", json!(true)),
+            ("checkout.limits", json!({ "min": 1, "max": 20 })),
+        ])
+    );
+}
+
+#[test]
+fn eval_config_filters_keys_by_exclude_prefix() {
+    let resolved = eval_config(
+        sample_config(),
+        value_map(vec![("country", json!("IN")), ("city", json!("BLR"))]),
+        MergeStrategy::MERGE,
+        None,
+        Some(vec!["checkout.".to_string()]),
+    );
+
+    assert_eq!(resolved, value_map(vec![("search.enabled", json!(true))]));
+}
+
+#[test]
+fn eval_config_exclude_prefix_wins_over_include_prefix() {
+    let resolved = eval_config(
+        sample_config(),
+        value_map(vec![("country", json!("IN")), ("city", json!("BLR"))]),
+        MergeStrategy::MERGE,
+        Some(vec!["checkout.".to_string()]),
+        Some(vec!["checkout.limits".to_string()]),
+    );
+
+    assert_eq!(resolved, value_map(vec![("checkout.enabled", json!(true))]));
+}
+
+#[test]
+fn eval_config_ignores_blank_prefixes() {
+    let config = sample_config();
+    let unfiltered = eval_config(
+        config,
+        value_map(vec![("country", json!("IN"))]),
+        MergeStrategy::MERGE,
+        None,
+        None,
+    );
+
+    let with_blanks = eval_config(
+        sample_config(),
+        value_map(vec![("country", json!("IN"))]),
+        MergeStrategy::MERGE,
+        Some(vec!["".to_string(), "   ".to_string()]),
+        Some(vec!["".to_string()]),
+    );
+
+    assert_eq!(with_blanks, unfiltered);
+}
+
+#[test]
+fn eval_config_resolves_local_cohort_dimensions() {
+    let config = Config {
+        default_configs: default_configs(vec![("shipping.free", json!(false))]),
+        contexts: vec![context("c0", vec![("tier", json!("metro"))], "o0")],
+        overrides: overrides_map(vec![("o0", vec![("shipping.free", json!(true))])]),
+        dimensions: cohort_dimensions(),
+    };
+
+    // `country: IN` resolves the `tier` cohort to `metro`, which the context
+    // matches even though `tier` was never supplied.
+    let resolved = eval_config(
+        config,
+        value_map(vec![("country", json!("IN"))]),
+        MergeStrategy::MERGE,
+        None,
+        None,
+    );
+
+    assert_eq!(resolved, value_map(vec![("shipping.free", json!(true))]));
+}
+
+#[test]
+fn eval_config_unresolved_local_cohort_falls_back_to_otherwise() {
+    let config = Config {
+        default_configs: default_configs(vec![("shipping.free", json!(false))]),
+        contexts: vec![context("c0", vec![("tier", json!("metro"))], "o0")],
+        overrides: overrides_map(vec![("o0", vec![("shipping.free", json!(true))])]),
+        dimensions: cohort_dimensions(),
+    };
+
+    let resolved = eval_config(
+        config,
+        value_map(vec![("country", json!("FR"))]),
+        MergeStrategy::MERGE,
+        None,
+        None,
+    );
+
+    assert_eq!(resolved, value_map(vec![("shipping.free", json!(false))]));
+}
+
+// ---------------------------------------------------------------------------
+// eval
+// ---------------------------------------------------------------------------
+
+/// query data, strategy, include prefixes, exclude prefixes
+type EvalCase = (
+    Map<String, Value>,
+    MergeStrategy,
+    Option<Vec<String>>,
+    Option<Vec<String>>,
+);
+
+/// `eval` is the borrowing twin of `eval_config`; the two must agree.
+fn eval_from(
+    config: &Config,
+    query_data: Map<String, Value>,
+    merge_strategy: MergeStrategy,
+    filter_prefixes: Option<Vec<String>>,
+    filter_exclude_prefixes: Option<Vec<String>>,
+) -> Map<String, Value> {
+    eval(
+        config.default_configs.clone(),
+        &config.contexts,
+        &config.overrides,
+        &config.dimensions,
+        query_data,
+        merge_strategy,
+        filter_prefixes,
+        filter_exclude_prefixes,
+    )
+}
+
+#[test]
+fn eval_applies_matching_overrides() {
+    let config = sample_config();
+
+    let resolved = eval_from(
+        &config,
+        value_map(vec![("country", json!("IN"))]),
+        MergeStrategy::MERGE,
+        None,
+        None,
+    );
+
+    assert_eq!(
+        resolved,
+        value_map(vec![
+            ("checkout.enabled", json!(true)),
+            ("checkout.limits", json!({ "min": 1, "max": 20 })),
+            ("search.enabled", json!(false)),
+        ])
+    );
+}
+
+#[test]
+fn eval_matches_eval_config_across_strategies_and_filters() {
+    let cases: Vec<EvalCase> = vec![
+        (
+            value_map(vec![("country", json!("IN"))]),
+            MergeStrategy::MERGE,
+            None,
+            None,
+        ),
+        (
+            value_map(vec![("country", json!("IN"))]),
+            MergeStrategy::REPLACE,
+            None,
+            None,
+        ),
+        (Map::new(), MergeStrategy::MERGE, None, None),
+        (
+            value_map(vec![("country", json!("IN")), ("city", json!("BLR"))]),
+            MergeStrategy::MERGE,
+            Some(vec!["checkout.".to_string()]),
+            None,
+        ),
+        (
+            value_map(vec![("country", json!("IN")), ("city", json!("BLR"))]),
+            MergeStrategy::MERGE,
+            None,
+            Some(vec!["checkout.".to_string()]),
+        ),
+    ];
+
+    let config = sample_config();
+
+    for (query_data, strategy, prefixes, exclude_prefixes) in cases {
+        let borrowed = eval_from(
+            &config,
+            query_data.clone(),
+            strategy,
+            prefixes.clone(),
+            exclude_prefixes.clone(),
+        );
+        let owned = eval_config(
+            sample_config(),
+            query_data.clone(),
+            strategy,
+            prefixes.clone(),
+            exclude_prefixes.clone(),
+        );
+
+        assert_eq!(borrowed, owned, "mismatch for query data {query_data:?}");
+    }
+}
+
+#[test]
+fn eval_leaves_the_borrowed_config_reusable() {
+    let config = sample_config();
+    let query_data = value_map(vec![("country", json!("IN")), ("city", json!("BLR"))]);
+
+    let first = eval_from(
+        &config,
+        query_data.clone(),
+        MergeStrategy::MERGE,
+        None,
+        None,
+    );
+    // A second run over the same borrowed data must not observe anything
+    // consumed by the first.
+    let second = eval_from(
+        &config,
+        query_data.clone(),
+        MergeStrategy::MERGE,
+        None,
+        None,
+    );
+
+    assert_eq!(first, second);
+    assert_eq!(config.overrides.len(), 2);
+    assert_eq!(config.contexts.len(), 2);
+}
+
+#[test]
+fn eval_without_matching_context_returns_defaults() {
+    let config = sample_config();
+
+    let resolved = eval_from(
+        &config,
+        value_map(vec![("country", json!("US"))]),
+        MergeStrategy::MERGE,
+        None,
+        None,
+    );
+
+    assert_eq!(resolved, config.default_configs.clone().into_inner());
+}
+
+#[test]
+fn eval_resolves_local_cohort_dimensions() {
+    let config = Config {
+        default_configs: default_configs(vec![("shipping.free", json!(false))]),
+        contexts: vec![context("c0", vec![("tier", json!("metro"))], "o0")],
+        overrides: overrides_map(vec![("o0", vec![("shipping.free", json!(true))])]),
+        dimensions: cohort_dimensions(),
+    };
+
+    let resolved = eval_from(
+        &config,
+        value_map(vec![("country", json!("US"))]),
+        MergeStrategy::MERGE,
+        None,
+        None,
+    );
+
+    assert_eq!(resolved, value_map(vec![("shipping.free", json!(true))]));
+}
+
+#[test]
+fn eval_filters_keys_by_prefix() {
+    let config = sample_config();
+
+    let resolved = eval_from(
+        &config,
+        value_map(vec![("country", json!("IN")), ("city", json!("BLR"))]),
+        MergeStrategy::MERGE,
+        Some(vec!["search.".to_string()]),
+        None,
+    );
+
+    assert_eq!(resolved, value_map(vec![("search.enabled", json!(true))]));
+}
+
+#[test]
+fn eval_with_empty_config_returns_empty_map() {
+    let resolved = eval(
+        ExtendedMap::default(),
+        &[],
+        &HashMap::new(),
+        &HashMap::new(),
+        value_map(vec![("country", json!("IN"))]),
+        MergeStrategy::MERGE,
+        None,
+        None,
+    );
+
+    assert_eq!(resolved, Map::new());
+}
+
+// ---------------------------------------------------------------------------
+// ConfigRef
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_ref_round_trips_through_into_parts_and_from_parts() {
+    let config = sample_config();
+    let config_ref = ConfigRef {
+        default_configs: config.default_configs.clone(),
+        contexts: config.contexts.iter().collect(),
+        overrides: Cow::Borrowed(&config.overrides),
+        dimensions: &config.dimensions,
+    };
+
+    let (contexts, overrides, defaults, dimensions) = config_ref.into_parts();
+    let rebuilt = ConfigRef::from_parts(contexts, overrides, defaults, dimensions);
+
+    assert_eq!(rebuilt.contexts.len(), config.contexts.len());
+    assert_eq!(rebuilt.overrides.len(), config.overrides.len());
+    assert_eq!(
+        rebuilt.default_configs.clone().into_inner(),
+        config.default_configs.clone().into_inner()
+    );
+    assert!(matches!(rebuilt.overrides, Cow::Borrowed(_)));
+}
+
+#[test]
+fn config_ref_filter_by_prefix_drops_contexts_left_without_overrides() {
+    let config = sample_config();
+    let config_ref = ConfigRef {
+        default_configs: config.default_configs.clone(),
+        contexts: config.contexts.iter().collect(),
+        overrides: Cow::Borrowed(&config.overrides),
+        dimensions: &config.dimensions,
+    };
+
+    let filtered = config_ref.filter_by_prefix(
+        &PrefixList::from_iter(vec!["checkout.".to_string()]),
+        &PrefixList::new(),
+    );
+
+    // Only `c0` overrides a `checkout.*` key, so `c1` is dropped along with its
+    // now-empty override.
+    assert_eq!(filtered.contexts.len(), 1);
+    assert_eq!(filtered.contexts[0].id, "c0");
+    assert!(filtered.overrides.contains_key("o0"));
+    assert!(!filtered.overrides.contains_key("o1"));
+    assert_eq!(
+        filtered.default_configs.into_inner(),
+        value_map(vec![
+            ("checkout.enabled", json!(false)),
+            ("checkout.limits", json!({ "min": 1, "max": 10 })),
+        ])
+    );
+}

--- a/crates/superposition_core/src/experiment.rs
+++ b/crates/superposition_core/src/experiment.rs
@@ -114,7 +114,7 @@ pub fn get_applicable_variants(
     dimensions_info: &HashMap<String, DimensionInfo>,
     experiments: Experiments,
     experiment_groups: &ExperimentGroups,
-    query_data: &Map<String, Value>,
+    query_data: Map<String, Value>,
     identifier: &str,
     prefix: Option<Vec<String>>,
     exclude_prefix: Option<Vec<String>>,
@@ -146,7 +146,7 @@ pub fn get_applicable_buckets_from_group(
         .iter()
         .filter_map(|exp_group| {
             let hashed_percentage = calculate_bucket_index(identifier, &exp_group.id);
-            log::info!(
+            log::debug!(
                 "Identifier: {}, Experiment Group ID: {}, Hashed Percentage: {}",
                 identifier,
                 exp_group.id,

--- a/crates/superposition_core/src/ffi.rs
+++ b/crates/superposition_core/src/ffi.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use serde_json::{Map, Value};
 use superposition_types::experimental::Experimental;
 use superposition_types::{
-    Config, Context, DimensionInfo, ExtendedMap, Overrides, PrefixList,
+    Config, ConfigFilter, Context, DimensionInfo, ExtendedMap, Overrides, PrefixList,
 };
 use thiserror::Error;
 
@@ -12,9 +12,9 @@ use crate::experiment::{
     filter_experiments_by_context, get_satisfied_experiments, ExperimentConfig,
 };
 use crate::{
-    eval_config, eval_config_with_reasoning, experiment::ExperimentationArgs,
-    experiment::FfiExperimentGroup, get_applicable_variants, ConfigFormat, FfiExperiment,
-    JsonFormat, MergeStrategy, TomlFormat,
+    eval, eval_config, experiment::ExperimentationArgs, experiment::FfiExperimentGroup,
+    get_applicable_variants, ConfigFormat, FfiExperiment, JsonFormat, MergeStrategy,
+    TomlFormat,
 };
 
 #[derive(Debug, Error, uniffi::Error)]
@@ -23,90 +23,77 @@ pub enum OperationError {
     Unexpected(String),
 }
 
-fn json_to_map(j: Map<String, Value>) -> serde_json::Result<HashMap<String, String>> {
+fn json_to_map(j: Map<String, Value>) -> Result<HashMap<String, String>, OperationError> {
     j.iter()
         .map(|(k, v)| serde_json::to_string(v).map(|v| (k.clone(), v)))
         .collect::<serde_json::Result<HashMap<String, String>>>()
+        .map_err(|err| OperationError::Unexpected(err.to_string()))
 }
 
-fn json_from_map(m: HashMap<String, String>) -> serde_json::Result<Map<String, Value>> {
+fn json_from_map(
+    m: HashMap<String, String>,
+) -> Result<Map<String, Value>, OperationError> {
     m.iter()
         .map(|(k, v)| serde_json::from_str(v).map(|v| (k.clone(), v)))
         .collect::<serde_json::Result<Map<String, Value>>>()
+        .map_err(|err| OperationError::Unexpected(err.to_string()))
 }
 
-type EvalFn = fn(
-    ExtendedMap,
-    Vec<Context>,
-    HashMap<String, Overrides>,
-    HashMap<String, DimensionInfo>,
-    Map<String, Value>,
-    MergeStrategy,
-    Option<Vec<String>>,
-    Option<Vec<String>>,
-) -> Result<Map<String, Value>, String>;
-
-#[allow(clippy::too_many_arguments)]
-fn ffi_eval_logic(
-    default_config: ExtendedMap,
-    contexts: Vec<Context>,
-    overrides: HashMap<String, Overrides>,
-    dimensions: HashMap<String, DimensionInfo>,
+/// Parses the FFI query data and, when experimentation is requested, resolves the
+/// applicable variants into it under `variantIds`.
+///
+/// The prefix lists are borrowed because the caller still needs them for the eval
+/// itself; they are only cloned on the experimentation path.
+fn prepare_query_data(
+    dimensions: &HashMap<String, DimensionInfo>,
     query_data: HashMap<String, String>,
-    merge_strategy: MergeStrategy,
-    filter_prefixes: Option<Vec<String>>,
-    filter_exclude_prefixes: Option<Vec<String>>,
     experimentation: Option<ExperimentationArgs>,
-    eval_fn: EvalFn,
-) -> Result<HashMap<String, String>, OperationError> {
-    let mut _q = json_from_map(query_data)
-        .map_err(|err| OperationError::Unexpected(err.to_string()))?;
+    filter_prefixes: Option<&Vec<String>>,
+    filter_exclude_prefixes: Option<&Vec<String>>,
+) -> Result<Map<String, Value>, OperationError> {
+    let mut query_data = json_from_map(query_data)?;
 
     if let Some(e_args) = experimentation {
         // NOTE Parsing to allow for testing. This has to be migrated to the new
         // bucketing procedure.
         let identifier = e_args.targeting_key;
         let variants = get_applicable_variants(
-            &dimensions,
+            dimensions,
             e_args.experiments,
             &e_args.experiment_groups,
-            _q.clone(),
+            query_data.clone(),
             &identifier,
-            filter_prefixes.clone(),
-            filter_exclude_prefixes.clone(),
+            filter_prefixes.cloned(),
+            filter_exclude_prefixes.cloned(),
         );
-        _q.insert("variantIds".to_string(), variants.into());
+        query_data.insert("variantIds".to_string(), variants.into());
     }
 
-    let r = eval_fn(
-        default_config,
-        contexts,
-        overrides,
-        dimensions,
-        _q,
-        merge_strategy,
-        filter_prefixes,
-        filter_exclude_prefixes,
-    )
-    .map_err(OperationError::Unexpected)?;
-
-    json_to_map(r).map_err(|err| OperationError::Unexpected(err.to_string()))
+    Ok(query_data)
 }
 
 #[allow(clippy::too_many_arguments)]
 #[uniffi::export]
 fn ffi_eval_config(
     default_config: ExtendedMap,
-    contexts: Vec<Context>,
-    overrides: HashMap<String, Overrides>,
-    dimensions: HashMap<String, DimensionInfo>,
+    contexts: &[Context],
+    overrides: &HashMap<String, Overrides>,
+    dimensions: &HashMap<String, DimensionInfo>,
     query_data: HashMap<String, String>,
     merge_strategy: MergeStrategy,
     filter_prefixes: Option<Vec<String>>,
     filter_exclude_prefixes: Option<Vec<String>>,
     experimentation: Option<ExperimentationArgs>,
 ) -> Result<HashMap<String, String>, OperationError> {
-    ffi_eval_logic(
+    let query_data = prepare_query_data(
+        dimensions,
+        query_data,
+        experimentation,
+        filter_prefixes.as_ref(),
+        filter_exclude_prefixes.as_ref(),
+    )?;
+
+    json_to_map(eval(
         default_config,
         contexts,
         overrides,
@@ -115,36 +102,33 @@ fn ffi_eval_config(
         merge_strategy,
         filter_prefixes,
         filter_exclude_prefixes,
-        experimentation,
-        eval_config,
-    )
+    ))
 }
 
-#[allow(clippy::too_many_arguments)]
 #[uniffi::export]
-fn ffi_eval_config_with_reasoning(
-    default_config: ExtendedMap,
-    contexts: Vec<Context>,
-    overrides: HashMap<String, Overrides>,
-    dimensions: HashMap<String, DimensionInfo>,
+fn ffi_eval(
+    config: Config,
     query_data: HashMap<String, String>,
     merge_strategy: MergeStrategy,
     filter_prefixes: Option<Vec<String>>,
     filter_exclude_prefixes: Option<Vec<String>>,
     experimentation: Option<ExperimentationArgs>,
 ) -> Result<HashMap<String, String>, OperationError> {
-    ffi_eval_logic(
-        default_config,
-        contexts,
-        overrides,
-        dimensions,
+    let query_data = prepare_query_data(
+        &config.dimensions,
+        query_data,
+        experimentation,
+        filter_prefixes.as_ref(),
+        filter_exclude_prefixes.as_ref(),
+    )?;
+
+    json_to_map(eval_config(
+        config,
         query_data,
         merge_strategy,
         filter_prefixes,
         filter_exclude_prefixes,
-        experimentation,
-        eval_config_with_reasoning,
-    )
+    ))
 }
 
 #[uniffi::export]
@@ -155,8 +139,7 @@ fn ffi_get_applicable_variants(
     prefix: Option<Vec<String>>,
     exclude_prefix: Option<Vec<String>>,
 ) -> Result<Vec<String>, OperationError> {
-    let _query_data = json_from_map(query_data)
-        .map_err(|err| OperationError::Unexpected(err.to_string()))?;
+    let _query_data = json_from_map(query_data)?;
 
     let identifier = eargs.targeting_key;
     let r = get_applicable_variants(
@@ -239,10 +222,7 @@ fn ffi_parse_config_file_with_filters(
     prefix: Option<Vec<String>>,
     exclude_prefix: Option<Vec<String>>,
 ) -> Result<Config, OperationError> {
-    let dimension_data = dimension_data
-        .map(json_from_map)
-        .transpose()
-        .map_err(|err| OperationError::Unexpected(err.to_string()))?;
+    let dimension_data = dimension_data.map(json_from_map).transpose()?;
     let prefix_list = prefix.map(PrefixList::from_iter);
     let exclude_prefix_list = exclude_prefix.map(PrefixList::from_iter);
 
@@ -302,8 +282,7 @@ impl ProviderCache {
         overrides: HashMap<String, Overrides>,
         dimensions: HashMap<String, DimensionInfo>,
     ) -> Result<(), OperationError> {
-        let default_config_map = json_from_map(default_config)
-            .map_err(|err| OperationError::Unexpected(err.to_string()))?;
+        let default_config_map = json_from_map(default_config)?;
 
         let mut cache_data = self.data.lock().map_err(|err| {
             OperationError::Unexpected(format!("Failed to acquire cache lock: {}", err))
@@ -346,10 +325,7 @@ impl ProviderCache {
             OperationError::Unexpected(format!("Failed to acquire cache lock: {}", err))
         })?;
 
-        let mut _q: Map<String, Value> = json_from_map(query_data)
-            .map_err(|err| OperationError::Unexpected(err.to_string()))?;
-
-        let config = cache_data.config.clone();
+        let mut _q: Map<String, Value> = json_from_map(query_data)?;
 
         if let Some(experiment_config) = &cache_data.experiment {
             if (!experiment_config.experiments.is_empty()
@@ -357,7 +333,7 @@ impl ProviderCache {
                 && targeting_key.as_ref().is_some_and(|key| !key.is_empty())
             {
                 let variants = get_applicable_variants(
-                    &config.dimensions,
+                    &cache_data.config.dimensions,
                     experiment_config.experiments.clone(),
                     &experiment_config.experiment_groups,
                     _q.clone(),
@@ -369,19 +345,18 @@ impl ProviderCache {
             }
         }
 
-        let r = eval_config(
-            config.default_configs,
-            config.contexts,
-            config.overrides,
-            config.dimensions,
+        let r = eval(
+            cache_data.config.default_configs.clone(),
+            &cache_data.config.contexts,
+            &cache_data.config.overrides,
+            &cache_data.config.dimensions,
             _q,
             merge_strategy,
             filter_prefixes,
             filter_exclude_prefixes,
-        )
-        .map_err(OperationError::Unexpected)?;
+        );
 
-        json_to_map(r).map_err(|err| OperationError::Unexpected(err.to_string()))
+        json_to_map(r)
     }
 
     fn filter_config(
@@ -390,10 +365,7 @@ impl ProviderCache {
         prefix: Option<Vec<String>>,
         exclude_prefix: Option<Vec<String>>,
     ) -> Result<Config, OperationError> {
-        let dimension_data = dimension_data
-            .map(json_from_map)
-            .transpose()
-            .map_err(|err| OperationError::Unexpected(err.to_string()))?;
+        let dimension_data = dimension_data.map(json_from_map).transpose()?;
         let prefix_list = prefix.map(PrefixList::from_iter);
         let exclude_prefix_list = exclude_prefix.map(PrefixList::from_iter);
 
@@ -423,8 +395,7 @@ impl ProviderCache {
     ) -> Result<ExperimentConfig, OperationError> {
         let dimension_data = dimension_data
             .map(json_from_map)
-            .transpose()
-            .map_err(|err| OperationError::Unexpected(err.to_string()))?
+            .transpose()?
             .unwrap_or_default();
 
         let (exps, exp_grps) = {
@@ -474,8 +445,7 @@ impl ProviderCache {
     ) -> Result<Vec<String>, OperationError> {
         let dimension_data = dimension_data
             .map(json_from_map)
-            .transpose()
-            .map_err(|err| OperationError::Unexpected(err.to_string()))?
+            .transpose()?
             .unwrap_or_default();
 
         let (exps, exp_grps, dimensions_info) = {

--- a/crates/superposition_core/src/ffi.rs
+++ b/crates/superposition_core/src/ffi.rs
@@ -3,7 +3,9 @@ use std::sync::{Arc, Mutex};
 
 use serde_json::{Map, Value};
 use superposition_types::experimental::Experimental;
-use superposition_types::{Config, Context, DimensionInfo, Overrides, PrefixList};
+use superposition_types::{
+    Config, Context, DimensionInfo, ExtendedMap, Overrides, PrefixList,
+};
 use thiserror::Error;
 
 use crate::experiment::{
@@ -34,11 +36,11 @@ fn json_from_map(m: HashMap<String, String>) -> serde_json::Result<Map<String, V
 }
 
 type EvalFn = fn(
+    ExtendedMap,
+    Vec<Context>,
+    HashMap<String, Overrides>,
+    HashMap<String, DimensionInfo>,
     Map<String, Value>,
-    &[Context],
-    &HashMap<String, Overrides>,
-    &HashMap<String, DimensionInfo>,
-    &Map<String, Value>,
     MergeStrategy,
     Option<Vec<String>>,
     Option<Vec<String>>,
@@ -46,8 +48,8 @@ type EvalFn = fn(
 
 #[allow(clippy::too_many_arguments)]
 fn ffi_eval_logic(
-    default_config: HashMap<String, String>,
-    contexts: &[Context],
+    default_config: ExtendedMap,
+    contexts: Vec<Context>,
     overrides: HashMap<String, Overrides>,
     dimensions: HashMap<String, DimensionInfo>,
     query_data: HashMap<String, String>,
@@ -57,8 +59,6 @@ fn ffi_eval_logic(
     experimentation: Option<ExperimentationArgs>,
     eval_fn: EvalFn,
 ) -> Result<HashMap<String, String>, OperationError> {
-    let _d = json_from_map(default_config)
-        .map_err(|err| OperationError::Unexpected(err.to_string()))?;
     let mut _q = json_from_map(query_data)
         .map_err(|err| OperationError::Unexpected(err.to_string()))?;
 
@@ -70,7 +70,7 @@ fn ffi_eval_logic(
             &dimensions,
             e_args.experiments,
             &e_args.experiment_groups,
-            &_q,
+            _q.clone(),
             &identifier,
             filter_prefixes.clone(),
             filter_exclude_prefixes.clone(),
@@ -79,11 +79,11 @@ fn ffi_eval_logic(
     }
 
     let r = eval_fn(
-        _d,
+        default_config,
         contexts,
-        &overrides,
-        &dimensions,
-        &_q,
+        overrides,
+        dimensions,
+        _q,
         merge_strategy,
         filter_prefixes,
         filter_exclude_prefixes,
@@ -96,8 +96,8 @@ fn ffi_eval_logic(
 #[allow(clippy::too_many_arguments)]
 #[uniffi::export]
 fn ffi_eval_config(
-    default_config: HashMap<String, String>,
-    contexts: &[Context],
+    default_config: ExtendedMap,
+    contexts: Vec<Context>,
     overrides: HashMap<String, Overrides>,
     dimensions: HashMap<String, DimensionInfo>,
     query_data: HashMap<String, String>,
@@ -123,8 +123,8 @@ fn ffi_eval_config(
 #[allow(clippy::too_many_arguments)]
 #[uniffi::export]
 fn ffi_eval_config_with_reasoning(
-    default_config: HashMap<String, String>,
-    contexts: &[Context],
+    default_config: ExtendedMap,
+    contexts: Vec<Context>,
     overrides: HashMap<String, Overrides>,
     dimensions: HashMap<String, DimensionInfo>,
     query_data: HashMap<String, String>,
@@ -155,7 +155,7 @@ fn ffi_get_applicable_variants(
     prefix: Option<Vec<String>>,
     exclude_prefix: Option<Vec<String>>,
 ) -> Result<Vec<String>, OperationError> {
-    let _query_data = json_from_map(query_data.clone())
+    let _query_data = json_from_map(query_data)
         .map_err(|err| OperationError::Unexpected(err.to_string()))?;
 
     let identifier = eargs.targeting_key;
@@ -163,7 +163,7 @@ fn ffi_get_applicable_variants(
         &dimensions_info,
         eargs.experiments,
         &eargs.experiment_groups,
-        &_query_data,
+        _query_data,
         &identifier,
         prefix,
         exclude_prefix,
@@ -260,7 +260,7 @@ fn ffi_parse_config_file_with_filters(
     };
 
     Ok(config.filter(
-        dimension_data.as_ref(),
+        dimension_data,
         prefix_list.as_ref(),
         exclude_prefix_list.as_ref(),
     ))
@@ -346,8 +346,10 @@ impl ProviderCache {
             OperationError::Unexpected(format!("Failed to acquire cache lock: {}", err))
         })?;
 
-        let mut _q = json_from_map(query_data)
+        let mut _q: Map<String, Value> = json_from_map(query_data)
             .map_err(|err| OperationError::Unexpected(err.to_string()))?;
+
+        let config = cache_data.config.clone();
 
         if let Some(experiment_config) = &cache_data.experiment {
             if (!experiment_config.experiments.is_empty()
@@ -355,10 +357,10 @@ impl ProviderCache {
                 && targeting_key.as_ref().is_some_and(|key| !key.is_empty())
             {
                 let variants = get_applicable_variants(
-                    &cache_data.config.dimensions,
+                    &config.dimensions,
                     experiment_config.experiments.clone(),
                     &experiment_config.experiment_groups,
-                    &_q,
+                    _q.clone(),
                     targeting_key.as_deref().unwrap_or(""),
                     filter_prefixes.clone(),
                     filter_exclude_prefixes.clone(),
@@ -368,11 +370,11 @@ impl ProviderCache {
         }
 
         let r = eval_config(
-            cache_data.config.default_configs.inner().clone(),
-            &cache_data.config.contexts,
-            &cache_data.config.overrides,
-            &cache_data.config.dimensions,
-            &_q,
+            config.default_configs,
+            config.contexts,
+            config.overrides,
+            config.dimensions,
+            _q,
             merge_strategy,
             filter_prefixes,
             filter_exclude_prefixes,
@@ -406,7 +408,7 @@ impl ProviderCache {
         };
 
         Ok(config.filter(
-            dimension_data.as_ref(),
+            dimension_data,
             prefix_list.as_ref(),
             exclude_prefix_list.as_ref(),
         ))
@@ -501,7 +503,7 @@ impl ProviderCache {
             &dimensions_info,
             exps,
             &exp_grps,
-            &dimension_data,
+            dimension_data,
             &targeting_key,
             prefix,
             exclude_prefix,

--- a/crates/superposition_core/src/ffi_legacy.rs
+++ b/crates/superposition_core/src/ffi_legacy.rs
@@ -1,10 +1,11 @@
-// src/ffi.rs
-use std::collections::HashMap;
-use std::ffi::{c_char, CStr, CString};
-use std::ptr;
+use std::{
+    collections::HashMap,
+    ffi::{c_char, CStr, CString},
+    ptr,
+};
 
 use serde_json::{Map, Value};
-use superposition_types::{Context, DimensionInfo, Overrides};
+use superposition_types::{Context, DimensionInfo, ExtendedMap, Overrides};
 
 use crate::config::{self, MergeStrategy};
 use crate::experiment::{ExperimentConfig, ExperimentGroups, ExperimentationArgs};
@@ -226,7 +227,7 @@ pub unsafe extern "C" fn core_provider_cache_eval_config(
                 &data.config.dimensions,
                 experiment_config.experiments.clone(),
                 &experiment_config.experiment_groups,
-                &query_data,
+                query_data.clone(),
                 tkey.as_deref().unwrap_or(""),
                 filter_prefixes.clone(),
                 filter_exclude_prefixes.clone(),
@@ -235,12 +236,13 @@ pub unsafe extern "C" fn core_provider_cache_eval_config(
         }
     }
 
+    let config = data.config.clone();
     match config::eval_config(
-        data.config.default_configs.inner().clone(),
-        &data.config.contexts,
-        &data.config.overrides,
-        &data.config.dimensions,
-        &query_data,
+        config.default_configs,
+        config.contexts,
+        config.overrides,
+        config.dimensions,
+        query_data,
         merge_strategy,
         filter_prefixes,
         filter_exclude_prefixes,
@@ -320,7 +322,7 @@ pub unsafe extern "C" fn core_get_resolved_config(
 
     // Parse all parameters
     let default_config = match parse_json::<Map<String, Value>>(default_config_json) {
-        Ok(config) => config,
+        Ok(config) => ExtendedMap::from(config),
         Err(e) => {
             copy_string(ebuf, format!("Failed to parse default_config: {}", e));
             return ptr::null_mut();
@@ -417,7 +419,7 @@ pub unsafe extern "C" fn core_get_resolved_config(
             &dimensions,
             e_args.experiments,
             &e_args.experiment_groups,
-            &query_data,
+            query_data.clone(),
             &identifier,
             filter_prefixes.clone(),
             filter_exclude_prefixes.clone(),
@@ -429,10 +431,10 @@ pub unsafe extern "C" fn core_get_resolved_config(
     // Call pure config resolution logic
     match config::eval_config(
         default_config,
-        &contexts,
-        &overrides,
-        &dimensions,
-        &query_data,
+        contexts,
+        overrides,
+        dimensions,
+        query_data,
         merge_strategy,
         filter_prefixes,
         filter_exclude_prefixes,
@@ -482,7 +484,7 @@ pub unsafe extern "C" fn core_get_resolved_config_with_reasoning(
 
     // Parse parameters (same logic as above)
     let default_config = match parse_json::<Map<String, Value>>(default_config_json) {
-        Ok(config) => config,
+        Ok(config) => ExtendedMap::from(config),
         Err(e) => {
             copy_string(ebuf, format!("Failed to parse default_config: {}", e));
             return ptr::null_mut();
@@ -580,7 +582,7 @@ pub unsafe extern "C" fn core_get_resolved_config_with_reasoning(
             &dimensions,
             e_args.experiments,
             &e_args.experiment_groups,
-            &query_data,
+            query_data.clone(),
             &identifier,
             filter_prefixes.clone(),
             filter_exclude_prefixes.clone(),
@@ -592,10 +594,10 @@ pub unsafe extern "C" fn core_get_resolved_config_with_reasoning(
     // Call config resolution with reasoning
     match config::eval_config_with_reasoning(
         default_config,
-        &contexts,
-        &overrides,
-        &dimensions,
-        &query_data,
+        contexts,
+        overrides,
+        dimensions,
+        query_data,
         merge_strategy,
         filter_prefixes,
         filter_exclude_prefixes,
@@ -727,7 +729,7 @@ pub unsafe extern "C" fn core_get_applicable_variants(
         &dimensions,
         experiments,
         &experiment_groups,
-        &query_data,
+        query_data,
         &identifier,
         filter_prefixes,
         filter_exclude_prefixes,

--- a/crates/superposition_core/src/ffi_legacy.rs
+++ b/crates/superposition_core/src/ffi_legacy.rs
@@ -237,25 +237,20 @@ pub unsafe extern "C" fn core_provider_cache_eval_config(
     }
 
     let config = data.config.clone();
-    match config::eval_config(
+    let result = config::eval(
         config.default_configs,
-        config.contexts,
-        config.overrides,
-        config.dimensions,
+        &config.contexts,
+        &config.overrides,
+        &config.dimensions,
         query_data,
         merge_strategy,
         filter_prefixes,
         filter_exclude_prefixes,
-    ) {
-        Ok(result) => match serde_json::to_string(&result) {
-            Ok(json_str) => string_to_c_str(json_str),
-            Err(e) => {
-                copy_string(ebuf, format!("Failed to serialize result: {}", e));
-                ptr::null_mut()
-            }
-        },
+    );
+    match serde_json::to_string(&result) {
+        Ok(json_str) => string_to_c_str(json_str),
         Err(e) => {
-            copy_string(ebuf, e);
+            copy_string(ebuf, format!("Failed to serialize result: {}", e));
             ptr::null_mut()
         }
     }
@@ -429,188 +424,20 @@ pub unsafe extern "C" fn core_get_resolved_config(
     }
 
     // Call pure config resolution logic
-    match config::eval_config(
+    let result = config::eval(
         default_config,
-        contexts,
-        overrides,
-        dimensions,
+        &contexts,
+        &overrides,
+        &dimensions,
         query_data,
         merge_strategy,
         filter_prefixes,
         filter_exclude_prefixes,
-    ) {
-        Ok(result) => match serde_json::to_string(&result) {
-            Ok(json_str) => string_to_c_str(json_str),
-            Err(e) => {
-                copy_string(ebuf, format!("Failed to serialize result: {}", e));
-                ptr::null_mut()
-            }
-        },
+    );
+    match serde_json::to_string(&result) {
+        Ok(json_str) => string_to_c_str(json_str),
         Err(e) => {
-            copy_string(ebuf, e);
-            ptr::null_mut()
-        }
-    }
-}
-
-/// # Safety
-///
-/// Caller ensures that `ebuf` is a sufficiently long buffer to store the
-/// error message.
-#[no_mangle]
-pub unsafe extern "C" fn core_get_resolved_config_with_reasoning(
-    default_config_json: *const c_char,
-    contexts_json: *const c_char,
-    overrides_json: *const c_char,
-    dimensions: *const c_char,
-    query_data_json: *const c_char,
-    merge_strategy_str: *const c_char,
-    filter_prefixes_json: *const c_char,
-    filter_exclude_prefixes_json: *const c_char,
-    experimentation_json: *const c_char,
-    ebuf: *mut c_char,
-) -> *mut c_char {
-    // Same parameter validation as above...
-    if default_config_json.is_null()
-        || contexts_json.is_null()
-        || overrides_json.is_null()
-        || dimensions.is_null()
-        || query_data_json.is_null()
-        || merge_strategy_str.is_null()
-    {
-        copy_string(ebuf, "Null pointer provided");
-        return ptr::null_mut();
-    }
-
-    // Parse parameters (same logic as above)
-    let default_config = match parse_json::<Map<String, Value>>(default_config_json) {
-        Ok(config) => ExtendedMap::from(config),
-        Err(e) => {
-            copy_string(ebuf, format!("Failed to parse default_config: {}", e));
-            return ptr::null_mut();
-        }
-    };
-
-    let contexts = match parse_json::<Vec<Context>>(contexts_json) {
-        Ok(contexts) => contexts,
-        Err(e) => {
-            copy_string(ebuf, format!("Failed to parse contexts: {}", e));
-            return ptr::null_mut();
-        }
-    };
-
-    let overrides = match parse_json::<HashMap<String, Overrides>>(overrides_json) {
-        Ok(overrides) => overrides,
-        Err(e) => {
-            copy_string(ebuf, format!("Failed to parse overrides: {}", e));
-            return ptr::null_mut();
-        }
-    };
-
-    let mut query_data = match parse_json::<Map<String, Value>>(query_data_json) {
-        Ok(data) => data,
-        Err(e) => {
-            copy_string(ebuf, format!("Failed to parse query_data: {}", e));
-            return ptr::null_mut();
-        }
-    };
-
-    let merge_strategy = match c_str_to_string(merge_strategy_str) {
-        Ok(strategy) => match strategy.to_lowercase().as_str() {
-            "merge" => MergeStrategy::MERGE,
-            "replace" => MergeStrategy::REPLACE,
-            _ => MergeStrategy::default(),
-        },
-        Err(e) => {
-            copy_string(ebuf, format!("Failed to parse merge_strategy: {}", e));
-            return ptr::null_mut();
-        }
-    };
-
-    let filter_prefixes: Option<Vec<String>> = if filter_prefixes_json.is_null() {
-        None
-    } else {
-        match parse_json::<Vec<String>>(filter_prefixes_json) {
-            Ok(prefixes) => Some(prefixes),
-            Err(e) => {
-                copy_string(ebuf, format!("Failed to parse filter_prefixes: {}", e));
-                return ptr::null_mut();
-            }
-        }
-    };
-
-    let filter_exclude_prefixes: Option<Vec<String>> =
-        if filter_exclude_prefixes_json.is_null() {
-            None
-        } else {
-            match parse_json::<Vec<String>>(filter_exclude_prefixes_json) {
-                Ok(v) => Some(v),
-                Err(e) => {
-                    copy_string(
-                        ebuf,
-                        format!("Failed to parse filter_exclude_prefixes: {}", e),
-                    );
-                    return ptr::null_mut();
-                }
-            }
-        };
-
-    let experimentation: Option<ExperimentationArgs> = if experimentation_json.is_null() {
-        None
-    } else {
-        match parse_json::<ExperimentationArgs>(experimentation_json) {
-            Ok(exp_args) => Some(exp_args),
-            Err(e) => {
-                copy_string(ebuf, format!("Failed to parse experimentation: {}", e));
-                return ptr::null_mut();
-            }
-        }
-    };
-
-    let dimensions = match parse_json::<HashMap<String, DimensionInfo>>(dimensions) {
-        Ok(dimensions) => dimensions,
-        Err(e) => {
-            copy_string(ebuf, format!("Failed to parse dimensions: {}", e));
-            return ptr::null_mut();
-        }
-    };
-
-    if let Some(e_args) = experimentation {
-        let identifier = e_args.targeting_key;
-
-        let variants = get_applicable_variants(
-            &dimensions,
-            e_args.experiments,
-            &e_args.experiment_groups,
-            query_data.clone(),
-            &identifier,
-            filter_prefixes.clone(),
-            filter_exclude_prefixes.clone(),
-        );
-
-        query_data.insert("variantIds".to_string(), variants.into());
-    }
-
-    // Call config resolution with reasoning
-    match config::eval_config_with_reasoning(
-        default_config,
-        contexts,
-        overrides,
-        dimensions,
-        query_data,
-        merge_strategy,
-        filter_prefixes,
-        filter_exclude_prefixes,
-    ) {
-        Ok(result) => match serde_json::to_string(&result) {
-            Ok(json_str) => string_to_c_str(json_str),
-            Err(e) => {
-                copy_string(ebuf, format!("Failed to serialize result: {}", e));
-                ptr::null_mut()
-            }
-        },
-        Err(e) => {
-            copy_string(ebuf, e);
+            copy_string(ebuf, format!("Failed to serialize result: {}", e));
             ptr::null_mut()
         }
     }

--- a/crates/superposition_core/src/format/tests/json.rs
+++ b/crates/superposition_core/src/format/tests/json.rs
@@ -295,11 +295,11 @@ fn test_json_resolution_with_local_cohorts() {
     dims.insert("os".to_string(), Value::String("linux".to_string()));
 
     let result = crate::eval_config(
-        (*config.default_configs).clone(),
-        &config.contexts,
-        &config.overrides,
-        &config.dimensions,
-        &dims,
+        config.default_configs,
+        config.contexts,
+        config.overrides,
+        config.dimensions,
+        dims,
         crate::MergeStrategy::MERGE,
         None,
         None,

--- a/crates/superposition_core/src/format/tests/json.rs
+++ b/crates/superposition_core/src/format/tests/json.rs
@@ -294,17 +294,8 @@ fn test_json_resolution_with_local_cohorts() {
     let mut dims = Map::new();
     dims.insert("os".to_string(), Value::String("linux".to_string()));
 
-    let result = crate::eval_config(
-        config.default_configs,
-        config.contexts,
-        config.overrides,
-        config.dimensions,
-        dims,
-        crate::MergeStrategy::MERGE,
-        None,
-        None,
-    )
-    .unwrap();
+    let result =
+        crate::eval_config(config, dims, crate::MergeStrategy::MERGE, None, None);
 
     assert_eq!(
         result.get("max_count"),

--- a/crates/superposition_core/src/format/tests/toml.rs
+++ b/crates/superposition_core/src/format/tests/toml.rs
@@ -269,17 +269,8 @@ max_count = 95
     let mut dims = Map::new();
     dims.insert("os".to_string(), Value::String("linux".to_string()));
 
-    let result = crate::eval_config(
-        config.default_configs,
-        config.contexts,
-        config.overrides,
-        config.dimensions,
-        dims,
-        crate::MergeStrategy::MERGE,
-        None,
-        None,
-    )
-    .unwrap();
+    let result =
+        crate::eval_config(config, dims, crate::MergeStrategy::MERGE, None, None);
 
     assert_eq!(
         result.get("max_count"),

--- a/crates/superposition_core/src/format/tests/toml.rs
+++ b/crates/superposition_core/src/format/tests/toml.rs
@@ -270,11 +270,11 @@ max_count = 95
     dims.insert("os".to_string(), Value::String("linux".to_string()));
 
     let result = crate::eval_config(
-        (*config.default_configs).clone(),
-        &config.contexts,
-        &config.overrides,
-        &config.dimensions,
-        &dims,
+        config.default_configs,
+        config.contexts,
+        config.overrides,
+        config.dimensions,
+        dims,
         crate::MergeStrategy::MERGE,
         None,
         None,

--- a/crates/superposition_core/src/lib.rs
+++ b/crates/superposition_core/src/lib.rs
@@ -13,7 +13,7 @@ pub mod format;
 pub mod helpers;
 pub mod validations;
 // Re-export main config functions
-pub use config::{eval_config, eval_config_with_reasoning, merge, MergeStrategy};
+pub use config::{eval, eval_config, merge, MergeStrategy};
 
 // Re-export experiment functions
 pub use experiment::{
@@ -22,8 +22,8 @@ pub use experiment::{
 
 // Re-export legacy FFI functions
 pub use ffi_legacy::{
-    core_free_string, core_get_resolved_config, core_get_resolved_config_with_reasoning,
-    core_parse_json_config, core_parse_toml_config,
+    core_free_string, core_get_resolved_config, core_parse_json_config,
+    core_parse_toml_config,
 };
 
 // Re-export format module and types

--- a/crates/superposition_core/src/lib.rs
+++ b/crates/superposition_core/src/lib.rs
@@ -1,6 +1,8 @@
 #![deny(unused_crate_dependencies)]
 #[cfg(test)]
 use criterion as _;
+#[cfg(test)]
+use jsonlogic as _;
 
 uniffi::setup_scaffolding!("superposition_client");
 pub mod config;

--- a/crates/superposition_core/tests/test_filter_debug.rs
+++ b/crates/superposition_core/tests/test_filter_debug.rs
@@ -79,7 +79,7 @@ timeout = 90
 
     // Simulate what API does - filter by empty dimension data
     let empty_dimensions: Map<String, serde_json::Value> = Map::new();
-    let filtered_config = config.filter_by_dimensions(&empty_dimensions);
+    let filtered_config = config.filter_by_dimensions(empty_dimensions);
 
     println!("\n=== After filter (empty dimensions) ===");
     println!("Contexts count: {}", filtered_config.contexts.len());

--- a/crates/superposition_core/tests/test_filter_debug.rs
+++ b/crates/superposition_core/tests/test_filter_debug.rs
@@ -1,7 +1,7 @@
 use serde_json::{Map, Value};
 use superposition_core::{ConfigFormat, TomlFormat};
 use superposition_types::{
-    Config, DefaultConfigInfo, DefaultConfigsWithSchema, DetailedConfig,
+    Config, ConfigFilter, DefaultConfigInfo, DefaultConfigsWithSchema, DetailedConfig,
 };
 
 /// Helper function to convert Config to DetailedConfig by inferring schema from value.

--- a/crates/superposition_provider/src/client.rs
+++ b/crates/superposition_provider/src/client.rs
@@ -7,9 +7,9 @@ pub use open_feature::{
     EvaluationContext,
 };
 use serde_json::{Map, Value};
-use superposition_core::experiment::ExperimentGroups;
 use superposition_core::{
-    eval_config, get_applicable_variants, Experiments, MergeStrategy,
+    eval, experiment::ExperimentGroups, get_applicable_variants, Experiments,
+    MergeStrategy,
 };
 use superposition_types::{Config, DimensionInfo};
 use tokio::join;
@@ -243,25 +243,19 @@ impl CacConfig {
         exclude_prefix_filter: Option<&[String]>,
     ) -> Result<Map<String, Value>> {
         let cached_config = self.cached_config.read().await;
-        match cached_config.to_owned() {
+        match cached_config.as_ref() {
             Some(cached_config) => {
                 // Use ConversionUtils to evaluate config
-                eval_config(
-                    cached_config.default_configs,
-                    cached_config.contexts,
-                    cached_config.overrides,
-                    cached_config.dimensions,
+                Ok(eval(
+                    cached_config.default_configs.clone(),
+                    &cached_config.contexts,
+                    &cached_config.overrides,
+                    &cached_config.dimensions,
                     query_data,
                     MergeStrategy::MERGE,
                     prefix_filter.map(|p| p.to_vec()),
                     exclude_prefix_filter.map(|p| p.to_vec()),
-                )
-                .map_err(|e| {
-                    SuperpositionError::ConfigError(format!(
-                        "Failed to evaluate config: {}",
-                        e
-                    ))
-                })
+                ))
             }
             None => Err(SuperpositionError::ConfigError(
                 "No cached config available".into(),

--- a/crates/superposition_provider/src/client.rs
+++ b/crates/superposition_provider/src/client.rs
@@ -6,7 +6,7 @@ pub use open_feature::{
     provider::{ProviderMetadata, ProviderStatus, ResolutionDetails},
     EvaluationContext,
 };
-use serde_json::Value;
+use serde_json::{Map, Value};
 use superposition_core::experiment::ExperimentGroups;
 use superposition_core::{
     eval_config, get_applicable_variants, Experiments, MergeStrategy,
@@ -24,7 +24,7 @@ use crate::utils::ConversionUtils;
 pub struct CacConfig {
     superposition_options: SuperpositionOptions,
     options: ConfigurationOptions,
-    fallback_config: Option<serde_json::Map<String, Value>>,
+    fallback_config: Option<Map<String, Value>>,
     cached_config: Arc<RwLock<Option<Config>>>,
     last_updated: Arc<RwLock<Option<chrono::DateTime<chrono::Utc>>>>,
     polling_task_cancellation_token: Arc<RwLock<Option<CancellationToken>>>,
@@ -238,19 +238,19 @@ impl CacConfig {
     /// Evaluate configuration for given context and return resolved values
     pub async fn evaluate_config(
         &self,
-        query_data: &serde_json::Map<String, Value>,
+        query_data: Map<String, Value>,
         prefix_filter: Option<&[String]>,
         exclude_prefix_filter: Option<&[String]>,
-    ) -> Result<serde_json::Map<String, Value>> {
+    ) -> Result<Map<String, Value>> {
         let cached_config = self.cached_config.read().await;
-        match cached_config.as_ref() {
+        match cached_config.to_owned() {
             Some(cached_config) => {
                 // Use ConversionUtils to evaluate config
                 eval_config(
-                    (*cached_config.default_configs).clone(),
-                    &cached_config.contexts,
-                    &cached_config.overrides,
-                    &cached_config.dimensions,
+                    cached_config.default_configs,
+                    cached_config.contexts,
+                    cached_config.overrides,
+                    cached_config.dimensions,
                     query_data,
                     MergeStrategy::MERGE,
                     prefix_filter.map(|p| p.to_vec()),
@@ -591,7 +591,7 @@ impl ExperimentationConfig {
     pub async fn get_applicable_variants(
         &self,
         dimensions_info: &HashMap<String, DimensionInfo>,
-        contexts: &serde_json::Map<String, Value>,
+        contexts: Map<String, Value>,
         identifier: Option<String>,
     ) -> Result<Vec<String>> {
         let cached_experiments = self.cached_experiments.read().await;

--- a/crates/superposition_provider/src/conversions.rs
+++ b/crates/superposition_provider/src/conversions.rs
@@ -217,7 +217,9 @@ pub fn value_to_struct(value: Value) -> Result<open_feature::StructValue> {
 /// `open_feature::Value` has no null variant. Dropping the key leaves the rest of the
 /// object readable; erroring would make one null field render the entire flag
 /// unresolvable, which is what this used to do.
-fn object_fields(map: Map<String, Value>) -> Result<HashMap<String, open_feature::Value>> {
+fn object_fields(
+    map: Map<String, Value>,
+) -> Result<HashMap<String, open_feature::Value>> {
     let mut fields = HashMap::new();
     for (k, v) in map {
         if v.is_null() {
@@ -253,9 +255,11 @@ pub fn value_to_openfeature_value(value: Value) -> Result<open_feature::Value> {
                 .map(value_to_openfeature_value)
                 .collect::<Result<Vec<_>>>()?,
         )),
-        Value::Object(map) => Ok(open_feature::Value::Struct(open_feature::StructValue {
-            fields: object_fields(map)?,
-        })),
+        Value::Object(map) => {
+            Ok(open_feature::Value::Struct(open_feature::StructValue {
+                fields: object_fields(map)?,
+            }))
+        }
         // Reachable only for a null *array element*: object fields are filtered out by
         // `object_fields` first. Dropping it here would shift every later index, so this
         // stays an error.

--- a/crates/superposition_provider/src/data_source/file.rs
+++ b/crates/superposition_provider/src/data_source/file.rs
@@ -116,7 +116,7 @@ impl SuperpositionDataSource for FileDataSource {
         })?;
 
         config = config.filter(
-            context.as_ref(),
+            context,
             prefix_filter.map(PrefixList::from_iter).as_ref(),
             exclude_prefix_filter.map(PrefixList::from_iter).as_ref(),
         );

--- a/crates/superposition_provider/src/data_source/file.rs
+++ b/crates/superposition_provider/src/data_source/file.rs
@@ -6,7 +6,7 @@ use chrono::{DateTime, Utc};
 use notify::{Event, RecommendedWatcher, Watcher};
 use serde_json::{Map, Value};
 use superposition_core::{ConfigFormat, JsonFormat, TomlFormat};
-use superposition_types::PrefixList;
+use superposition_types::{ConfigFilter, PrefixList};
 use tokio::sync::broadcast;
 
 use crate::data_source::FetchResponse;

--- a/crates/superposition_provider/src/local_provider.rs
+++ b/crates/superposition_provider/src/local_provider.rs
@@ -545,7 +545,7 @@ impl LocalResolutionProvider {
                     &dimensions_info,
                     exp_data.data.experiments.clone(),
                     &exp_data.data.experiment_groups,
-                    &query_data,
+                    query_data.clone(),
                     &targeting_key.unwrap_or_default(),
                     prefix_filter.clone(),
                     exclude_prefix_filter.clone(),
@@ -561,22 +561,25 @@ impl LocalResolutionProvider {
         // Evaluate config using cached data
         let cached = self.cached_config.read().await;
         match cached.as_ref() {
-            Some(config_data) => eval_config(
-                (*config_data.data.default_configs).clone(),
-                &config_data.data.contexts,
-                &config_data.data.overrides,
-                &config_data.data.dimensions,
-                &query_data,
-                MergeStrategy::MERGE,
-                prefix_filter,
-                exclude_prefix_filter,
-            )
-            .map_err(|e| {
-                SuperpositionError::ConfigError(format!(
-                    "Failed to evaluate config: {}",
-                    e
-                ))
-            }),
+            Some(config_data) => {
+                let config = config_data.data.clone();
+                eval_config(
+                    config.default_configs,
+                    config.contexts,
+                    config.overrides,
+                    config.dimensions,
+                    query_data,
+                    MergeStrategy::MERGE,
+                    prefix_filter,
+                    exclude_prefix_filter,
+                )
+                .map_err(|e| {
+                    SuperpositionError::ConfigError(format!(
+                        "Failed to evaluate config: {}",
+                        e
+                    ))
+                })
+            }
             None => Err(SuperpositionError::ProviderError(
                 "Provider not initialized: no cached config available".into(),
             )),
@@ -616,7 +619,7 @@ impl FeatureExperimentMeta for LocalResolutionProvider {
                 &dimensions_info,
                 exp_data.data.experiments.clone(),
                 &exp_data.data.experiment_groups,
-                &query_data,
+                query_data,
                 &targeting_key.unwrap_or_default(),
                 prefix_filter,
                 exclude_prefix_filter,
@@ -731,11 +734,10 @@ impl SuperpositionDataSource for LocalResolutionProvider {
 
         let prefix = prefix_filter.map(PrefixList::from_iter);
         let exclude_prefix = exclude_prefix_filter.map(PrefixList::from_iter);
-        config_data.data = config_data.data.filter(
-            context.as_ref(),
-            prefix.as_ref(),
-            exclude_prefix.as_ref(),
-        );
+        config_data.data =
+            config_data
+                .data
+                .filter(context, prefix.as_ref(), exclude_prefix.as_ref());
 
         Ok(FetchResponse::Data(config_data))
     }

--- a/crates/superposition_provider/src/local_provider.rs
+++ b/crates/superposition_provider/src/local_provider.rs
@@ -11,10 +11,10 @@ use open_feature::{EvaluationContext, EvaluationResult, StructValue};
 use serde_json::{Map, Value};
 use superposition_core::experiment::{filter_experiments_by_context, FfiExperimentGroup};
 use superposition_core::{
-    eval_config, get_applicable_variants, get_satisfied_experiments, MergeStrategy,
+    eval, get_applicable_variants, get_satisfied_experiments, MergeStrategy,
 };
 use superposition_types::experimental::Experimental;
-use superposition_types::{DimensionInfo, PrefixList};
+use superposition_types::{ConfigFilter, DimensionInfo, PrefixList};
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, Duration};
@@ -561,25 +561,16 @@ impl LocalResolutionProvider {
         // Evaluate config using cached data
         let cached = self.cached_config.read().await;
         match cached.as_ref() {
-            Some(config_data) => {
-                let config = config_data.data.clone();
-                eval_config(
-                    config.default_configs,
-                    config.contexts,
-                    config.overrides,
-                    config.dimensions,
-                    query_data,
-                    MergeStrategy::MERGE,
-                    prefix_filter,
-                    exclude_prefix_filter,
-                )
-                .map_err(|e| {
-                    SuperpositionError::ConfigError(format!(
-                        "Failed to evaluate config: {}",
-                        e
-                    ))
-                })
-            }
+            Some(config_data) => Ok(eval(
+                config_data.data.default_configs.clone(),
+                &config_data.data.contexts,
+                &config_data.data.overrides,
+                &config_data.data.dimensions,
+                query_data,
+                MergeStrategy::MERGE,
+                prefix_filter,
+                exclude_prefix_filter,
+            )),
             None => Err(SuperpositionError::ProviderError(
                 "Provider not initialized: no cached config available".into(),
             )),

--- a/crates/superposition_provider/src/provider.rs
+++ b/crates/superposition_provider/src/provider.rs
@@ -121,7 +121,7 @@ impl SuperpositionProvider {
         let variant_ids = if let Some(exp_config) = &self.exp_config {
             let dimensions_info = self.get_dimensions_info().await;
             exp_config
-                .get_applicable_variants(&dimensions_info, &context, targeting_key)
+                .get_applicable_variants(&dimensions_info, context.clone(), targeting_key)
                 .await?
         } else {
             vec![]
@@ -133,7 +133,7 @@ impl SuperpositionProvider {
         );
 
         match &self.cac_config {
-            Some(cac_config) => cac_config.evaluate_config(&context, None, None).await,
+            Some(cac_config) => cac_config.evaluate_config(context, None, None).await,
             None => Err(SuperpositionError::ConfigError(
                 "CAC config not initialized".into(),
             )),
@@ -167,7 +167,7 @@ impl SuperpositionProvider {
         if let Some(dimension_filter) =
             dimension_filter.filter(|query_map| !query_map.is_empty())
         {
-            cached_config = cached_config.filter_by_dimensions(&dimension_filter);
+            cached_config = cached_config.filter_by_dimensions(dimension_filter);
         };
 
         Ok(cached_config)

--- a/crates/superposition_provider/src/provider.rs
+++ b/crates/superposition_provider/src/provider.rs
@@ -9,7 +9,7 @@ use open_feature::{
     StructValue,
 };
 use serde_json::{Map, Value};
-use superposition_types::{Config, DimensionInfo, PrefixList};
+use superposition_types::{Config, ConfigFilter, DimensionInfo, PrefixList};
 use tokio::sync::RwLock;
 
 use crate::types::*;

--- a/crates/superposition_provider/src/utils.rs
+++ b/crates/superposition_provider/src/utils.rs
@@ -499,7 +499,7 @@ impl ConversionUtils {
     /// Evaluate config using superposition_types logic and return resolved values
     pub fn evaluate_config(
         config: Config,
-        dimension_data: &Map<String, Value>,
+        dimension_data: Map<String, Value>,
         prefix_filter: Option<&[String]>,
         exclude_prefix_filter: Option<&[String]>,
     ) -> Result<HashMap<String, Value>> {
@@ -533,16 +533,17 @@ impl ConversionUtils {
             final_config.contexts.len()
         );
 
-        // Start with default configs
-        let mut result = final_config.default_configs.into_inner();
-
-        // Apply overrides based on context priority (higher priority wins)
-        let mut sorted_contexts = final_config.contexts.clone();
-        sorted_contexts.sort_by_key(|c| std::cmp::Reverse(c.priority)); // Sort by priority descending
+        let Config {
+            default_configs: mut result,
+            contexts: mut sorted_contexts,
+            overrides,
+            ..
+        } = final_config;
+        sorted_contexts.sort_by_key(|c| std::cmp::Reverse(c.weight));
 
         for context in sorted_contexts {
             if let Some(override_key) = context.override_with_keys.first() {
-                if let Some(overrides) = final_config.overrides.get(override_key) {
+                if let Some(overrides) = overrides.get(override_key) {
                     let override_map: Map<String, Value> = overrides.clone().into();
                     for (override_key, value) in override_map {
                         result.insert(override_key, value);
@@ -558,7 +559,8 @@ impl ConversionUtils {
         );
 
         // Convert Map<String, Value> to HashMap<String, Value>
-        let final_result: HashMap<String, Value> = result.into_iter().collect();
+        let final_result: HashMap<String, Value> =
+            result.into_inner().into_iter().collect();
         Ok(final_result)
     }
 }

--- a/crates/superposition_provider/src/utils.rs
+++ b/crates/superposition_provider/src/utils.rs
@@ -14,8 +14,8 @@ use superposition_types::database::models::experimentation::{
     Bucket, Buckets, ExperimentStatusType, GroupType, Variant, VariantType, Variants,
 };
 use superposition_types::{
-    Cac, Condition, Config, Context, DimensionInfo, Exp, ExtendedMap, OverrideWithKeys,
-    Overrides, PrefixList,
+    Cac, Condition, Config, ConfigFilter, Context, DimensionInfo, Exp, ExtendedMap,
+    OverrideWithKeys, Overrides, PrefixList,
 };
 
 use crate::{conversions, types::*};

--- a/crates/superposition_types/src/api/config.rs
+++ b/crates/superposition_types/src/api/config.rs
@@ -46,6 +46,7 @@ pub struct ExplainResolveQuery {
 pub struct ResolveConfigQuery {
     #[query_param(skip_if_empty)]
     pub version: Option<String>,
+    // TODO: Deprecate this
     pub show_reasoning: Option<bool>,
     pub resolve_remote: Option<bool>,
     #[query_param(skip_if_empty)]

--- a/crates/superposition_types/src/api/config.rs
+++ b/crates/superposition_types/src/api/config.rs
@@ -81,7 +81,7 @@ pub struct Explanation {
 }
 
 #[derive(
-    strum_macros::EnumString, Clone, strum_macros::Display, Default, uniffi::Enum,
+    strum_macros::EnumString, Clone, Copy, strum_macros::Display, Default, uniffi::Enum,
 )]
 #[strum(serialize_all = "snake_case")]
 pub enum MergeStrategy {

--- a/crates/superposition_types/src/config.rs
+++ b/crates/superposition_types/src/config.rs
@@ -247,6 +247,12 @@ impl Contextual for Context {
     }
 }
 
+impl Contextual for &Context {
+    fn get_condition(&self) -> &Condition {
+        &self.condition
+    }
+}
+
 #[derive(Serialize, Deserialize, PartialEq, Clone, Debug, Deref, DerefMut)]
 #[serde(try_from = "Vec<String>")]
 pub struct OverrideWithKeys([String; 1]);
@@ -295,11 +301,12 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn filter_by_dimensions(self, dimension_data: &Map<String, Value>) -> Self {
+    pub fn filter_by_dimensions(self, dimension_data: Map<String, Value>) -> Self {
         let modified_context =
             evaluate_local_cohorts_skip_unresolved(&self.dimensions, dimension_data);
 
-        let filtered_context = Context::filter_by_eval(self.contexts, &modified_context);
+        let filtered_context =
+            Contextual::filter_by_eval(self.contexts, &modified_context);
         let mut initial_overrides = self.overrides;
         let filtered_overrides: HashMap<String, Overrides> = filtered_context
             .iter()
@@ -355,13 +362,8 @@ impl Config {
             })
             .collect::<HashMap<_, _>>();
 
-        let filtered_context: Vec<Context> = self
-            .contexts
-            .into_iter()
-            .filter(|context| {
-                filtered_overrides.contains_key(context.override_with_keys.get_key())
-            })
-            .collect();
+        let mut filtered_context = contexts;
+        filtered_context.retain(|c| filtered_overrides.contains_key(c.override_key()));
 
         Self {
             contexts: filtered_context,
@@ -373,7 +375,7 @@ impl Config {
 
     pub fn filter(
         self,
-        dimension_data: Option<&Map<String, Value>>,
+        dimension_data: Option<Map<String, Value>>,
         prefix_list: Option<&PrefixList>,
         exclude_prefix_list: Option<&PrefixList>,
     ) -> Self {

--- a/crates/superposition_types/src/config.rs
+++ b/crates/superposition_types/src/config.rs
@@ -1,7 +1,10 @@
 #[cfg(test)]
 pub(crate) mod tests;
 
-use std::collections::{BTreeMap, HashMap};
+use std::{
+    borrow::{Borrow, Cow},
+    collections::{BTreeMap, HashMap},
+};
 
 use derive_more::{AsRef, Deref, DerefMut, Into};
 #[cfg(feature = "diesel_derives")]
@@ -301,31 +304,6 @@ pub struct Config {
 }
 
 impl Config {
-    pub fn filter_by_dimensions(self, dimension_data: Map<String, Value>) -> Self {
-        let modified_context =
-            evaluate_local_cohorts_skip_unresolved(&self.dimensions, dimension_data);
-
-        let filtered_context =
-            Contextual::filter_by_eval(self.contexts, &modified_context);
-        let mut initial_overrides = self.overrides;
-        let filtered_overrides: HashMap<String, Overrides> = filtered_context
-            .iter()
-            .flat_map(|ele| {
-                let override_with_key = ele.override_with_keys.get_key();
-                initial_overrides
-                    .remove(override_with_key)
-                    .map(|value| (override_with_key.to_string(), value))
-            })
-            .collect();
-
-        Self {
-            contexts: filtered_context,
-            overrides: filtered_overrides,
-            default_configs: self.default_configs,
-            dimensions: self.dimensions,
-        }
-    }
-
     pub fn filter_default_by_prefix(
         &self,
         prefix_list: &PrefixList,
@@ -338,17 +316,119 @@ impl Config {
         )
         .into()
     }
+}
 
-    pub fn filter_by_prefix(
+impl<'a> ConfigFilter<'a> for Config {
+    type Context = Context;
+    type Dimensions = HashMap<String, DimensionInfo>;
+
+    fn into_parts(
+        self,
+    ) -> (
+        Vec<Self::Context>,
+        Cow<'a, HashMap<String, Overrides>>,
+        ExtendedMap,
+        Self::Dimensions,
+    ) {
+        (
+            self.contexts,
+            Cow::Owned(self.overrides),
+            self.default_configs,
+            self.dimensions,
+        )
+    }
+
+    fn from_parts(
+        contexts: Vec<Self::Context>,
+        overrides: Cow<'a, HashMap<String, Overrides>>,
+        default_configs: ExtendedMap,
+        dimensions: Self::Dimensions,
+    ) -> Self {
+        Self {
+            contexts,
+            overrides: overrides.into_owned(),
+            default_configs,
+            dimensions,
+        }
+    }
+}
+
+// Lets a context be either owned or borrowed without touching `Contextual`.
+pub trait OverrideKeyed {
+    fn override_key(&self) -> &String;
+}
+
+impl<T: Borrow<Context>> OverrideKeyed for T {
+    fn override_key(&self) -> &String {
+        self.borrow().override_with_keys.get_key()
+    }
+}
+
+/// `'a` is the lifetime the overrides may be borrowed from: an owning config
+/// implements this for any `'a`, a borrowing one only for its own.
+pub trait ConfigFilter<'a>: Sized {
+    type Context: Contextual + OverrideKeyed;
+    type Dimensions: Borrow<HashMap<String, DimensionInfo>>;
+
+    #[allow(clippy::type_complexity)]
+    fn into_parts(
+        self,
+    ) -> (
+        Vec<Self::Context>,
+        Cow<'a, HashMap<String, Overrides>>,
+        ExtendedMap,
+        Self::Dimensions,
+    );
+
+    fn from_parts(
+        contexts: Vec<Self::Context>,
+        overrides: Cow<'a, HashMap<String, Overrides>>,
+        default_configs: ExtendedMap,
+        dimensions: Self::Dimensions,
+    ) -> Self;
+
+    fn filter_by_dimensions(self, dimension_data: Map<String, Value>) -> Self {
+        let (contexts, mut overrides, defaults, dims) = self.into_parts();
+        let modified_context =
+            evaluate_local_cohorts_skip_unresolved(dims.borrow(), dimension_data);
+        let filtered_context = Contextual::filter_by_eval(contexts, &modified_context);
+
+        let filtered_overrides = filtered_context
+            .iter()
+            .flat_map(|ele| {
+                let key = ele.override_key();
+                // move the override out when we own the map, clone it when we don't
+                match &mut overrides {
+                    Cow::Owned(overrides) => overrides.remove(key),
+                    Cow::Borrowed(overrides) => overrides.get(key).cloned(),
+                }
+                .map(|v| (key.to_string(), v))
+            })
+            .collect();
+
+        Self::from_parts(
+            filtered_context,
+            Cow::Owned(filtered_overrides),
+            defaults,
+            dims,
+        )
+    }
+
+    fn filter_by_prefix(
         self,
         prefix_list: &PrefixList,
         exclude_prefix_list: &PrefixList,
     ) -> Self {
-        let filtered_default_config =
-            self.filter_default_by_prefix(prefix_list, exclude_prefix_list);
+        let (contexts, overrides, defaults, dims) = self.into_parts();
+        let filtered_default_config: ExtendedMap = filter_into_config_keys_by_prefix(
+            defaults.into_inner(),
+            prefix_list,
+            exclude_prefix_list,
+        )
+        .into();
 
-        let filtered_overrides = self
-            .overrides
+        let filtered_overrides = overrides
+            .into_owned()
             .into_iter()
             .filter_map(|(key, overrides)| {
                 let filtered_overrides_map = filter_into_config_keys_by_prefix(
@@ -365,15 +445,15 @@ impl Config {
         let mut filtered_context = contexts;
         filtered_context.retain(|c| filtered_overrides.contains_key(c.override_key()));
 
-        Self {
-            contexts: filtered_context,
-            overrides: filtered_overrides,
-            default_configs: filtered_default_config,
-            dimensions: self.dimensions,
-        }
+        Self::from_parts(
+            filtered_context,
+            Cow::Owned(filtered_overrides),
+            filtered_default_config,
+            dims,
+        )
     }
 
-    pub fn filter(
+    fn filter(
         self,
         dimension_data: Option<Map<String, Value>>,
         prefix_list: Option<&PrefixList>,

--- a/crates/superposition_types/src/config/tests.rs
+++ b/crates/superposition_types/src/config/tests.rs
@@ -6,7 +6,7 @@ use map::{with_dimensions, without_dimensions};
 use serde_json::{from_value, json, Map, Number, Value};
 
 use super::Config;
-use crate::{ExtendedMap, PrefixList};
+use crate::{ConfigFilter, ExtendedMap, PrefixList};
 
 pub(crate) fn get_dimension_data1() -> Map<String, Value> {
     Map::from_iter(vec![(String::from("test3"), Value::Bool(true))])

--- a/crates/superposition_types/src/config/tests.rs
+++ b/crates/superposition_types/src/config/tests.rs
@@ -91,17 +91,17 @@ fn filter_by_dimensions_with_dimension() {
     let config = with_dimensions::get_config();
 
     assert_eq!(
-        config.clone().filter_by_dimensions(&get_dimension_data1()),
+        config.clone().filter_by_dimensions(get_dimension_data1()),
         with_dimensions::get_dimension_filtered_config1()
     );
 
     assert_eq!(
-        config.clone().filter_by_dimensions(&get_dimension_data2()),
+        config.clone().filter_by_dimensions(get_dimension_data2()),
         with_dimensions::get_dimension_filtered_config2()
     );
 
     assert_eq!(
-        config.filter_by_dimensions(&get_dimension_data3()),
+        config.filter_by_dimensions(get_dimension_data3()),
         get_dimension_filtered_config3_with_dimension()
     );
 }
@@ -111,17 +111,17 @@ fn filter_by_dimensions_without_dimension() {
     let config = without_dimensions::get_config();
 
     assert_eq!(
-        config.clone().filter_by_dimensions(&get_dimension_data1()),
+        config.clone().filter_by_dimensions(get_dimension_data1()),
         without_dimensions::get_dimension_filtered_config1()
     );
 
     assert_eq!(
-        config.clone().filter_by_dimensions(&get_dimension_data2()),
+        config.clone().filter_by_dimensions(get_dimension_data2()),
         without_dimensions::get_dimension_filtered_config2()
     );
 
     assert_eq!(
-        config.filter_by_dimensions(&get_dimension_data3()),
+        config.filter_by_dimensions(get_dimension_data3()),
         get_dimension_filtered_config3_without_dimension()
     );
 }

--- a/crates/superposition_types/src/contextual.rs
+++ b/crates/superposition_types/src/contextual.rs
@@ -5,7 +5,7 @@ use serde_json::{Map, Value};
 use crate::config::Condition;
 use crate::{logic, DimensionInfo};
 
-pub trait Contextual: Clone {
+pub trait Contextual: Sized {
     fn get_condition(&self) -> &Condition;
 
     fn filter_by_eval(

--- a/crates/superposition_types/src/contextual.rs
+++ b/crates/superposition_types/src/contextual.rs
@@ -9,53 +9,47 @@ pub trait Contextual: Sized {
     fn get_condition(&self) -> &Condition;
 
     fn filter_by_eval(
-        contexts: Vec<Self>,
+        mut contexts: Vec<Self>,
         dimension_data: &Map<String, Value>,
     ) -> Vec<Self> {
+        contexts.retain(|context| {
+            logic::partial_apply(context.get_condition(), dimension_data)
+        });
         contexts
-            .into_iter()
-            .filter(|context| {
-                logic::partial_apply(context.get_condition(), dimension_data)
-            })
-            .collect()
     }
 
     fn filter_exact_match(
-        contexts: Vec<Self>,
+        mut contexts: Vec<Self>,
         dimension_data: &Map<String, Value>,
     ) -> Vec<Self> {
+        contexts.retain(|context| {
+            let condition = context.get_condition();
+            logic::apply(condition, dimension_data)
+                && condition.len() == dimension_data.len()
+        });
         contexts
-            .into_iter()
-            .filter(|context| {
-                let condition = context.get_condition();
-                logic::apply(condition, dimension_data)
-                    && condition.len() == dimension_data.len()
-            })
-            .collect()
     }
 
     fn filter_by_dimension(
-        contexts: Vec<Self>,
+        mut contexts: Vec<Self>,
         original_dimension_keys: &[&String],
         dimensions_info: &HashMap<String, DimensionInfo>,
     ) -> Vec<Self> {
-        contexts
-            .into_iter()
-            .filter(|context| {
-                let variables = context.get_condition();
-                original_dimension_keys.iter().all(|dimension| {
-                    variables.contains_key(*dimension)
-                        || dimensions_info
-                            .get(*dimension)
-                            .map(|info| {
-                                info.dependency_graph
-                                    .keys()
-                                    .any(|k| variables.contains_key(k))
-                            })
-                            .unwrap_or_default()
-                })
+        contexts.retain(|context| {
+            let variables = context.get_condition();
+            original_dimension_keys.iter().all(|dimension| {
+                variables.contains_key(*dimension)
+                    || dimensions_info
+                        .get(*dimension)
+                        .map(|info| {
+                            info.dependency_graph
+                                .keys()
+                                .any(|k| variables.contains_key(k))
+                        })
+                        .unwrap_or_default()
             })
-            .collect()
+        });
+        contexts
     }
 }
 

--- a/crates/superposition_types/src/custom_query.rs
+++ b/crates/superposition_types/src/custom_query.rs
@@ -186,6 +186,12 @@ where
 #[serde(from = "HashMap<String,String>")]
 pub struct QueryMap(Map<String, Value>);
 
+impl QueryMap {
+    pub fn into_inner(self) -> Map<String, Value> {
+        self.0
+    }
+}
+
 impl IsEmpty for QueryMap {
     fn is_empty(&self) -> bool {
         self.0.is_empty()

--- a/crates/superposition_types/src/database/models/cac.rs
+++ b/crates/superposition_types/src/database/models/cac.rs
@@ -21,7 +21,7 @@ use serde_json::Value;
 #[cfg(feature = "diesel_derives")]
 use superposition_derives::{JsonFromSql, JsonToSql, TextFromSql, TextToSql};
 
-use crate::{Cac, Condition, Contextual, ExtendedMap, Overridden, Overrides};
+use crate::{Condition, Contextual, ExtendedMap, Overridden, Overrides};
 
 #[cfg(feature = "diesel_derives")]
 use super::super::schema::{
@@ -58,9 +58,9 @@ impl Contextual for Context {
     }
 }
 
-impl Overridden<Cac<Overrides>> for Context {
-    fn get_overrides(&self) -> Overrides {
-        self.override_.clone()
+impl Overridden for Context {
+    fn get_overrides_mut(&mut self) -> &mut Overrides {
+        &mut self.override_
     }
 }
 

--- a/crates/superposition_types/src/database/models/experimentation.rs
+++ b/crates/superposition_types/src/database/models/experimentation.rs
@@ -248,9 +248,9 @@ pub struct Variant {
     pub overrides: Exp<Overrides>,
 }
 
-impl Overridden<Exp<Overrides>> for Variant {
-    fn get_overrides(&self) -> Overrides {
-        self.overrides.clone().into_inner()
+impl Overridden for Variant {
+    fn get_overrides_mut(&mut self) -> &mut Overrides {
+        &mut self.overrides
     }
 }
 

--- a/crates/superposition_types/src/experimental.rs
+++ b/crates/superposition_types/src/experimental.rs
@@ -8,30 +8,26 @@ pub trait Experimental: Clone {
     fn get_condition(&self) -> &Condition;
 
     fn filter_by_eval(
-        experiments: Vec<Self>,
+        mut experiments: Vec<Self>,
         dimension_data: &Map<String, Value>,
     ) -> Vec<Self> {
+        experiments.retain(|exp| {
+            let condition = exp.get_condition();
+            if condition.is_empty() {
+                true
+            } else {
+                logic::partial_apply(condition, dimension_data)
+            }
+        });
         experiments
-            .into_iter()
-            .filter(|exp| {
-                let condition = exp.get_condition();
-                if condition.is_empty() {
-                    true
-                } else {
-                    logic::partial_apply(condition, dimension_data)
-                }
-            })
-            .collect()
     }
 
     fn get_satisfied(
-        experiments: Vec<Self>,
+        mut experiments: Vec<Self>,
         dimension_data: &Map<String, Value>,
     ) -> Vec<Self> {
+        experiments.retain(|exp| logic::apply(exp.get_condition(), dimension_data));
         experiments
-            .into_iter()
-            .filter(|exp| logic::apply(exp.get_condition(), dimension_data))
-            .collect()
     }
 }
 
@@ -39,32 +35,18 @@ pub trait ExperimentalVariants: Experimental {
     fn get_variants_mut(&mut self) -> &mut Vec<Variant>;
 
     fn filter_keys_by_prefix(
-        experiments: Vec<Self>,
+        mut experiments: Vec<Self>,
         prefix_list: &PrefixList,
         exclude_prefix_list: &PrefixList,
     ) -> Vec<Self> {
-        experiments
-            .into_iter()
-            .filter_map(|mut experiment| {
-                experiment.get_variants_mut().retain_mut(|variant| {
-                    Variant::filter_keys_by_prefix(
-                        variant,
-                        prefix_list,
-                        exclude_prefix_list,
-                    )
-                    .map(|filtered_overrides_map| {
-                        variant.overrides = filtered_overrides_map;
-                        true
-                    })
-                    .unwrap_or(false)
-                });
+        experiments.retain_mut(|experiment| {
+            experiment.get_variants_mut().retain_mut(|variant| {
+                Variant::filter_keys_by_prefix(variant, prefix_list, exclude_prefix_list)
+                    .is_ok()
+            });
 
-                if !experiment.get_variants_mut().is_empty() {
-                    Some(experiment)
-                } else {
-                    None // Skip this experiment
-                }
-            })
-            .collect()
+            !experiment.get_variants_mut().is_empty()
+        });
+        experiments
     }
 }

--- a/crates/superposition_types/src/lib.rs
+++ b/crates/superposition_types/src/lib.rs
@@ -39,8 +39,8 @@ use serde_json::{Map, Value};
 use superposition_derives::{JsonFromSql, JsonToSql};
 
 pub use config::{
-    Condition, Config, Context, DefaultConfigInfo, DefaultConfigsWithSchema,
-    DetailedConfig, DimensionInfo, OverrideWithKeys, Overrides,
+    Condition, Config, ConfigFilter, Context, DefaultConfigInfo,
+    DefaultConfigsWithSchema, DetailedConfig, DimensionInfo, OverrideWithKeys, Overrides,
 };
 pub use contextual::Contextual;
 pub use logic::{apply, partial_apply};
@@ -158,7 +158,7 @@ impl<T> Cac<T> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Copy, Serialize, Deref)]
+#[derive(Clone, Debug, PartialEq, Copy, Serialize, Deref, DerefMut)]
 pub struct Exp<T>(T);
 impl<T> Exp<T> {
     pub fn into_inner(self) -> T {

--- a/crates/superposition_types/src/lib.rs
+++ b/crates/superposition_types/src/lib.rs
@@ -384,6 +384,12 @@ impl From<Map<String, Value>> for ExtendedMap {
     }
 }
 
+impl FromIterator<(String, Value)> for ExtendedMap {
+    fn from_iter<T: IntoIterator<Item = (String, Value)>>(iter: T) -> Self {
+        Self(Map::from_iter(iter))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/superposition_types/src/logic.rs
+++ b/crates/superposition_types/src/logic.rs
@@ -77,8 +77,7 @@ pub fn partial_apply(
 }
 
 fn _evaluate_local_cohort_dimension(
-    cohort_based_on: &str,
-    cohort_based_on_value: &Value,
+    evaluation_data: &Value,
     schema: &Map<String, Value>,
 ) -> Option<String> {
     let definitions_object = schema.get("definitions")?.as_object()?;
@@ -95,8 +94,7 @@ fn _evaluate_local_cohort_dimension(
     for cohort_option in cohort_enums {
         let jsonlogic = definitions_object.get(cohort_option)?;
         // Find the first matching cohort definition
-        let evaluation_data = serde_json::json!({cohort_based_on: cohort_based_on_value});
-        if jsonlogic::apply(jsonlogic, &evaluation_data) == Ok(Value::Bool(true)) {
+        if jsonlogic::apply(jsonlogic, evaluation_data) == Ok(Value::Bool(true)) {
             return Some(cohort_option.to_string());
         }
     }
@@ -105,23 +103,29 @@ fn _evaluate_local_cohort_dimension(
 }
 
 fn evaluate_local_cohort_dimension(
-    cohort_based_on: &str,
-    cohort_based_on_value: &Value,
+    cohort_based_on: String,
+    cohort_based_on_value: Value,
     schema: &Map<String, Value>,
 ) -> String {
-    _evaluate_local_cohort_dimension(cohort_based_on, cohort_based_on_value, schema)
+    let evaluation_data =
+        Value::Object(Map::from_iter([(cohort_based_on, cohort_based_on_value)]));
+    _evaluate_local_cohort_dimension(&evaluation_data, schema)
         .unwrap_or_else(|| "otherwise".to_string())
 }
 
 /// Evaluates local cohort dependencies in a depth-first manner
 fn evaluate_local_cohorts_dependency(
     dimension: &str,
-    value: &Value,
     dependency_graph: &DependencyGraph,
     dimensions: &HashMap<String, DimensionInfo>,
     modified_context: &mut Map<String, Value>,
     query_data: &Map<String, Value>,
 ) {
+    let Some(value) = modified_context.get(dimension) else {
+        // This case is not possible, as the function is called only for dimensions that have been set in modified_context
+        return;
+    };
+
     let mut stack = dependency_graph
         .get(dimension)
         .cloned()
@@ -133,27 +137,23 @@ fn evaluate_local_cohorts_dependency(
     // Depth-first traversal of dependencies
     while let Some((cohort_dimension, based_on, based_on_val)) = stack.pop() {
         if let Some(dimension_info) = dimensions.get(&cohort_dimension) {
-            let mut cohort_val = None;
             match &dimension_info.dimension_type {
                 DimensionType::LocalCohort(_) => {
                     let cohort_value = Value::String(evaluate_local_cohort_dimension(
-                        &based_on,
-                        &based_on_val,
+                        based_on,
+                        based_on_val,
                         &dimension_info.schema,
                     ));
-                    modified_context
-                        .insert(cohort_dimension.clone(), cohort_value.clone());
-                    cohort_val = Some(cohort_value);
+                    modified_context.insert(cohort_dimension.clone(), cohort_value);
                 }
                 _ => {
                     if let Some(value) = query_data.get(&cohort_dimension) {
                         modified_context.insert(cohort_dimension.clone(), value.clone());
-                        cohort_val = Some(value.clone());
                     }
                 }
             }
 
-            if let Some(cohort_val) = cohort_val {
+            if let Some(cohort_val) = modified_context.get(&cohort_dimension) {
                 stack.extend(
                     dimension_info
                         .dependency_graph
@@ -171,27 +171,26 @@ fn evaluate_local_cohorts_dependency(
 
 fn _evaluate_local_cohorts(
     dimensions: &HashMap<String, DimensionInfo>,
-    query_data: &Map<String, Value>,
+    mut query_data: Map<String, Value>,
     skip_unresolved: bool,
 ) -> Map<String, Value> {
     if dimensions.is_empty() {
-        return query_data.clone();
+        return query_data;
     }
 
     let mut modified_context = Map::new();
 
     // Start from dimensions that are closest to root in each tree
-    for dimension_key in dimensions_to_start_from(dimensions, query_data) {
-        if let Some(value) = query_data.get(&dimension_key) {
+    for dimension_key in dimensions_to_start_from(dimensions, &query_data) {
+        if let Some(value) = query_data.remove(&dimension_key) {
             if let Some(dimension_info) = dimensions.get(&dimension_key) {
-                modified_context.insert(dimension_key.to_string(), value.clone());
+                modified_context.insert(dimension_key.to_string(), value);
                 evaluate_local_cohorts_dependency(
                     &dimension_key,
-                    value,
                     &dimension_info.dependency_graph,
                     dimensions,
                     &mut modified_context,
-                    query_data,
+                    &query_data,
                 );
             }
         }
@@ -227,7 +226,7 @@ fn _evaluate_local_cohorts(
 /// if the value provided for the local cohort was incorrect in the query data.
 pub fn evaluate_local_cohorts(
     dimensions: &HashMap<String, DimensionInfo>,
-    query_data: &Map<String, Value>,
+    query_data: Map<String, Value>,
 ) -> Map<String, Value> {
     _evaluate_local_cohorts(dimensions, query_data, false)
 }
@@ -235,7 +234,7 @@ pub fn evaluate_local_cohorts(
 /// Same as evaluate_local_cohorts but does not set unresolved local cohorts to "otherwise"
 pub fn evaluate_local_cohorts_skip_unresolved(
     dimensions: &HashMap<String, DimensionInfo>,
-    query_data: &Map<String, Value>,
+    query_data: Map<String, Value>,
 ) -> Map<String, Value> {
     _evaluate_local_cohorts(dimensions, query_data, true)
 }
@@ -256,10 +255,9 @@ pub fn dimensions_to_start_from(
         .collect::<Vec<String>>();
 
     for root_dimension in regular_dimensions {
-        let dependency_graph = &dimensions
+        let dependency_graph = dimensions
             .get(&root_dimension)
-            .map(|data| data.dependency_graph.clone())
-            .unwrap_or_default();
+            .map(|data| &data.dependency_graph);
 
         let mut stack = vec![root_dimension];
 
@@ -278,7 +276,7 @@ pub fn dimensions_to_start_from(
 
             stack.extend(
                 dependency_graph
-                    .get(&current_dimension)
+                    .and_then(|dg| dg.get(&current_dimension))
                     .cloned()
                     .unwrap_or_default(),
             );

--- a/crates/superposition_types/src/logic/tests.rs
+++ b/crates/superposition_types/src/logic/tests.rs
@@ -190,7 +190,7 @@ fn test_evaluate_local_cohorts_empty_dimensions() {
     .unwrap()
     .clone();
 
-    let result = evaluate_local_cohorts(&dimensions, &query_data);
+    let result = evaluate_local_cohorts(&dimensions, query_data.clone());
     assert_eq!(result, query_data);
 }
 
@@ -219,7 +219,7 @@ fn test_evaluate_local_cohorts_with_regular_dimension() {
     .unwrap()
     .clone();
 
-    let result = evaluate_local_cohorts(&dimensions, &query_data);
+    let result = evaluate_local_cohorts(&dimensions, query_data);
     assert_eq!(result.get("regular_dim"), Some(&json!("value1")));
 }
 
@@ -253,7 +253,7 @@ fn test_evaluate_local_cohorts_with_local_cohort_otherwise() {
 
     let query_data = Map::new();
 
-    let result = evaluate_local_cohorts(&dimensions, &query_data);
+    let result = evaluate_local_cohorts(&dimensions, query_data);
     assert_eq!(result.get("local_cohort_dim"), Some(&json!("otherwise")));
 }
 
@@ -301,7 +301,7 @@ fn test_evaluate_local_cohorts_with_dependency() {
     .unwrap()
     .clone();
 
-    let result = evaluate_local_cohorts(&dimensions, &query_data);
+    let result = evaluate_local_cohorts(&dimensions, query_data);
     assert_eq!(result.get("test"), Some(&json!("trigger_value")));
     assert_eq!(result.get("testdep"), Some(&json!("cohort1")));
 }
@@ -322,13 +322,19 @@ fn test_evaluate_local_cohort_dimension_function() {
     .unwrap()
     .clone();
 
-    let result = evaluate_local_cohort_dimension("test_value", &json!(42), &schema);
+    let result =
+        evaluate_local_cohort_dimension("test_value".to_string(), json!(42), &schema);
     assert_eq!(result, "exactly_42");
 
-    let result = evaluate_local_cohort_dimension("test_value", &json!(100), &schema);
+    let result =
+        evaluate_local_cohort_dimension("test_value".to_string(), json!(100), &schema);
     assert_eq!(result, "otherwise");
 
-    let result = evaluate_local_cohort_dimension("test_value", &json!("string"), &schema);
+    let result = evaluate_local_cohort_dimension(
+        "test_value".to_string(),
+        json!("string"),
+        &schema,
+    );
     assert_eq!(result, "otherwise");
 }
 
@@ -400,7 +406,7 @@ fn test_sample_dependency_graph() {
     assert_eq!(start_dims.len(), 1);
     assert!(start_dims.contains(&"test".to_string()));
 
-    let result = evaluate_local_cohorts(&dimensions, &query_data);
+    let result = evaluate_local_cohorts(&dimensions, query_data);
     assert_eq!(result.get("test"), Some(&json!("main_value")));
     assert_eq!(result.get("test_remote"), Some(&json!("remote_value_a")));
     assert_eq!(result.get("testdep"), Some(&json!("group_a")));
@@ -418,7 +424,7 @@ fn test_sample_dependency_graph() {
     assert!(start_dims2.contains(&"testtest".to_string()));
     assert!(start_dims2.contains(&"testdep".to_string()));
 
-    let result2 = evaluate_local_cohorts(&dimensions, &query_data2);
+    let result2 = evaluate_local_cohorts(&dimensions, query_data2);
     assert_eq!(result2.get("testtest"), Some(&json!("leaf_value")));
     assert_eq!(result2.get("testdep"), Some(&json!("otherwise")));
 }
@@ -648,7 +654,7 @@ fn test_evaluate_local_cohorts_missing_schema_definitions() {
     .unwrap()
     .clone();
 
-    let result = evaluate_local_cohorts(&dimensions, &query_data);
+    let result = evaluate_local_cohorts(&dimensions, query_data);
     assert_eq!(result.get("root"), Some(&json!("some_value")));
     assert_eq!(result.get("local_cohort"), Some(&json!("otherwise")));
 }
@@ -694,7 +700,7 @@ fn test_evaluate_local_cohorts_invalid_json_logic() {
     .unwrap()
     .clone();
 
-    let result = evaluate_local_cohorts(&dimensions, &query_data);
+    let result = evaluate_local_cohorts(&dimensions, query_data);
     assert_eq!(result.get("root"), Some(&json!("trigger_value")));
     assert_eq!(result.get("local_cohort"), Some(&json!("otherwise")));
 }
@@ -764,7 +770,7 @@ fn test_evaluate_local_cohorts_complex_json_logic() {
         .unwrap()
         .clone();
 
-        let result = evaluate_local_cohorts(&dimensions, &query_data);
+        let result = evaluate_local_cohorts(&dimensions, query_data);
         assert_eq!(result.get("user"), Some(&json!(user_value)));
         assert_eq!(result.get("cohort"), Some(&json!(expected_cohort)));
     }
@@ -825,7 +831,7 @@ fn test_evaluate_local_cohorts_remote_cohort_passthrough() {
     .unwrap()
     .clone();
 
-    let result = evaluate_local_cohorts(&dimensions, &query_data);
+    let result = evaluate_local_cohorts(&dimensions, query_data);
     assert_eq!(result.get("root"), Some(&json!("root_value")));
     assert_eq!(result.get("remote"), Some(&json!("remote_value_a")));
     assert_eq!(result.get("local"), Some(&json!("group_a")));
@@ -863,7 +869,7 @@ fn test_evaluate_local_cohorts_fills_missing_local_cohorts() {
     .unwrap()
     .clone();
 
-    let result = evaluate_local_cohorts(&dimensions, &query_data);
+    let result = evaluate_local_cohorts(&dimensions, query_data);
     assert_eq!(result.get("orphan_cohort"), Some(&json!("otherwise")));
 }
 
@@ -926,7 +932,11 @@ fn test_dimensions_to_start_from_with_multiple_regular_roots() {
 fn test_evaluate_local_cohort_dimension_edge_cases() {
     // Test with empty schema
     let empty_schema = Map::new();
-    let result = evaluate_local_cohort_dimension("test", &json!("value"), &empty_schema);
+    let result = evaluate_local_cohort_dimension(
+        "test".to_string(),
+        json!("value"),
+        &empty_schema,
+    );
     assert_eq!(result, "otherwise");
 
     // Test with schema missing enum
@@ -941,8 +951,11 @@ fn test_evaluate_local_cohort_dimension_edge_cases() {
     .unwrap()
     .clone();
 
-    let result =
-        evaluate_local_cohort_dimension("test", &json!("value"), &schema_no_enum);
+    let result = evaluate_local_cohort_dimension(
+        "test".to_string(),
+        json!("value"),
+        &schema_no_enum,
+    );
     assert_eq!(result, "otherwise");
 
     // Test with schema missing definitions
@@ -953,8 +966,11 @@ fn test_evaluate_local_cohort_dimension_edge_cases() {
     .unwrap()
     .clone();
 
-    let result =
-        evaluate_local_cohort_dimension("test", &json!("value"), &schema_no_definitions);
+    let result = evaluate_local_cohort_dimension(
+        "test".to_string(),
+        json!("value"),
+        &schema_no_definitions,
+    );
     assert_eq!(result, "otherwise");
 
     // Test with malformed enum (not array)
@@ -970,8 +986,11 @@ fn test_evaluate_local_cohort_dimension_edge_cases() {
     .unwrap()
     .clone();
 
-    let result =
-        evaluate_local_cohort_dimension("test", &json!("value"), &schema_bad_enum);
+    let result = evaluate_local_cohort_dimension(
+        "test".to_string(),
+        json!("value"),
+        &schema_bad_enum,
+    );
     assert_eq!(result, "otherwise");
 }
 
@@ -1046,7 +1065,7 @@ fn test_local_cohort_based_on_local_cohort() {
     .unwrap()
     .clone();
 
-    let result1 = evaluate_local_cohorts(&dimensions, &query_data1);
+    let result1 = evaluate_local_cohorts(&dimensions, query_data1);
     assert_eq!(result1.get("user_tier"), Some(&json!(1500)));
     assert_eq!(result1.get("user_category"), Some(&json!("premium")));
     assert_eq!(result1.get("user_segment"), Some(&json!("vip")));
@@ -1059,7 +1078,7 @@ fn test_local_cohort_based_on_local_cohort() {
     .unwrap()
     .clone();
 
-    let result2 = evaluate_local_cohorts(&dimensions, &query_data2);
+    let result2 = evaluate_local_cohorts(&dimensions, query_data2);
     assert_eq!(result2.get("user_tier"), Some(&json!(500)));
     assert_eq!(result2.get("user_category"), Some(&json!("standard")));
     assert_eq!(result2.get("user_segment"), Some(&json!("regular")));
@@ -1072,7 +1091,7 @@ fn test_local_cohort_based_on_local_cohort() {
     .unwrap()
     .clone();
 
-    let result3 = evaluate_local_cohorts(&dimensions, &query_data3);
+    let result3 = evaluate_local_cohorts(&dimensions, query_data3);
     assert_eq!(result3.get("user_tier"), Some(&json!(50)));
     assert_eq!(result3.get("user_category"), Some(&json!("basic")));
     assert_eq!(result3.get("user_segment"), Some(&json!("regular")));
@@ -1085,7 +1104,7 @@ fn test_local_cohort_based_on_local_cohort() {
     .unwrap()
     .clone();
 
-    let result4 = evaluate_local_cohorts(&dimensions, &query_data4);
+    let result4 = evaluate_local_cohorts(&dimensions, query_data4);
     assert_eq!(result4.get("user_tier"), Some(&json!(999)));
     assert_eq!(result4.get("user_category"), Some(&json!("otherwise")));
     assert_eq!(result4.get("user_segment"), Some(&json!("new")));
@@ -1166,7 +1185,7 @@ fn test_local_cohort_chain_with_intermediate_query_data() {
     assert_eq!(start_dims.len(), 1);
     assert!(start_dims.contains(&"country_group".to_string()));
 
-    let result = evaluate_local_cohorts(&dimensions, &query_data);
+    let result = evaluate_local_cohorts(&dimensions, query_data);
     assert_eq!(result.get("country_group"), Some(&json!("asia")));
     assert_eq!(result.get("market_segment"), Some(&json!("emerging")));
     // region should not be evaluated since it's not in the starting path
@@ -1267,7 +1286,7 @@ fn test_local_cohort_complex_branching() {
     .unwrap()
     .clone();
 
-    let result = evaluate_local_cohorts(&dimensions, &query_data);
+    let result = evaluate_local_cohorts(&dimensions, query_data);
     assert_eq!(result.get("device_type"), Some(&json!("android")));
     assert_eq!(result.get("device_category"), Some(&json!("mobile")));
     assert_eq!(result.get("ui_theme"), Some(&json!("dark")));
@@ -1281,7 +1300,7 @@ fn test_local_cohort_complex_branching() {
     .unwrap()
     .clone();
 
-    let result2 = evaluate_local_cohorts(&dimensions, &query_data2);
+    let result2 = evaluate_local_cohorts(&dimensions, query_data2);
     assert_eq!(result2.get("device_type"), Some(&json!("windows")));
     assert_eq!(result2.get("device_category"), Some(&json!("desktop")));
     assert_eq!(result2.get("ui_theme"), Some(&json!("light")));
@@ -1462,7 +1481,7 @@ fn test_multi_tree_complex_branching() {
     assert!(start_dims1.contains(&"location".to_string()));
     assert!(start_dims1.contains(&"user_tier".to_string()));
 
-    let result1 = evaluate_local_cohorts(&dimensions, &query_data1);
+    let result1 = evaluate_local_cohorts(&dimensions, query_data1);
     assert_eq!(result1.get("user_preferences"), Some(&json!("detailed")));
     assert_eq!(result1.get("location"), Some(&json!("usa")));
     assert_eq!(result1.get("region"), Some(&json!("west")));
@@ -1489,7 +1508,7 @@ fn test_multi_tree_complex_branching() {
     assert!(start_dims2.contains(&"timezone".to_string()));
     assert!(start_dims2.contains(&"region".to_string()));
 
-    let result2 = evaluate_local_cohorts(&dimensions, &query_data2);
+    let result2 = evaluate_local_cohorts(&dimensions, query_data2);
     assert_eq!(result2.get("user_id"), Some(&json!(1500)));
     assert_eq!(result2.get("user_tier"), Some(&json!("premium")));
     assert_eq!(result2.get("user_preferences"), Some(&json!("detailed")));
@@ -1729,7 +1748,7 @@ fn test_regular_overrides_local_cohort_in_query() {
     assert_eq!(start_dims1.len(), 1);
     assert!(start_dims1.contains(&"user_score".to_string()));
 
-    let result1 = evaluate_local_cohorts(&dimensions, &query_data1);
+    let result1 = evaluate_local_cohorts(&dimensions, query_data1);
     assert_eq!(result1.get("user_score"), Some(&json!(950)));
     assert_eq!(result1.get("user_category"), Some(&json!("gold")));
     assert_eq!(result1.get("reward_tier"), Some(&json!("premium")));
@@ -1747,7 +1766,7 @@ fn test_regular_overrides_local_cohort_in_query() {
     assert_eq!(start_dims2.len(), 1);
     assert!(start_dims2.contains(&"user_category".to_string()));
 
-    let result2 = evaluate_local_cohorts(&dimensions, &query_data2);
+    let result2 = evaluate_local_cohorts(&dimensions, query_data2);
     assert_eq!(result2.get("user_category"), Some(&json!("silver")));
     assert_eq!(result2.get("reward_tier"), Some(&json!("standard")));
 
@@ -1763,7 +1782,7 @@ fn test_regular_overrides_local_cohort_in_query() {
     assert_eq!(start_dims3.len(), 1);
     assert!(start_dims3.contains(&"user_category".to_string()));
 
-    let result3 = evaluate_local_cohorts(&dimensions, &query_data3);
+    let result3 = evaluate_local_cohorts(&dimensions, query_data3);
     assert_eq!(result3.get("user_category"), Some(&json!("otherwise")));
     assert_eq!(result3.get("reward_tier"), Some(&json!("otherwise")));
 
@@ -1777,7 +1796,7 @@ fn test_regular_overrides_local_cohort_in_query() {
     .unwrap()
     .clone();
 
-    let result4 = evaluate_local_cohorts(&dimensions, &query_data4);
+    let result4 = evaluate_local_cohorts(&dimensions, query_data4);
     assert_eq!(result4.get("user_score"), Some(&json!(300)));
     assert_eq!(result4.get("user_category"), Some(&json!("bronze")));
     assert_eq!(result4.get("reward_tier"), Some(&json!("basic")));

--- a/crates/superposition_types/src/overridden.rs
+++ b/crates/superposition_types/src/overridden.rs
@@ -67,14 +67,12 @@ pub(crate) fn filter_config_keys_by_prefix(
 }
 
 pub(crate) fn filter_into_config_keys_by_prefix(
-    overrides: Map<String, Value>,
+    mut overrides: Map<String, Value>,
     prefix_list: &PrefixList,
     exclude_prefix_list: &PrefixList,
 ) -> Map<String, Value> {
+    overrides.retain(|key, _| key_is_retained(key, prefix_list, exclude_prefix_list));
     overrides
-        .into_iter()
-        .filter(|(key, _)| key_is_retained(key, prefix_list, exclude_prefix_list))
-        .collect()
 }
 
 pub trait Overridden<T: TryFrom<Map<String, Value>>>: Clone {

--- a/crates/superposition_types/src/overridden.rs
+++ b/crates/superposition_types/src/overridden.rs
@@ -66,30 +66,42 @@ pub(crate) fn filter_config_keys_by_prefix(
         .collect()
 }
 
+pub(crate) fn filter_config_keys_by_prefix_mut(
+    overrides: &mut Map<String, Value>,
+    prefix_list: &PrefixList,
+    exclude_prefix_list: &PrefixList,
+) {
+    overrides.retain(|key, _| key_is_retained(key, prefix_list, exclude_prefix_list));
+}
+
 pub(crate) fn filter_into_config_keys_by_prefix(
     mut overrides: Map<String, Value>,
     prefix_list: &PrefixList,
     exclude_prefix_list: &PrefixList,
 ) -> Map<String, Value> {
-    overrides.retain(|key, _| key_is_retained(key, prefix_list, exclude_prefix_list));
+    filter_config_keys_by_prefix_mut(&mut overrides, prefix_list, exclude_prefix_list);
     overrides
 }
 
-pub trait Overridden<T: TryFrom<Map<String, Value>>>: Clone {
-    fn get_overrides(&self) -> Overrides;
+pub trait Overridden: Sized {
+    fn get_overrides_mut(&mut self) -> &mut Overrides;
 
     fn filter_keys_by_prefix(
-        context: &Self,
+        context: &mut Self,
         prefix_list: &PrefixList,
         exclude_prefix_list: &PrefixList,
-    ) -> Result<T, <T as TryFrom<Map<String, Value>>>::Error> {
-        let filtered_override = filter_config_keys_by_prefix(
-            &context.get_overrides(),
+    ) -> Result<(), String> {
+        filter_config_keys_by_prefix_mut(
+            context.get_overrides_mut(),
             prefix_list,
             exclude_prefix_list,
         );
 
-        T::try_from(filtered_override)
+        if context.get_overrides_mut().is_empty() {
+            Err("No overrides left after filtering".to_string())
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/examples/experimentation_client_integration_example/src/main.rs
+++ b/examples/experimentation_client_integration_example/src/main.rs
@@ -47,7 +47,7 @@ async fn get_variants(
     let variant = state
         .get_applicable_variant(
             &HashMap::new(),
-            &contexts.as_object().cloned().unwrap_or_default(),
+            contexts.as_object().cloned().unwrap_or_default(),
             &identifier,
             None,
             None,

--- a/examples/superposition_config_file_examples/src/main.rs
+++ b/examples/superposition_config_file_examples/src/main.rs
@@ -5,28 +5,28 @@ use superposition_core::{
 };
 
 fn evaluate_and_print(
-    config: &superposition_core::Config,
-    default_configs: &Map<String, Value>,
+    config: superposition_core::Config,
     description: &str,
-    dimensions: &Map<String, Value>,
+    dimensions: Map<String, Value>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!("\n--- {} ---", description);
 
+    let dims_str: Vec<String> = dimensions
+        .iter()
+        .map(|(k, v)| format!("{}={}", k, v))
+        .collect();
+
     let result = eval_config(
-        default_configs.clone(),
-        &config.contexts,
-        &config.overrides,
-        &config.dimensions,
+        config.default_configs,
+        config.contexts,
+        config.overrides,
+        config.dimensions,
         dimensions,
         MergeStrategy::MERGE,
         None,
         None,
     )?;
 
-    let dims_str: Vec<String> = dimensions
-        .iter()
-        .map(|(k, v)| format!("{}={}", k, v))
-        .collect();
     println!("Input dimensions: {}", dims_str.join(", "));
     println!("Resolved config:");
     println!(
@@ -98,7 +98,6 @@ fn run_toml_example() -> Result<(), Box<dyn std::error::Error>> {
 
     // Evaluate with different dimensions
     println!("\n--- Evaluating TOML Configuration ---");
-    let default_configs = (*config.default_configs).clone();
 
     // Example 1: Basic bike ride
     let mut dims1 = Map::new();
@@ -106,18 +105,13 @@ fn run_toml_example() -> Result<(), Box<dyn std::error::Error>> {
         "vehicle_type".to_string(),
         Value::String("bike".to_string()),
     );
-    evaluate_and_print(
-        &config,
-        &default_configs,
-        "Bike ride (no specific city)",
-        &dims1,
-    )?;
+    evaluate_and_print(config.clone(), "Bike ride (no specific city)", dims1)?;
 
     // Example 2: Cab ride in Bangalore
     let mut dims2 = Map::new();
     dims2.insert("city".to_string(), Value::String("Bangalore".to_string()));
     dims2.insert("vehicle_type".to_string(), Value::String("cab".to_string()));
-    evaluate_and_print(&config, &default_configs, "Cab ride in Bangalore", &dims2)?;
+    evaluate_and_print(config.clone(), "Cab ride in Bangalore", dims2)?;
 
     // Example 3: Cab ride in Delhi at 6 AM (morning surge)
     let mut dims3 = Map::new();
@@ -125,10 +119,9 @@ fn run_toml_example() -> Result<(), Box<dyn std::error::Error>> {
     dims3.insert("vehicle_type".to_string(), Value::String("cab".to_string()));
     dims3.insert("hour_of_day".to_string(), Value::Number(6.into()));
     evaluate_and_print(
-        &config,
-        &default_configs,
+        config.clone(),
         "Cab ride in Delhi at 6 AM (morning surge)",
-        &dims3,
+        dims3,
     )?;
 
     // Example 4: Auto ride (uses default values)
@@ -137,22 +130,12 @@ fn run_toml_example() -> Result<(), Box<dyn std::error::Error>> {
         "vehicle_type".to_string(),
         Value::String("auto".to_string()),
     );
-    evaluate_and_print(
-        &config,
-        &default_configs,
-        "Auto ride (uses default values)",
-        &dims4,
-    )?;
+    evaluate_and_print(config.clone(), "Auto ride (uses default values)", dims4)?;
 
     // Example 5: Chennai ride
     let mut dims5 = Map::new();
     dims5.insert("city".to_string(), Value::String("Chennai".to_string()));
-    evaluate_and_print(
-        &config,
-        &default_configs,
-        "Chennai ride (uses default values)",
-        &dims5,
-    )?;
+    evaluate_and_print(config, "Chennai ride (uses default values)", dims5)?;
 
     Ok(())
 }
@@ -187,7 +170,6 @@ fn run_json_example() -> Result<(), Box<dyn std::error::Error>> {
 
     // Evaluate with different dimensions
     println!("\n--- Evaluating JSON Configuration ---");
-    let default_configs = (*config.default_configs).clone();
 
     // Example 1: Basic bike ride
     let mut dims1 = Map::new();
@@ -195,18 +177,13 @@ fn run_json_example() -> Result<(), Box<dyn std::error::Error>> {
         "vehicle_type".to_string(),
         Value::String("bike".to_string()),
     );
-    evaluate_and_print(
-        &config,
-        &default_configs,
-        "Bike ride (no specific city)",
-        &dims1,
-    )?;
+    evaluate_and_print(config.clone(), "Bike ride (no specific city)", dims1)?;
 
     // Example 2: Cab ride in Bangalore
     let mut dims2 = Map::new();
     dims2.insert("city".to_string(), Value::String("Bangalore".to_string()));
     dims2.insert("vehicle_type".to_string(), Value::String("cab".to_string()));
-    evaluate_and_print(&config, &default_configs, "Cab ride in Bangalore", &dims2)?;
+    evaluate_and_print(config.clone(), "Cab ride in Bangalore", dims2)?;
 
     // Example 3: Cab ride in Delhi at 6 AM (morning surge)
     let mut dims3 = Map::new();
@@ -214,10 +191,9 @@ fn run_json_example() -> Result<(), Box<dyn std::error::Error>> {
     dims3.insert("vehicle_type".to_string(), Value::String("cab".to_string()));
     dims3.insert("hour_of_day".to_string(), Value::Number(6.into()));
     evaluate_and_print(
-        &config,
-        &default_configs,
+        config.clone(),
         "Cab ride in Delhi at 6 AM (morning surge)",
-        &dims3,
+        dims3,
     )?;
 
     // Example 4: Auto ride (uses default values)
@@ -226,22 +202,12 @@ fn run_json_example() -> Result<(), Box<dyn std::error::Error>> {
         "vehicle_type".to_string(),
         Value::String("auto".to_string()),
     );
-    evaluate_and_print(
-        &config,
-        &default_configs,
-        "Auto ride (uses default values)",
-        &dims4,
-    )?;
+    evaluate_and_print(config.clone(), "Auto ride (uses default values)", dims4)?;
 
     // Example 5: Chennai ride
     let mut dims5 = Map::new();
     dims5.insert("city".to_string(), Value::String("Chennai".to_string()));
-    evaluate_and_print(
-        &config,
-        &default_configs,
-        "Chennai ride (uses default values)",
-        &dims5,
-    )?;
+    evaluate_and_print(config, "Chennai ride (uses default values)", dims5)?;
 
     Ok(())
 }

--- a/examples/superposition_config_file_examples/src/main.rs
+++ b/examples/superposition_config_file_examples/src/main.rs
@@ -1,14 +1,12 @@
 use serde_json::{json, Map, Value};
 use std::fs;
-use superposition_core::{
-    eval_config, ConfigFormat, JsonFormat, MergeStrategy, TomlFormat,
-};
+use superposition_core::{eval, ConfigFormat, JsonFormat, MergeStrategy, TomlFormat};
 
 fn evaluate_and_print(
-    config: superposition_core::Config,
+    config: &superposition_core::Config,
     description: &str,
     dimensions: Map<String, Value>,
-) -> Result<(), Box<dyn std::error::Error>> {
+) {
     println!("\n--- {} ---", description);
 
     let dims_str: Vec<String> = dimensions
@@ -16,16 +14,16 @@ fn evaluate_and_print(
         .map(|(k, v)| format!("{}={}", k, v))
         .collect();
 
-    let result = eval_config(
-        config.default_configs,
-        config.contexts,
-        config.overrides,
-        config.dimensions,
+    let result = eval(
+        config.default_configs.clone(),
+        &config.contexts,
+        &config.overrides,
+        &config.dimensions,
         dimensions,
         MergeStrategy::MERGE,
         None,
         None,
-    )?;
+    );
 
     println!("Input dimensions: {}", dims_str.join(", "));
     println!("Resolved config:");
@@ -37,8 +35,6 @@ fn evaluate_and_print(
         "  surge_factor: {}",
         result.get("surge_factor").unwrap_or(&json!(null))
     );
-
-    Ok(())
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -105,24 +101,20 @@ fn run_toml_example() -> Result<(), Box<dyn std::error::Error>> {
         "vehicle_type".to_string(),
         Value::String("bike".to_string()),
     );
-    evaluate_and_print(config.clone(), "Bike ride (no specific city)", dims1)?;
+    evaluate_and_print(&config, "Bike ride (no specific city)", dims1);
 
     // Example 2: Cab ride in Bangalore
     let mut dims2 = Map::new();
     dims2.insert("city".to_string(), Value::String("Bangalore".to_string()));
     dims2.insert("vehicle_type".to_string(), Value::String("cab".to_string()));
-    evaluate_and_print(config.clone(), "Cab ride in Bangalore", dims2)?;
+    evaluate_and_print(&config, "Cab ride in Bangalore", dims2);
 
     // Example 3: Cab ride in Delhi at 6 AM (morning surge)
     let mut dims3 = Map::new();
     dims3.insert("city".to_string(), Value::String("Delhi".to_string()));
     dims3.insert("vehicle_type".to_string(), Value::String("cab".to_string()));
     dims3.insert("hour_of_day".to_string(), Value::Number(6.into()));
-    evaluate_and_print(
-        config.clone(),
-        "Cab ride in Delhi at 6 AM (morning surge)",
-        dims3,
-    )?;
+    evaluate_and_print(&config, "Cab ride in Delhi at 6 AM (morning surge)", dims3);
 
     // Example 4: Auto ride (uses default values)
     let mut dims4 = Map::new();
@@ -130,12 +122,12 @@ fn run_toml_example() -> Result<(), Box<dyn std::error::Error>> {
         "vehicle_type".to_string(),
         Value::String("auto".to_string()),
     );
-    evaluate_and_print(config.clone(), "Auto ride (uses default values)", dims4)?;
+    evaluate_and_print(&config, "Auto ride (uses default values)", dims4);
 
     // Example 5: Chennai ride
     let mut dims5 = Map::new();
     dims5.insert("city".to_string(), Value::String("Chennai".to_string()));
-    evaluate_and_print(config, "Chennai ride (uses default values)", dims5)?;
+    evaluate_and_print(&config, "Chennai ride (uses default values)", dims5);
 
     Ok(())
 }
@@ -177,24 +169,20 @@ fn run_json_example() -> Result<(), Box<dyn std::error::Error>> {
         "vehicle_type".to_string(),
         Value::String("bike".to_string()),
     );
-    evaluate_and_print(config.clone(), "Bike ride (no specific city)", dims1)?;
+    evaluate_and_print(&config, "Bike ride (no specific city)", dims1);
 
     // Example 2: Cab ride in Bangalore
     let mut dims2 = Map::new();
     dims2.insert("city".to_string(), Value::String("Bangalore".to_string()));
     dims2.insert("vehicle_type".to_string(), Value::String("cab".to_string()));
-    evaluate_and_print(config.clone(), "Cab ride in Bangalore", dims2)?;
+    evaluate_and_print(&config, "Cab ride in Bangalore", dims2);
 
     // Example 3: Cab ride in Delhi at 6 AM (morning surge)
     let mut dims3 = Map::new();
     dims3.insert("city".to_string(), Value::String("Delhi".to_string()));
     dims3.insert("vehicle_type".to_string(), Value::String("cab".to_string()));
     dims3.insert("hour_of_day".to_string(), Value::Number(6.into()));
-    evaluate_and_print(
-        config.clone(),
-        "Cab ride in Delhi at 6 AM (morning surge)",
-        dims3,
-    )?;
+    evaluate_and_print(&config, "Cab ride in Delhi at 6 AM (morning surge)", dims3);
 
     // Example 4: Auto ride (uses default values)
     let mut dims4 = Map::new();
@@ -202,12 +190,12 @@ fn run_json_example() -> Result<(), Box<dyn std::error::Error>> {
         "vehicle_type".to_string(),
         Value::String("auto".to_string()),
     );
-    evaluate_and_print(config.clone(), "Auto ride (uses default values)", dims4)?;
+    evaluate_and_print(&config, "Auto ride (uses default values)", dims4);
 
     // Example 5: Chennai ride
     let mut dims5 = Map::new();
     dims5.insert("city".to_string(), Value::String("Chennai".to_string()));
-    evaluate_and_print(config, "Chennai ride (uses default values)", dims5)?;
+    evaluate_and_print(&config, "Chennai ride (uses default values)", dims5);
 
     Ok(())
 }

--- a/examples/superposition_toml_example/src/main.rs
+++ b/examples/superposition_toml_example/src/main.rs
@@ -1,6 +1,6 @@
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 use std::fs;
-use superposition_core::{MergeStrategy, eval_config, parse_toml_config};
+use superposition_core::{eval_config, format::toml::parse_toml_config, MergeStrategy};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Superposition TOML Parser Example ===\n");
@@ -43,16 +43,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "vehicle_type".to_string(),
         Value::String("bike".to_string()),
     );
-    let config_clone = config.clone();
-    let result1 = eval_config(
-        config_clone.default_configs,
-        config_clone.contexts,
-        config_clone.overrides,
-        config_clone.dimensions,
-        dims1,
-        MergeStrategy::MERGE,
-        None,
-    )?;
+    let result1 = eval_config(config.clone(), dims1, MergeStrategy::MERGE, None, None);
 
     println!("Input dimensions: vehicle_type=bike");
     println!("Resolved config:");
@@ -71,16 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     dims2.insert("city".to_string(), Value::String("Bangalore".to_string()));
     dims2.insert("vehicle_type".to_string(), Value::String("cab".to_string()));
 
-    let config_clone = config.clone();
-    let result2 = eval_config(
-        config_clone.default_configs,
-        config_clone.contexts,
-        config_clone.overrides,
-        config_clone.dimensions,
-        dims2,
-        MergeStrategy::MERGE,
-        None,
-    )?;
+    let result2 = eval_config(config.clone(), dims2, MergeStrategy::MERGE, None, None);
 
     println!("Input dimensions: city=Bangalore, vehicle_type=cab");
     println!("Resolved config:");
@@ -100,16 +82,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     dims3.insert("vehicle_type".to_string(), Value::String("cab".to_string()));
     dims3.insert("hour_of_day".to_string(), Value::Number(6.into()));
 
-    let config_clone = config.clone();
-    let result3 = eval_config(
-        config_clone.default_configs,
-        config_clone.contexts,
-        config_clone.overrides,
-        config_clone.dimensions,
-        dims3,
-        MergeStrategy::MERGE,
-        None,
-    )?;
+    let result3 = eval_config(config.clone(), dims3, MergeStrategy::MERGE, None, None);
 
     println!("Input dimensions: city=Delhi, vehicle_type=cab, hour_of_day=6");
     println!("Resolved config:");
@@ -130,16 +103,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Value::String("auto".to_string()),
     );
 
-    let config_clone = config.clone();
-    let result4 = eval_config(
-        config_clone.default_configs,
-        config_clone.contexts,
-        config_clone.overrides,
-        config_clone.dimensions,
-        dims4,
-        MergeStrategy::MERGE,
-        None,
-    )?;
+    let result4 = eval_config(config.clone(), dims4, MergeStrategy::MERGE, None, None);
 
     println!("Input dimensions: vehicle_type=auto");
     println!("Resolved config:");
@@ -157,15 +121,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut dims5 = Map::new();
     dims5.insert("city".to_string(), Value::String("Chennai".to_string()));
 
-    let result5 = eval_config(
-        config.default_configs,
-        config.contexts,
-        config.overrides,
-        config.dimensions,
-        dims5,
-        MergeStrategy::MERGE,
-        None,
-    )?;
+    let result5 = eval_config(config.clone(), dims5, MergeStrategy::MERGE, None, None);
 
     println!("Input dimensions: city=Chennai");
     println!("Resolved config:");
@@ -187,15 +143,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Value::String("auto".to_string()),
     );
 
-    let result10 = eval_config(
-        default_configs.clone(),
-        &config.contexts,
-        &config.overrides,
-        &config.dimensions,
-        &dims10,
-        MergeStrategy::MERGE,
-        None,
-    )?;
+    let result10 = eval_config(config.clone(), dims10, MergeStrategy::MERGE, None, None);
 
     println!("Input: vehicle_type = auto");
     println!(
@@ -213,15 +161,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Value::String("auto".to_string()),
     );
 
-    let result11 = eval_config(
-        default_configs.clone(),
-        &config.contexts,
-        &config.overrides,
-        &config.dimensions,
-        &dims11,
-        MergeStrategy::MERGE,
-        None,
-    )?;
+    let result11 = eval_config(config.clone(), dims11, MergeStrategy::MERGE, None, None);
 
     println!("Input: city=Chennai, vehicle_type=auto");
     println!(
@@ -239,15 +179,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Value::String("auto".to_string()),
     );
 
-    let result11 = eval_config(
-        default_configs.clone(),
-        &config.contexts,
-        &config.overrides,
-        &config.dimensions,
-        &dims11,
-        MergeStrategy::MERGE,
-        None,
-    )?;
+    let result11 = eval_config(config, dims11, MergeStrategy::MERGE, None, None);
 
     println!("Input: city=Bangalore, vehicle_type=auto");
     println!(

--- a/examples/superposition_toml_example/src/main.rs
+++ b/examples/superposition_toml_example/src/main.rs
@@ -1,6 +1,6 @@
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 use std::fs;
-use superposition_core::{eval_config, parse_toml_config, MergeStrategy};
+use superposition_core::{MergeStrategy, eval_config, parse_toml_config};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("=== Superposition TOML Parser Example ===\n");
@@ -43,16 +43,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         "vehicle_type".to_string(),
         Value::String("bike".to_string()),
     );
-
-    // Clone default configs once for all evaluations
-    let default_configs = (*config.default_configs).clone();
-
+    let config_clone = config.clone();
     let result1 = eval_config(
-        default_configs.clone(),
-        &config.contexts,
-        &config.overrides,
-        &config.dimensions,
-        &dims1,
+        config_clone.default_configs,
+        config_clone.contexts,
+        config_clone.overrides,
+        config_clone.dimensions,
+        dims1,
         MergeStrategy::MERGE,
         None,
     )?;
@@ -74,12 +71,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     dims2.insert("city".to_string(), Value::String("Bangalore".to_string()));
     dims2.insert("vehicle_type".to_string(), Value::String("cab".to_string()));
 
+    let config_clone = config.clone();
     let result2 = eval_config(
-        default_configs.clone(),
-        &config.contexts,
-        &config.overrides,
-        &config.dimensions,
-        &dims2,
+        config_clone.default_configs,
+        config_clone.contexts,
+        config_clone.overrides,
+        config_clone.dimensions,
+        dims2,
         MergeStrategy::MERGE,
         None,
     )?;
@@ -102,12 +100,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     dims3.insert("vehicle_type".to_string(), Value::String("cab".to_string()));
     dims3.insert("hour_of_day".to_string(), Value::Number(6.into()));
 
+    let config_clone = config.clone();
     let result3 = eval_config(
-        default_configs.clone(),
-        &config.contexts,
-        &config.overrides,
-        &config.dimensions,
-        &dims3,
+        config_clone.default_configs,
+        config_clone.contexts,
+        config_clone.overrides,
+        config_clone.dimensions,
+        dims3,
         MergeStrategy::MERGE,
         None,
     )?;
@@ -131,12 +130,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         Value::String("auto".to_string()),
     );
 
+    let config_clone = config.clone();
     let result4 = eval_config(
-        default_configs.clone(),
-        &config.contexts,
-        &config.overrides,
-        &config.dimensions,
-        &dims4,
+        config_clone.default_configs,
+        config_clone.contexts,
+        config_clone.overrides,
+        config_clone.dimensions,
+        dims4,
         MergeStrategy::MERGE,
         None,
     )?;
@@ -158,11 +158,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     dims5.insert("city".to_string(), Value::String("Chennai".to_string()));
 
     let result5 = eval_config(
-        default_configs.clone(),
-        &config.contexts,
-        &config.overrides,
-        &config.dimensions,
-        &dims5,
+        config.default_configs,
+        config.contexts,
+        config.overrides,
+        config.dimensions,
+        dims5,
         MergeStrategy::MERGE,
         None,
     )?;


### PR DESCRIPTION
## Problem
Too much unnecessary cloning of data in eval logic

## Solution
Take ownership of data in functions wherever necessary instead of borrowing and then cloning inside the functions, allowing the caller functions to decide upon necessary cloning and ownership transfer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streamlined configuration evaluation APIs for direct resolution of configurations and experimentation data.
  * Added support for evaluating configuration data through foreign-function interfaces, including new Python and Kotlin bindings.
  * Added flexible filtering by dimensions and key prefixes.
  * Added utilities for extracting query data and building extended configuration maps.

* **Bug Fixes**
  * Improved override merging and context filtering behavior.
  * Reduced unnecessary data copying during configuration and cohort evaluation.
  * Lowered routine experiment bucketing diagnostics to debug-level logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->