### PR TITLE
fix(python): Add missing SuperpositionDataSource implementation for LocalResolutionProvider

### DIFF
--- a/clients/java/bindings/src/main/kotlin/uniffi/superposition_client/superposition_client.kt
+++ b/clients/java/bindings/src/main/kotlin/uniffi/superposition_client/superposition_client.kt
@@ -877,7 +877,7 @@ fun uniffi_superposition_core_fn_method_providercache_eval_config(`ptr`: Pointer
 ): RustBuffer.ByValue
 fun uniffi_superposition_core_fn_method_providercache_filter_config(`ptr`: Pointer,`dimensionData`: RustBuffer.ByValue,`prefix`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBufferConfig.ByValue
-fun uniffi_superposition_core_fn_method_providercache_filter_experiment(`ptr`: Pointer,`dimensionData`: RustBuffer.ByValue,`prefix`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
+fun uniffi_superposition_core_fn_method_providercache_filter_experiment(`ptr`: Pointer,`dimensionData`: RustBuffer.ByValue,`prefix`: RustBuffer.ByValue,`partialApply`: Byte,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
 fun uniffi_superposition_core_fn_method_providercache_get_applicable_variants(`ptr`: Pointer,`dimensionData`: RustBuffer.ByValue,`prefix`: RustBuffer.ByValue,`targetingKey`: RustBuffer.ByValue,uniffi_out_err: UniffiRustCallStatus, 
 ): RustBuffer.ByValue
@@ -1047,7 +1047,7 @@ private fun uniffiCheckApiChecksums(lib: IntegrityCheckingUniffiLib) {
     if (lib.uniffi_superposition_core_checksum_method_providercache_filter_config() != 21761.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
-    if (lib.uniffi_superposition_core_checksum_method_providercache_filter_experiment() != 60575.toShort()) {
+    if (lib.uniffi_superposition_core_checksum_method_providercache_filter_experiment() != 31120.toShort()) {
         throw RuntimeException("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     }
     if (lib.uniffi_superposition_core_checksum_method_providercache_get_applicable_variants() != 12269.toShort()) {
@@ -1231,6 +1231,29 @@ public object FfiConverterUByte: FfiConverter<UByte, Byte> {
 /**
  * @suppress
  */
+public object FfiConverterBoolean: FfiConverter<Boolean, Byte> {
+    override fun lift(value: Byte): Boolean {
+        return value.toInt() != 0
+    }
+
+    override fun read(buf: ByteBuffer): Boolean {
+        return lift(buf.get())
+    }
+
+    override fun lower(value: Boolean): Byte {
+        return if (value) 1.toByte() else 0.toByte()
+    }
+
+    override fun allocationSize(value: Boolean) = 1UL
+
+    override fun write(value: Boolean, buf: ByteBuffer) {
+        buf.put(lower(value))
+    }
+}
+
+/**
+ * @suppress
+ */
 public object FfiConverterString: FfiConverter<String, RustBuffer.ByValue> {
     // Note: we don't inherit from FfiConverterRustBuffer, because we use a
     // special encoding when lowering/lifting.  We can use `RustBuffer.len` to
@@ -1390,7 +1413,7 @@ public interface ProviderCacheInterface {
     
     fun `filterConfig`(`dimensionData`: Map<kotlin.String, kotlin.String>?, `prefix`: List<kotlin.String>?): Config
     
-    fun `filterExperiment`(`dimensionData`: Map<kotlin.String, kotlin.String>?, `prefix`: List<kotlin.String>?): ExperimentConfig
+    fun `filterExperiment`(`dimensionData`: Map<kotlin.String, kotlin.String>?, `prefix`: List<kotlin.String>?, `partialApply`: kotlin.Boolean): ExperimentConfig
     
     fun `getApplicableVariants`(`dimensionData`: Map<kotlin.String, kotlin.String>?, `prefix`: List<kotlin.String>?, `targetingKey`: kotlin.String): List<kotlin.String>
     
@@ -1517,12 +1540,12 @@ open class ProviderCache: Disposable, AutoCloseable, ProviderCacheInterface
     
 
     
-    @Throws(OperationException::class)override fun `filterExperiment`(`dimensionData`: Map<kotlin.String, kotlin.String>?, `prefix`: List<kotlin.String>?): ExperimentConfig {
+    @Throws(OperationException::class)override fun `filterExperiment`(`dimensionData`: Map<kotlin.String, kotlin.String>?, `prefix`: List<kotlin.String>?, `partialApply`: kotlin.Boolean): ExperimentConfig {
             return FfiConverterTypeExperimentConfig.lift(
     callWithPointer {
     uniffiRustCallWithError(OperationException) { _status ->
     UniffiLib.INSTANCE.uniffi_superposition_core_fn_method_providercache_filter_experiment(
-        it, FfiConverterOptionalMapStringString.lower(`dimensionData`),FfiConverterOptionalSequenceString.lower(`prefix`),_status)
+        it, FfiConverterOptionalMapStringString.lower(`dimensionData`),FfiConverterOptionalSequenceString.lower(`prefix`),FfiConverterBoolean.lower(`partialApply`),_status)
 }
     }
     )

--- a/clients/python/bindings/superposition_bindings/superposition_client.py
+++ b/clients/python/bindings/superposition_bindings/superposition_client.py
@@ -511,7 +511,7 @@ def _uniffi_check_api_checksums(lib):
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_superposition_core_checksum_method_providercache_filter_config() != 21761:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
-    if lib.uniffi_superposition_core_checksum_method_providercache_filter_experiment() != 60575:
+    if lib.uniffi_superposition_core_checksum_method_providercache_filter_experiment() != 31120:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
     if lib.uniffi_superposition_core_checksum_method_providercache_get_applicable_variants() != 12269:
         raise InternalError("UniFFI API checksum mismatch: try cleaning and rebuilding your project")
@@ -661,6 +661,7 @@ _UniffiLib.uniffi_superposition_core_fn_method_providercache_filter_experiment.a
     ctypes.c_void_p,
     _UniffiRustBuffer,
     _UniffiRustBuffer,
+    ctypes.c_int8,
     ctypes.POINTER(_UniffiRustCallStatus),
 )
 _UniffiLib.uniffi_superposition_core_fn_method_providercache_filter_experiment.restype = _UniffiRustBuffer
@@ -1066,6 +1067,27 @@ class _UniffiConverterUInt8(_UniffiConverterPrimitiveInt):
 
     @staticmethod
     def write(value, buf):
+        buf.write_u8(value)
+
+class _UniffiConverterBool:
+    @classmethod
+    def check_lower(cls, value):
+        return not not value
+
+    @classmethod
+    def lower(cls, value):
+        return 1 if value else 0
+
+    @staticmethod
+    def lift(value):
+        return value != 0
+
+    @classmethod
+    def read(cls, buf):
+        return cls.lift(buf.read_u8())
+
+    @classmethod
+    def write(cls, value, buf):
         buf.write_u8(value)
 
 class _UniffiConverterString:
@@ -1747,7 +1769,7 @@ class ProviderCacheProtocol(typing.Protocol):
         raise NotImplementedError
     def filter_config(self, dimension_data: "typing.Optional[dict[str, str]]",prefix: "typing.Optional[typing.List[str]]"):
         raise NotImplementedError
-    def filter_experiment(self, dimension_data: "typing.Optional[dict[str, str]]",prefix: "typing.Optional[typing.List[str]]"):
+    def filter_experiment(self, dimension_data: "typing.Optional[dict[str, str]]",prefix: "typing.Optional[typing.List[str]]",partial_apply: "bool"):
         raise NotImplementedError
     def get_applicable_variants(self, dimension_data: "typing.Optional[dict[str, str]]",prefix: "typing.Optional[typing.List[str]]",targeting_key: "str"):
         raise NotImplementedError
@@ -1816,15 +1838,18 @@ class ProviderCache():
 
 
 
-    def filter_experiment(self, dimension_data: "typing.Optional[dict[str, str]]",prefix: "typing.Optional[typing.List[str]]") -> "ExperimentConfig":
+    def filter_experiment(self, dimension_data: "typing.Optional[dict[str, str]]",prefix: "typing.Optional[typing.List[str]]",partial_apply: "bool") -> "ExperimentConfig":
         _UniffiConverterOptionalMapStringString.check_lower(dimension_data)
         
         _UniffiConverterOptionalSequenceString.check_lower(prefix)
         
+        _UniffiConverterBool.check_lower(partial_apply)
+        
         return _UniffiConverterTypeExperimentConfig.lift(
             _uniffi_rust_call_with_error(_UniffiConverterTypeOperationError,_UniffiLib.uniffi_superposition_core_fn_method_providercache_filter_experiment,self._uniffi_clone_pointer(),
         _UniffiConverterOptionalMapStringString.lower(dimension_data),
-        _UniffiConverterOptionalSequenceString.lower(prefix))
+        _UniffiConverterOptionalSequenceString.lower(prefix),
+        _UniffiConverterBool.lower(partial_apply))
         )
 
 

--- a/clients/python/provider/superposition_provider/data_source.py
+++ b/clients/python/provider/superposition_provider/data_source.py
@@ -77,7 +77,6 @@ class SuperpositionDataSource(ABC):
     while consumers interact with this unified interface.
     """
 
-    @abstractmethod
     async def fetch_config(
         self,
         if_modified_since: Optional[datetime] = None,
@@ -90,7 +89,7 @@ class SuperpositionDataSource(ABC):
         Returns:
             FetchResponse with ConfigData or NotModified status.
         """
-        pass
+        return await self.fetch_filtered_config(if_modified_since=if_modified_since)
 
     @abstractmethod
     async def fetch_filtered_config(

--- a/clients/python/provider/superposition_provider/file_data_source.py
+++ b/clients/python/provider/superposition_provider/file_data_source.py
@@ -100,51 +100,6 @@ class FileDataSource(SuperpositionDataSource):
         else:
             raise ValueError(f"Unsupported file format: {file_path}")
 
-    async def _fetch_config_with_filters(
-        self,
-        context: Optional[Dict[str, Any]] = None,
-        prefix_filter: Optional[List[str]] = None,
-        if_modified_since: Optional[datetime] = None,
-    ) -> FetchResponse[ConfigData]:
-        """Fetch configuration from file, applying filters and 304 Not Modified logic.
-        Args:
-            context: Optional context for filtering (ignored).
-            prefix_filter: Optional key prefixes to include.
-            if_modified_since: Timestamp for 304 Not Modified check.
-        """
-        if if_modified_since is not None:
-            logger.debug("FileDataSource: ignoring if_modified_since, always reading fresh from file")
-
-        try:
-            now = datetime.now(timezone.utc)
-            # Read and parse file
-            with open(self.file_path, 'r') as f:
-                content = f.read()
-
-            config = _parse_config_file(content, self.file_format, context, prefix_filter)
-
-            return FetchResponse.data(ConfigData(
-                data=config,
-                fetched_at=now,
-            ))
-        except Exception as e:
-            logger.error(f"Failed to fetch config from {self.file_path}: {e}")
-            raise
-
-    async def fetch_config(
-        self,
-        if_modified_since: Optional[datetime] = None,
-    ) -> FetchResponse[ConfigData]:
-        """Fetch configuration from file.
-
-        Args:
-            if_modified_since: Timestamp for 304 Not Modified check.
-
-        Returns:
-            FetchResponse with ConfigData or NotModified status.
-        """
-        return await self._fetch_config_with_filters(if_modified_since=if_modified_since)
-
     async def fetch_filtered_config(
         self,
         context: Optional[Dict[str, Any]] = None,
@@ -164,7 +119,24 @@ class FileDataSource(SuperpositionDataSource):
         Returns:
             FetchResponse with ConfigData or NotModified status.
         """
-        return await self._fetch_config_with_filters(context, prefix_filter, if_modified_since)
+        if if_modified_since is not None:
+            logger.debug("FileDataSource: ignoring if_modified_since, always reading fresh from file")
+
+        try:
+            now = datetime.now(timezone.utc)
+            # Read and parse file
+            with open(self.file_path, 'r') as f:
+                content = f.read()
+
+            config = _parse_config_file(content, self.file_format, context, prefix_filter)
+
+            return FetchResponse.data(ConfigData(
+                data=config,
+                fetched_at=now,
+            ))
+        except Exception as e:
+            logger.error(f"Failed to fetch config from {self.file_path}: {e}")
+            raise
 
     async def fetch_active_experiments(
         self,

--- a/clients/python/provider/superposition_provider/http_data_source.py
+++ b/clients/python/provider/superposition_provider/http_data_source.py
@@ -62,12 +62,22 @@ class HttpDataSource(SuperpositionDataSource):
         # Create Superposition client
         return Superposition(config=sdk_config)
 
-    async def _fetch_config_with_filters(
+    async def fetch_filtered_config(
         self,
         context: Optional[Dict[str, Any]] = None,
         prefix_filter: Optional[List[str]] = None,
-        if_modified_since: Optional[datetime] = None
+        if_modified_since: Optional[datetime] = None,
     ) -> FetchResponse[ConfigData]:
+        """Fetch resolved configuration filtered by context and prefixes.
+
+        Args:
+            context: Optional context for filtering.
+            prefix_filter: Optional list of key prefixes to include.
+            if_modified_since: Optional timestamp for 304 Not Modified check.
+
+        Returns:
+            FetchResponse with ConfigData or NotModified status.
+        """
         try:
             context = {k: Document(v) for k, v in context.items()} if context else None
             response = await self.client.get_config(
@@ -88,38 +98,6 @@ class HttpDataSource(SuperpositionDataSource):
             return FetchResponse.not_modified()
         except Exception as e:
             raise e
-
-    async def fetch_config(
-        self,
-        if_modified_since: Optional[datetime] = None,
-    ) -> FetchResponse:
-        """Fetch full resolved configuration.
-
-        Args:
-            if_modified_since: Optional timestamp for 304 Not Modified check.
-
-        Returns:
-            FetchResponse with ConfigData or NotModified status.
-        """
-        return await self._fetch_config_with_filters(if_modified_since=if_modified_since)
-
-    async def fetch_filtered_config(
-        self,
-        context: Optional[Dict[str, Any]] = None,
-        prefix_filter: Optional[List[str]] = None,
-        if_modified_since: Optional[datetime] = None,
-    ) -> FetchResponse:
-        """Fetch resolved configuration filtered by context and prefixes.
-
-        Args:
-            context: Optional context for filtering.
-            prefix_filter: Optional list of key prefixes to include.
-            if_modified_since: Optional timestamp for 304 Not Modified check.
-
-        Returns:
-            FetchResponse with ConfigData or NotModified status.
-        """
-        return await self._fetch_config_with_filters(context, prefix_filter, if_modified_since)
 
     async def _fetch_filtered_experiment(
         self,
@@ -173,7 +151,7 @@ class HttpDataSource(SuperpositionDataSource):
         context: Optional[Dict[str, Any]] = None,
         prefix_filter: Optional[List[str]] = None,
         if_modified_since: Optional[datetime] = None,
-    ) -> FetchResponse:
+    ) -> FetchResponse[ExperimentData]:
         """Fetch active experiments with candidate conditions.
 
         Args:

--- a/clients/python/provider/superposition_provider/local_provider.py
+++ b/clients/python/provider/superposition_provider/local_provider.py
@@ -22,13 +22,14 @@ from openfeature.flag_evaluation import FlagResolutionDetails
 from superposition_bindings.superposition_client import ProviderCache
 from superposition_bindings.superposition_types import MergeStrategy
 
+from . import FetchResponse
 from .data_source import SuperpositionDataSource, ConfigData, ExperimentData
 from .interfaces import AllFeatureProvider, FeatureExperimentMeta
 from .types import RefreshStrategy, OnDemandStrategy, WatchStrategy, PollingStrategy, ManualStrategy, default_on_demand_strategy
 
 logger = logging.getLogger(__name__)
 
-class LocalResolutionProvider(AbstractProvider, AllFeatureProvider, FeatureExperimentMeta):
+class LocalResolutionProvider(AbstractProvider, AllFeatureProvider, FeatureExperimentMeta, SuperpositionDataSource):
     """Local in-process OpenFeature provider with caching and refresh strategies.
 
     Features:
@@ -531,3 +532,107 @@ class LocalResolutionProvider(AbstractProvider, AllFeatureProvider, FeatureExper
         """Update ffi exp config cache with new values."""
         exp = self.cached_experiments.data
         self.ffi_cache.init_experiments(exp.experiments, exp.experiment_groups)
+
+
+    async def fetch_filtered_config(
+        self,
+        context: Optional[Dict[str, Any]] = None,
+        prefix_filter: Optional[List[str]] = None,
+        if_modified_since: Optional[datetime] = None,
+    ) -> FetchResponse[ConfigData]:
+        """Fetch configuration, optionally filtered.
+
+        Note: File-based filtering is not efficient; consider using HttpDataSource
+        for production configurations that need filtering.
+
+        Args:
+            context: Optional context for filtering (ignored).
+            prefix_filter: Optional key prefixes to include.
+            if_modified_since: Timestamp for 304 Not Modified check.
+
+        Returns:
+            FetchResponse with ConfigData or NotModified status.
+        """
+        if not self.ffi_cache or not self.cached_config:
+            raise RuntimeError("Provider not properly initialized or no config available")
+
+        if if_modified_since is not None:
+            logger.debug("LocalResolutionProvider: ignoring if_modified_since, always reading fresh from file")
+
+        return FetchResponse.data(ConfigData(
+            data=self.ffi_cache.filter_config(context, prefix_filter),
+            fetched_at=self.cached_config.fetched_at,
+        ))
+
+    async def fetch_active_experiments(
+        self,
+        if_modified_since: Optional[datetime] = None,
+    ) -> FetchResponse[ExperimentData]:
+        """Fetch experiments from file.
+
+        Args:
+            if_modified_since: Timestamp for 304 Not Modified check.
+
+        Returns:
+            FetchResponse with ExperimentData or NotModified status.
+        """
+        if not self.supports_experiments():
+            raise NotImplementedError("Experiments not supported by this provider")
+
+        if not self.cached_experiments:
+            raise RuntimeError("Provider not properly initialized or no experiments available")
+
+        if if_modified_since is not None:
+            logger.debug("LocalResolutionProvider: ignoring if_modified_since for experiments, always returning cached data")
+
+        return FetchResponse.data(self.cached_experiments)
+
+    async def fetch_candidate_active_experiments(
+        self,
+        context: Optional[Dict[str, Any]] = None,
+        prefix_filter: Optional[List[str]] = None,
+        if_modified_since: Optional[datetime] = None,
+    ) -> FetchResponse[ExperimentData]:
+        """Fetch candidate active experiments."""
+        if not self.supports_experiments():
+            raise NotImplementedError("Experiments not supported by this provider")
+
+        if not self.ffi_cache or not self.cached_experiments:
+            raise RuntimeError("Provider not properly initialized or no experiments available")
+
+        if if_modified_since is not None:
+            logger.debug("LocalResolutionProvider: ignoring if_modified_since for experiments, always returning cached data")
+
+        return FetchResponse.data(ExperimentData(
+            data=self.ffi_cache.filter_experiment(context, prefix_filter, False),
+            fetched_at=self.cached_experiments.fetched_at,
+        ))
+
+    async def fetch_matching_active_experiments(
+        self,
+        context: Optional[Dict[str, Any]] = None,
+        prefix_filter: Optional[List[str]] = None,
+        if_modified_since: Optional[datetime] = None,
+    ) -> FetchResponse[ExperimentData]:
+        """Fetch matching active experiments."""
+        if not self.supports_experiments():
+            raise NotImplementedError("Experiments not supported by this provider")
+
+        if not self.ffi_cache or not self.cached_experiments:
+            raise RuntimeError("Provider not properly initialized or no experiments available")
+
+        if if_modified_since is not None:
+            logger.debug("LocalResolutionProvider: ignoring if_modified_since for experiments, always returning cached data")
+
+        return FetchResponse.data(ExperimentData(
+            data=self.ffi_cache.filter_experiment(context, prefix_filter, True),
+            fetched_at=self.cached_experiments.fetched_at,
+        ))
+
+    def supports_experiments(self) -> bool:
+        """File source supports experiments if path is configured."""
+        return self.primary_source.supports_experiments()
+
+    async def close(self) -> None:
+        """Stop watching and clean up resources."""
+        return await self.shutdown()

--- a/crates/superposition_core/src/ffi.rs
+++ b/crates/superposition_core/src/ffi.rs
@@ -6,7 +6,9 @@ use superposition_types::experimental::Experimental;
 use superposition_types::{Config, Context, DimensionInfo, Overrides};
 use thiserror::Error;
 
-use crate::experiment::{filter_experiments_by_context, ExperimentConfig};
+use crate::experiment::{
+    filter_experiments_by_context, get_satisfied_experiments, ExperimentConfig,
+};
 use crate::{
     eval_config, eval_config_with_reasoning, experiment::ExperimentationArgs,
     experiment::FfiExperimentGroup, get_applicable_variants, ConfigFormat, FfiExperiment,
@@ -389,6 +391,7 @@ impl ProviderCache {
         &self,
         dimension_data: Option<HashMap<String, String>>,
         prefix: Option<Vec<String>>,
+        partial_apply: bool,
     ) -> Result<ExperimentConfig, OperationError> {
         let dimension_data = dimension_data
             .map(json_from_map)
@@ -416,12 +419,21 @@ impl ProviderCache {
             )
         };
 
+        let exp_filter_fn = if partial_apply {
+            filter_experiments_by_context
+        } else {
+            get_satisfied_experiments
+        };
+
+        let exp_grp_filter_fn = if partial_apply {
+            FfiExperimentGroup::filter_by_eval
+        } else {
+            FfiExperimentGroup::get_satisfied
+        };
+
         Ok(ExperimentConfig {
-            experiments: filter_experiments_by_context(exps, &dimension_data, prefix),
-            experiment_groups: FfiExperimentGroup::filter_by_eval(
-                exp_grps,
-                &dimension_data,
-            ),
+            experiments: exp_filter_fn(exps, &dimension_data, prefix),
+            experiment_groups: exp_grp_filter_fn(exp_grps, &dimension_data),
         })
     }
 

--- a/crates/superposition_provider/src/data_source.rs
+++ b/crates/superposition_provider/src/data_source.rs
@@ -102,7 +102,10 @@ pub trait SuperpositionDataSource: Send + Sync {
     async fn fetch_config(
         &self,
         if_modified_since: Option<DateTime<Utc>>,
-    ) -> Result<FetchResponse<ConfigData>>;
+    ) -> Result<FetchResponse<ConfigData>> {
+        self.fetch_filtered_config(None, None, if_modified_since)
+            .await
+    }
 
     /// Fetch a resolved configuration filtered by the given context and key prefixes.
     async fn fetch_filtered_config(

--- a/crates/superposition_provider/src/data_source/file.rs
+++ b/crates/superposition_provider/src/data_source/file.rs
@@ -51,8 +51,10 @@ impl FileDataSource {
 
 #[async_trait]
 impl SuperpositionDataSource for FileDataSource {
-    async fn fetch_config(
+    async fn fetch_filtered_config(
         &self,
+        context: Option<Map<String, Value>>,
+        prefix_filter: Option<Vec<String>>,
         if_modified_since: Option<DateTime<Utc>>,
     ) -> Result<FetchResponse<ConfigData>> {
         if if_modified_since.is_some() {
@@ -72,7 +74,7 @@ impl SuperpositionDataSource for FileDataSource {
             "json" => JsonFormat::parse_config,
             _ => TomlFormat::parse_config,
         };
-        let config = parser(&content).map_err(|e| {
+        let mut config = parser(&content).map_err(|e| {
             SuperpositionError::ConfigError(format!(
                 "Failed to parse {} config: {}",
                 self.file_format.to_uppercase(),
@@ -80,30 +82,15 @@ impl SuperpositionDataSource for FileDataSource {
             ))
         })?;
 
+        config = config.filter(
+            context.as_ref(),
+            prefix_filter.map(|p| p.into_iter().collect()).as_ref(),
+        );
+
         Ok(FetchResponse::Data(ConfigData {
             data: config,
             fetched_at: now,
         }))
-    }
-
-    async fn fetch_filtered_config(
-        &self,
-        context: Option<Map<String, Value>>,
-        prefix_filter: Option<Vec<String>>,
-        if_modified_since: Option<DateTime<Utc>>,
-    ) -> Result<FetchResponse<ConfigData>> {
-        let resp = self
-            .fetch_config(if_modified_since)
-            .await?
-            .map_data(|mut data| {
-                data.data = data.data.filter(
-                    context.as_ref(),
-                    prefix_filter.map(|p| p.into_iter().collect()).as_ref(),
-                );
-                data
-            });
-
-        Ok(resp)
     }
 
     async fn fetch_active_experiments(

--- a/crates/superposition_provider/src/data_source/http.rs
+++ b/crates/superposition_provider/src/data_source/http.rs
@@ -98,8 +98,11 @@ impl HttpDataSource {
 
         Ok(experiments_response)
     }
+}
 
-    async fn fetch_config_with_filters(
+#[async_trait]
+impl SuperpositionDataSource for HttpDataSource {
+    async fn fetch_filtered_config(
         &self,
         context: Option<Map<String, Value>>,
         prefix_filter: Option<Vec<String>>,
@@ -155,27 +158,6 @@ impl HttpDataSource {
         };
 
         resp
-    }
-}
-
-#[async_trait]
-impl SuperpositionDataSource for HttpDataSource {
-    async fn fetch_config(
-        &self,
-        if_modified_since: Option<DateTime<Utc>>,
-    ) -> Result<FetchResponse<ConfigData>> {
-        self.fetch_config_with_filters(None, None, if_modified_since)
-            .await
-    }
-
-    async fn fetch_filtered_config(
-        &self,
-        context: Option<Map<String, Value>>,
-        prefix_filter: Option<Vec<String>>,
-        if_modified_since: Option<DateTime<Utc>>,
-    ) -> Result<FetchResponse<ConfigData>> {
-        self.fetch_config_with_filters(context, prefix_filter, if_modified_since)
-            .await
     }
 
     async fn fetch_active_experiments(

--- a/crates/superposition_provider/src/local_provider.rs
+++ b/crates/superposition_provider/src/local_provider.rs
@@ -607,39 +607,32 @@ impl FeatureProvider for LocalResolutionProvider {
 
 #[async_trait]
 impl SuperpositionDataSource for LocalResolutionProvider {
-    async fn fetch_config(
-        &self,
-        if_modified_since: Option<DateTime<Utc>>,
-    ) -> Result<FetchResponse<ConfigData>> {
-        if if_modified_since.is_some() {
-            log::debug!("LocalResolutionProvider: ignoring if_modified_since for config, always returning cached data");
-        }
-        let cached = self.cached_config.read().await;
-        match cached.as_ref() {
-            Some(data) => Ok(FetchResponse::Data(data.clone())),
-            None => Err(SuperpositionError::ConfigError(
-                "No cached config available".into(),
-            )),
-        }
-    }
-
     async fn fetch_filtered_config(
         &self,
         context: Option<Map<String, Value>>,
         prefix_filter: Option<Vec<String>>,
         if_modified_since: Option<DateTime<Utc>>,
     ) -> Result<FetchResponse<ConfigData>> {
-        let resp = self
-            .fetch_config(if_modified_since)
-            .await?
-            .map_data(|mut c| {
-                let prefix = prefix_filter.map(HashSet::from_iter);
-                c.data = c.data.filter(context.as_ref(), prefix.as_ref());
+        if if_modified_since.is_some() {
+            log::debug!("LocalResolutionProvider: ignoring if_modified_since for config, always returning cached data");
+        }
 
-                c
-            });
+        let mut config_data = {
+            let cached = self.cached_config.read().await;
+            match cached.as_ref() {
+                Some(data) => data.clone(),
+                None => {
+                    return Err(SuperpositionError::ConfigError(
+                        "No cached config available".into(),
+                    ))
+                }
+            }
+        };
 
-        Ok(resp)
+        let prefix = prefix_filter.map(HashSet::from_iter);
+        config_data.data = config_data.data.filter(context.as_ref(), prefix.as_ref());
+
+        Ok(FetchResponse::Data(config_data))
     }
 
     async fn fetch_active_experiments(


### PR DESCRIPTION
## ChangeLog
1. Added missing implementation of SuperpositionDataSource for LocalResolutionProvider in python provider
2. Re-used `fetch_filtered_config` for `fetch_config` in the default implementation to avoid unnecessary implementation 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `partialApply` parameter to experiment filtering methods, enabling partial application filtering support across Kotlin and Python bindings.
  * LocalProvider now implements data source interface with async methods for fetching configurations and experiments.

* **Refactoring**
  * Reorganized config fetching architecture to use filtered-fetch as the primary implementation path across file and HTTP data sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->