### PR TITLE
feat: add breadcrumbs and superposition platform links

### DIFF
--- a/crates/context_aware_config/src/api/context/handlers.rs
+++ b/crates/context_aware_config/src/api/context/handlers.rs
@@ -281,8 +281,8 @@ async fn update_handler(
     )
     .await?;
 
-    let (override_resp, config_version) =
-        conn.transaction::<_, superposition::AppError, _>(|transaction_conn| {
+    let (override_resp, config_version) = conn
+        .transaction::<_, superposition::AppError, _>(|transaction_conn| {
             let override_resp = operations::update(
                 &workspace_context,
                 req.into_inner(),
@@ -423,8 +423,8 @@ async fn move_handler(
     )
     .await?;
 
-    let (move_response, config_version) =
-        conn.transaction::<_, superposition::AppError, _>(|transaction_conn| {
+    let (move_response, config_version) = conn
+        .transaction::<_, superposition::AppError, _>(|transaction_conn| {
             let move_response = operations::r#move(
                 &workspace_context,
                 ctx_id,

--- a/crates/frontend/src/app.rs
+++ b/crates/frontend/src/app.rs
@@ -35,7 +35,7 @@ use crate::pages::{
     webhooks::Webhooks,
     workspace::Workspace,
 };
-use crate::types::Envs;
+use crate::types::{Envs, RoutePart, RouteSegment, join_route_parts};
 
 #[component]
 pub fn App(app_envs: Envs) -> impl IntoView {
@@ -117,7 +117,10 @@ pub fn App(app_envs: Envs) -> impl IntoView {
                 <Routes base=service_prefix.to_string()>
                     <Route
                         ssr=SsrMode::InOrder
-                        path="/admin/organisations"
+                        path=format!(
+                            "/{}",
+                            join_route_parts([RouteSegment::Admin, RouteSegment::Organisations]),
+                        )
                         view=move || {
                             view! {
                                 <CommonLayout>
@@ -129,7 +132,14 @@ pub fn App(app_envs: Envs) -> impl IntoView {
 
                     <Route
                         ssr=SsrMode::Async
-                        path="/admin/settings/authz"
+                        path=format!(
+                            "/{}",
+                            join_route_parts([
+                                RouteSegment::Admin,
+                                RouteSegment::Settings,
+                                RouteSegment::Authz,
+                            ]),
+                        )
                         view=move || {
                             view! {
                                 <CommonLayout>
@@ -139,102 +149,258 @@ pub fn App(app_envs: Envs) -> impl IntoView {
                         }
                     />
 
-                    <Route ssr=SsrMode::Async path="/admin/:org_id" view=OrgLayout>
-                        <Route ssr=SsrMode::Async path="workspaces" view=Workspace />
-
-                        <Route ssr=SsrMode::Async path="org-authz" view=OrganisationAuthz />
-                    </Route>
-
-                    <Route ssr=SsrMode::Async path="/admin/:org_id/:workspace" view=Layout>
-                        <Route ssr=SsrMode::Async path="dimensions" view=Dimensions />
+                    <Route
+                        ssr=SsrMode::Async
+                        path=format!(
+                            "/{}",
+                            join_route_parts([
+                                RoutePart::from(RouteSegment::Admin),
+                                RoutePart::from("org_id"),
+                            ]),
+                        )
+                        view=OrgLayout
+                    >
                         <Route
                             ssr=SsrMode::Async
-                            path="dimensions/action/create"
+                            path=join_route_parts([RouteSegment::Workspaces])
+                            view=Workspace
+                        />
+
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([RouteSegment::OrgAuthz])
+                            view=OrganisationAuthz
+                        />
+                    </Route>
+
+                    <Route
+                        ssr=SsrMode::Async
+                        path=format!(
+                            "/{}",
+                            join_route_parts([
+                                RoutePart::from(RouteSegment::Admin),
+                                RoutePart::from("org_id"),
+                                RoutePart::from("workspace"),
+                            ]),
+                        )
+                        view=Layout
+                    >
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([RouteSegment::Dimensions])
+                            view=Dimensions
+                        />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([
+                                RouteSegment::Dimensions,
+                                RouteSegment::Action,
+                                RouteSegment::Create,
+                            ])
                             view=CreateDimension
                         />
                         <Route
                             ssr=SsrMode::Async
-                            path="dimensions/:dimension_name/edit"
+                            path=join_route_parts([
+                                RoutePart::from(RouteSegment::Dimensions),
+                                RoutePart::from("dimension_name"),
+                                RoutePart::from(RouteSegment::Edit),
+                            ])
                             view=EditDimension
                         />
                         <Route
                             ssr=SsrMode::Async
-                            path="dimensions/:dimension_name"
+                            path=join_route_parts([
+                                RoutePart::from(RouteSegment::Dimensions),
+                                RoutePart::from("dimension_name"),
+                            ])
                             view=DimensionPage
                         />
 
-                        <Route ssr=SsrMode::Async path="function" view=FunctionList />
                         <Route
                             ssr=SsrMode::Async
-                            path="function/action/create"
+                            path=join_route_parts([RouteSegment::Function])
+                            view=FunctionList
+                        />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([
+                                RouteSegment::Function,
+                                RouteSegment::Action,
+                                RouteSegment::Create,
+                            ])
                             view=CreateFunctionView
                         />
                         <Route
                             ssr=SsrMode::Async
-                            path="function/:function_name"
+                            path=join_route_parts([
+                                RoutePart::from(RouteSegment::Function),
+                                RoutePart::from("function_name"),
+                            ])
                             view=FunctionPage
                         />
 
-                        <Route ssr=SsrMode::Async path="experiments" view=ExperimentList />
-                        <Route ssr=SsrMode::Async path="experiments/:id" view=ExperimentPage />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([RouteSegment::Experiments])
+                            view=ExperimentList
+                        />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([
+                                RoutePart::from(RouteSegment::Experiments),
+                                RoutePart::from("id"),
+                            ])
+                            view=ExperimentPage
+                        />
 
                         <Route
                             ssr=SsrMode::Async
-                            path="experiment-groups"
+                            path=join_route_parts([RouteSegment::ExperimentGroups])
                             view=ExperimentGroupListing
                         />
                         <Route
                             ssr=SsrMode::Async
-                            path="experiment-groups/:id"
+                            path=join_route_parts([
+                                RoutePart::from(RouteSegment::ExperimentGroups),
+                                RoutePart::from("id"),
+                            ])
                             view=ExperimentGroups
                         />
 
-                        <Route ssr=SsrMode::Async path="default-config" view=DefaultConfigList />
                         <Route
                             ssr=SsrMode::Async
-                            path="default-config/action/create"
+                            path=join_route_parts([RouteSegment::DefaultConfig])
+                            view=DefaultConfigList
+                        />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([
+                                RouteSegment::DefaultConfig,
+                                RouteSegment::Action,
+                                RouteSegment::Create,
+                            ])
                             view=CreateDefaultConfig
                         />
                         <Route
                             ssr=SsrMode::Async
-                            path="default-config/:config_key/edit"
+                            path=join_route_parts([
+                                RoutePart::from(RouteSegment::DefaultConfig),
+                                RoutePart::from("config_key"),
+                                RoutePart::from(RouteSegment::Edit),
+                            ])
                             view=EditDefaultConfig
                         />
                         <Route
                             ssr=SsrMode::Async
-                            path="default-config/:config_key"
+                            path=join_route_parts([
+                                RoutePart::from(RouteSegment::DefaultConfig),
+                                RoutePart::from("config_key"),
+                            ])
                             view=DefaultConfig
                         />
 
-                        <Route ssr=SsrMode::Async path="overrides" view=ContextOverride />
-
-                        <Route ssr=SsrMode::Async path="resolve" view=Home />
-
-                        <Route ssr=SsrMode::Async path="types" view=TypesPage />
-                        <Route ssr=SsrMode::Async path="types/:type_name" view=TypePage />
-
-                        <Route ssr=SsrMode::Async path="config/versions" view=ConfigVersionList />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([RouteSegment::Overrides])
+                            view=ContextOverride
+                        />
 
                         <Route
                             ssr=SsrMode::Async
-                            path="config/versions/:version"
+                            path=join_route_parts([RouteSegment::Resolve])
+                            view=Home
+                        />
+
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([RouteSegment::Types])
+                            view=TypesPage
+                        />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([
+                                RoutePart::from(RouteSegment::Types),
+                                RoutePart::from("type_name"),
+                            ])
+                            view=TypePage
+                        />
+
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([RouteSegment::Config, RouteSegment::Versions])
+                            view=ConfigVersionList
+                        />
+
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([
+                                RoutePart::from(RouteSegment::Config),
+                                RoutePart::from(RouteSegment::Versions),
+                                RoutePart::from("version"),
+                            ])
                             view=ConfigVersion
                         />
 
-                        <Route ssr=SsrMode::Async path="compare" view=CompareOverrides />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([RouteSegment::Compare])
+                            view=CompareOverrides
+                        />
 
-                        <Route ssr=SsrMode::Async path="webhooks" view=Webhooks />
-                        <Route ssr=SsrMode::Async path="webhooks/:webhook_name" view=Webhook />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([RouteSegment::Webhooks])
+                            view=Webhooks
+                        />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([
+                                RoutePart::from(RouteSegment::Webhooks),
+                                RoutePart::from("webhook_name"),
+                            ])
+                            view=Webhook
+                        />
 
-                        <Route ssr=SsrMode::Async path="audit-log" view=AuditLog />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([RouteSegment::AuditLog])
+                            view=AuditLog
+                        />
 
-                        <Route ssr=SsrMode::Async path="authz" view=WorkspaceAuthz />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([RouteSegment::Authz])
+                            view=WorkspaceAuthz
+                        />
 
-                        <Route ssr=SsrMode::Async path="variables" view=VariablesList />
-                        <Route ssr=SsrMode::Async path="variables/:variable_name" view=Variable />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([RouteSegment::Variables])
+                            view=VariablesList
+                        />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([
+                                RoutePart::from(RouteSegment::Variables),
+                                RoutePart::from("variable_name"),
+                            ])
+                            view=Variable
+                        />
 
-                        <Route ssr=SsrMode::Async path="secrets" view=SecretsList />
-                        <Route ssr=SsrMode::Async path="secrets/:secret_name" view=Secret />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([RouteSegment::Secrets])
+                            view=SecretsList
+                        />
+                        <Route
+                            ssr=SsrMode::Async
+                            path=join_route_parts([
+                                RoutePart::from(RouteSegment::Secrets),
+                                RoutePart::from("secret_name"),
+                            ])
+                            view=Secret
+                        />
                     </Route>
                 // <Route
                 // path="/*any"

--- a/crates/frontend/src/components.rs
+++ b/crates/frontend/src/components.rs
@@ -1,6 +1,7 @@
 pub mod alert;
 pub mod authz;
 pub mod badge;
+pub mod breadcrumbs;
 pub mod button;
 pub mod change_form;
 pub mod change_summary;

--- a/crates/frontend/src/components/breadcrumbs.rs
+++ b/crates/frontend/src/components/breadcrumbs.rs
@@ -1,0 +1,171 @@
+use leptos::*;
+use leptos_router::{A, use_location};
+
+use crate::types::{BreadcrumbSegment, OrganisationId, Workspace};
+use crate::utils::use_url_base;
+
+const SKIP_SEGMENTS: [&str; 4] = ["admin", "action", "authz", "org-authz"];
+
+/// Maps a URL path segment to a human-readable label.
+/// Returns None for segments that should be skipped (like "action").
+fn segment_to_label(segment: &str) -> Option<String> {
+    let title_segments = [
+        "types",
+        "audit-log",
+        "default-config",
+        "experiment-groups",
+        "compare",
+        "config",
+        "dimensions",
+        "experiments",
+        "function",
+        "resolve",
+        "secrets",
+        "variables",
+        "versions",
+        "webhooks",
+        "workspaces",
+        "overrides",
+        "create",
+        "edit",
+    ];
+    match segment {
+        x if !title_segments.contains(&x) => Some(segment.to_string()),
+        x => Some(
+            x.split('-')
+                .map(|s| {
+                    let mut chars = s.chars();
+                    match chars.next() {
+                        Some(first) => {
+                            first.to_uppercase().collect::<String>() + chars.as_str()
+                        }
+                        None => String::new(),
+                    }
+                })
+                .collect::<Vec<String>>()
+                .join(" "),
+        ),
+    }
+}
+
+/// Builds the breadcrumb trail from the current URL path.
+fn build_breadcrumbs(path: &str, base: &str) -> Vec<BreadcrumbSegment> {
+    // Strip the base prefix if present
+    let path = path.replace(base, "");
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+    let mut previous_segments = String::new();
+    let mut breadcrumbs = Vec::new();
+    for (i, segment) in segments.iter().enumerate() {
+        let is_current = i == segments.len() - 1;
+        if !SKIP_SEGMENTS.contains(segment) {
+            if let Some(label) = segment_to_label(segment) {
+                breadcrumbs.push(BreadcrumbSegment {
+                    label,
+                    href: if is_current {
+                        String::new()
+                    } else {
+                        let current = if previous_segments == "/admin" {
+                            "organisations"
+                        } else if previous_segments
+                            .split("/")
+                            .filter(|s| !s.is_empty())
+                            .collect::<Vec<&str>>()
+                            .len()
+                            == 2
+                        {
+                            "workspaces"
+                        } else {
+                            segment
+                        };
+                        format!("{}{}/{}", base, previous_segments, current)
+                    },
+                    is_current,
+                });
+            }
+        }
+        previous_segments.push('/');
+        previous_segments.push_str(segment);
+    }
+    breadcrumbs
+}
+
+/// Global navigation breadcrumbs component.
+/// Displays a breadcrumb trail based on the current URL path.
+/// Structure: <org> >> <workspace> >> <section> >> <detail>
+#[component]
+pub fn Breadcrumbs() -> impl IntoView {
+    let location = use_location();
+    let base = use_url_base();
+
+    // Check if we have org/workspace context (for workspace-level pages)
+    let org_context = use_context::<Signal<OrganisationId>>();
+    let workspace_context = use_context::<Signal<Workspace>>();
+
+    // Only show breadcrumbs if we have context (org or workspace level)
+    let has_context = org_context.is_some() || workspace_context.is_some();
+
+    let breadcrumbs = Signal::derive(move || {
+        if !has_context {
+            return Vec::new();
+        }
+        let path = location.pathname.get();
+        build_breadcrumbs(&path, &base)
+    });
+
+    view! {
+        <Show when=move || !breadcrumbs.get().is_empty() fallback=|| view! { <></> }>
+            <nav class="flex items-center flex-wrap gap-1 text-sm mb-4" aria-label="Breadcrumb">
+                <ol class="flex items-center flex-wrap gap-1">
+                    <For
+                        each=move || breadcrumbs.get()
+                        key=|crumb| format!("{}-{}", crumb.label, crumb.href)
+                        children=move |crumb: BreadcrumbSegment| {
+                            view! {
+                                <li class="flex items-center gap-1">
+                                    <BreadcrumbItem item=crumb />
+                                </li>
+                            }
+                        }
+                    />
+                </ol>
+            </nav>
+        </Show>
+    }
+}
+
+/// Renders a single breadcrumb item - either a link or plain text.
+#[component]
+fn BreadcrumbItem(item: BreadcrumbSegment) -> impl IntoView {
+    // is_current means this is the last item (current page), so no separator needed
+    let show_separator = !item.is_current;
+
+    view! {
+        <div class="flex items-center gap-1">
+            {if item.is_current || item.href.is_empty() {
+                view! { <span class="font-bold text-gray-800">{item.label.clone()}</span> }
+                    .into_view()
+            } else {
+                view! {
+                    <A
+                        href=item.href.clone()
+                        class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 hover:underline"
+                    >
+                        {item.label.clone()}
+                    </A>
+                }
+                    .into_view()
+            }}
+            {if show_separator {
+                view! {
+                    <span class="text-gray-400 dark:text-gray-500">
+                        <i class="ri-arrow-right-s-line"></i>
+                    </span>
+                }
+                    .into_view()
+            } else {
+                ().into_view()
+            }}
+        </div>
+    }
+}

--- a/crates/frontend/src/components/breadcrumbs.rs
+++ b/crates/frontend/src/components/breadcrumbs.rs
@@ -1,0 +1,171 @@
+use leptos::*;
+use leptos_router::{A, use_location};
+
+use crate::types::{BreadcrumbSegment, OrganisationId, Workspace};
+use crate::utils::use_url_base;
+
+const SKIP_SEGMENTS: [&str; 4] = ["admin", "action", "authz", "org-authz"];
+
+/// Maps a URL path segment to a human-readable label.
+/// Returns None for segments that should be skipped (like "action").
+fn segment_to_label(segment: &str) -> Option<String> {
+    let title_segments = [
+        "types",
+        "audit-log",
+        "default-config",
+        "experiment-groups",
+        "compare",
+        "config",
+        "dimensions",
+        "experiments",
+        "function",
+        "resolve",
+        "secrets",
+        "variables",
+        "versions",
+        "webhooks",
+        "workspaces",
+        "overrides",
+        "create",
+        "edit",
+    ];
+    match segment {
+        x if !title_segments.contains(&x) => Some(segment.to_string()),
+        x => Some(
+            x.split('-')
+                .map(|s| {
+                    let mut chars = s.chars();
+                    match chars.next() {
+                        Some(first) => {
+                            first.to_uppercase().collect::<String>() + chars.as_str()
+                        }
+                        None => String::new(),
+                    }
+                })
+                .collect::<Vec<String>>()
+                .join(" "),
+        ),
+    }
+}
+
+/// Builds the breadcrumb trail from the current URL path.
+fn build_breadcrumbs(path: &str, base: &str) -> Vec<BreadcrumbSegment> {
+    // Strip the base prefix if present
+    let path = path.strip_prefix(base).unwrap_or(path);
+    let segments: Vec<&str> = path.split('/').filter(|s| !s.is_empty()).collect();
+
+    let mut previous_segments = String::new();
+    let mut breadcrumbs = Vec::new();
+    for (i, segment) in segments.iter().enumerate() {
+        let is_current = i == segments.len() - 1;
+        if !SKIP_SEGMENTS.contains(segment) {
+            if let Some(label) = segment_to_label(segment) {
+                breadcrumbs.push(BreadcrumbSegment {
+                    label,
+                    href: if is_current {
+                        String::new()
+                    } else {
+                        let current = if previous_segments == "/admin" {
+                            "organisations"
+                        } else if previous_segments
+                            .split("/")
+                            .filter(|s| !s.is_empty())
+                            .collect::<Vec<&str>>()
+                            .len()
+                            == 2
+                        {
+                            "workspaces"
+                        } else {
+                            segment
+                        };
+                        format!("{}{}/{}", base, previous_segments, current)
+                    },
+                    is_current,
+                });
+            }
+        }
+        previous_segments.push('/');
+        previous_segments.push_str(segment);
+    }
+    breadcrumbs
+}
+
+/// Global navigation breadcrumbs component.
+/// Displays a breadcrumb trail based on the current URL path.
+/// Structure: <org> >> <workspace> >> <section> >> <detail>
+#[component]
+pub fn Breadcrumbs() -> impl IntoView {
+    let location = use_location();
+    let base = use_url_base();
+
+    // Check if we have org/workspace context (for workspace-level pages)
+    let org_context = use_context::<Signal<OrganisationId>>();
+    let workspace_context = use_context::<Signal<Workspace>>();
+
+    // Only show breadcrumbs if we have context (org or workspace level)
+    let has_context = org_context.is_some() || workspace_context.is_some();
+
+    let breadcrumbs = Signal::derive(move || {
+        if !has_context {
+            return Vec::new();
+        }
+        let path = location.pathname.get();
+        build_breadcrumbs(&path, &base)
+    });
+
+    view! {
+        <Show when=move || !breadcrumbs.get().is_empty() fallback=|| view! { <></> }>
+            <nav class="flex items-center flex-wrap gap-1 text-sm mb-4" aria-label="Breadcrumb">
+                <ol class="flex items-center flex-wrap gap-1">
+                    <For
+                        each=move || breadcrumbs.get()
+                        key=|crumb| format!("{}-{}", crumb.label, crumb.href)
+                        children=move |crumb: BreadcrumbSegment| {
+                            view! {
+                                <li class="flex items-center gap-1">
+                                    <BreadcrumbItem item=crumb />
+                                </li>
+                            }
+                        }
+                    />
+                </ol>
+            </nav>
+        </Show>
+    }
+}
+
+/// Renders a single breadcrumb item - either a link or plain text.
+#[component]
+fn BreadcrumbItem(item: BreadcrumbSegment) -> impl IntoView {
+    // is_current means this is the last item (current page), so no separator needed
+    let show_separator = !item.is_current;
+
+    view! {
+        <div class="flex items-center gap-1">
+            {if item.is_current || item.href.is_empty() {
+                view! { <span class="font-bold text-gray-800">{item.label.clone()}</span> }
+                    .into_view()
+            } else {
+                view! {
+                    <A
+                        href=item.href.clone()
+                        class="text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-300 hover:underline"
+                    >
+                        {item.label.clone()}
+                    </A>
+                }
+                    .into_view()
+            }}
+            {if show_separator {
+                view! {
+                    <span class="text-gray-400 dark:text-gray-500">
+                        <i class="ri-arrow-right-s-line"></i>
+                    </span>
+                }
+                    .into_view()
+            } else {
+                ().into_view()
+            }}
+        </div>
+    }
+}

--- a/crates/frontend/src/components/breadcrumbs.rs
+++ b/crates/frontend/src/components/breadcrumbs.rs
@@ -1,50 +1,39 @@
+use std::str::FromStr;
+
 use leptos::*;
 use leptos_router::{A, use_location};
 
-use crate::types::{BreadcrumbSegment, OrganisationId, Workspace};
+use crate::types::{BreadcrumbSegment, OrganisationId, RouteSegment, Workspace};
 use crate::utils::use_url_base;
 
-const SKIP_SEGMENTS: [&str; 4] = ["admin", "action", "authz", "org-authz"];
+const SKIP_SEGMENTS: [RouteSegment; 4] = [
+    RouteSegment::Admin,
+    RouteSegment::Action,
+    RouteSegment::Authz,
+    RouteSegment::OrgAuthz,
+];
 
 /// Maps a URL path segment to a human-readable label.
 /// Returns None for segments that should be skipped (like "action").
-fn segment_to_label(segment: &str) -> Option<String> {
-    let title_segments = [
-        "types",
-        "audit-log",
-        "default-config",
-        "experiment-groups",
-        "compare",
-        "config",
-        "dimensions",
-        "experiments",
-        "function",
-        "resolve",
-        "secrets",
-        "variables",
-        "versions",
-        "webhooks",
-        "workspaces",
-        "overrides",
-        "create",
-        "edit",
-    ];
-    match segment {
-        x if !title_segments.contains(&x) => Some(segment.to_string()),
-        x => Some(
-            x.split('-')
-                .map(|s| {
-                    let mut chars = s.chars();
-                    match chars.next() {
-                        Some(first) => {
-                            first.to_uppercase().collect::<String>() + chars.as_str()
-                        }
-                        None => String::new(),
+fn segment_to_label(segment: &str) -> String {
+    let is_known_segment = RouteSegment::from_str(segment).is_ok();
+
+    if !is_known_segment {
+        segment.to_string()
+    } else {
+        segment
+            .split('-')
+            .map(|s| {
+                let mut chars = s.chars();
+                match chars.next() {
+                    Some(first) => {
+                        first.to_uppercase().collect::<String>() + chars.as_str()
                     }
-                })
-                .collect::<Vec<String>>()
-                .join(" "),
-        ),
+                    None => String::new(),
+                }
+            })
+            .collect::<Vec<String>>()
+            .join(" ")
     }
 }
 
@@ -58,31 +47,78 @@ fn build_breadcrumbs(path: &str, base: &str) -> Vec<BreadcrumbSegment> {
     let mut breadcrumbs = Vec::new();
     for (i, segment) in segments.iter().enumerate() {
         let is_current = i == segments.len() - 1;
-        if !SKIP_SEGMENTS.contains(segment) {
-            if let Some(label) = segment_to_label(segment) {
+        let is_skipped = RouteSegment::try_from_str(segment)
+            .map(|seg| SKIP_SEGMENTS.contains(&seg))
+            .unwrap_or(false);
+
+        let is_config_versions_config =
+            *segment == "config" && segments.get(i + 1).copied() == Some("versions");
+        if is_config_versions_config {
+            previous_segments.push('/');
+            previous_segments.push_str(segment);
+            continue;
+        }
+
+        if !is_skipped {
+            let label = segment_to_label(segment);
+            let is_versions_in_config_flow = *segment == "versions"
+                && i > 0
+                && segments.get(i - 1).copied() == Some("config");
+
+            if previous_segments == "/admin" {
                 breadcrumbs.push(BreadcrumbSegment {
-                    label,
-                    href: if is_current {
-                        String::new()
-                    } else {
-                        let current = if previous_segments == "/admin" {
-                            "organisations"
-                        } else if previous_segments
-                            .split("/")
-                            .filter(|s| !s.is_empty())
-                            .collect::<Vec<&str>>()
-                            .len()
-                            == 2
-                        {
-                            "workspaces"
-                        } else {
-                            segment
-                        };
-                        format!("{}{}/{}", base, previous_segments, current)
-                    },
-                    is_current,
+                    label: "Organisations".to_string(),
+                    href: format!("{}{}/organisations", base, previous_segments),
+                    is_current: false,
                 });
             }
+            if previous_segments
+                .split("/")
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<&str>>()
+                .len()
+                == 3
+            {
+                breadcrumbs.insert(
+                    2,
+                    BreadcrumbSegment {
+                        label: "Workspaces".to_string(),
+                        href: {
+                            let proper_url_length = previous_segments
+                                .rfind("/")
+                                .unwrap_or(previous_segments.len());
+                            format!(
+                                "{}{}/workspaces",
+                                base,
+                                &previous_segments[..proper_url_length]
+                            )
+                        },
+                        is_current: false,
+                    },
+                );
+            }
+
+            breadcrumbs.push(BreadcrumbSegment {
+                label: if is_versions_in_config_flow {
+                    "Versions".to_string()
+                } else {
+                    label
+                },
+                href: if is_current
+                    || previous_segments == "/admin"
+                    || previous_segments
+                        .split("/")
+                        .filter(|s| !s.is_empty())
+                        .collect::<Vec<&str>>()
+                        .len()
+                        == 2
+                {
+                    String::new()
+                } else {
+                    format!("{}{}/{}", base, previous_segments, segment)
+                },
+                is_current,
+            });
         }
         previous_segments.push('/');
         previous_segments.push_str(segment);

--- a/crates/frontend/src/components/breadcrumbs.rs
+++ b/crates/frontend/src/components/breadcrumbs.rs
@@ -65,38 +65,23 @@ fn build_breadcrumbs(path: &str, base: &str) -> Vec<BreadcrumbSegment> {
                 && i > 0
                 && segments.get(i - 1).copied() == Some("config");
 
-            if previous_segments == "/admin" {
+            if i == 1 {
                 breadcrumbs.push(BreadcrumbSegment {
                     label: "Organisations".to_string(),
-                    href: format!("{}{}/organisations", base, previous_segments),
+                    href: format!("{}/admin/organisations", base),
                     is_current: false,
                 });
             }
-            if previous_segments
-                .split("/")
-                .filter(|s| !s.is_empty())
-                .collect::<Vec<&str>>()
-                .len()
-                == 3
-            {
-                breadcrumbs.insert(
-                    2,
-                    BreadcrumbSegment {
-                        label: "Workspaces".to_string(),
-                        href: {
-                            let proper_url_length = previous_segments
-                                .rfind("/")
-                                .unwrap_or(previous_segments.len());
-                            format!(
-                                "{}{}/workspaces",
-                                base,
-                                &previous_segments[..proper_url_length]
-                            )
-                        },
-                        is_current: false,
-                    },
-                );
-            }
+
+            let href = if is_current {
+                String::new()
+            } else if i == 1 {
+                format!("{}/admin/{}/workspaces", base, segment)
+            } else if i == 2 {
+                format!("{}{}/{}/default-config", base, previous_segments, segment)
+            } else {
+                format!("{}{}/{}", base, previous_segments, segment)
+            };
 
             breadcrumbs.push(BreadcrumbSegment {
                 label: if is_versions_in_config_flow {
@@ -104,19 +89,7 @@ fn build_breadcrumbs(path: &str, base: &str) -> Vec<BreadcrumbSegment> {
                 } else {
                     label
                 },
-                href: if is_current
-                    || previous_segments == "/admin"
-                    || previous_segments
-                        .split("/")
-                        .filter(|s| !s.is_empty())
-                        .collect::<Vec<&str>>()
-                        .len()
-                        == 2
-                {
-                    String::new()
-                } else {
-                    format!("{}{}/{}", base, previous_segments, segment)
-                },
+                href,
                 is_current,
             });
         }

--- a/crates/frontend/src/components/side_nav.rs
+++ b/crates/frontend/src/components/side_nav.rs
@@ -341,7 +341,7 @@ pub fn NavComponent(
             >
                 <div class="h-[84px] px-4 py-2 flex items-center justify-center gap-8">
                     <A
-                        href=format!("{base}/admin")
+                        href=format!("{base}/admin/organisations")
                         class="max-xl:hidden max-xl:group-hover:block xl:group-[.collapsed]:hidden text-sm font-semibold text-center text-slate-700 whitespace-nowrap"
                     >
                         Superposition Platform

--- a/crates/frontend/src/hoc/layout.rs
+++ b/crates/frontend/src/hoc/layout.rs
@@ -1,6 +1,7 @@
 use crate::{
     api::workspaces,
     components::{
+        breadcrumbs::Breadcrumbs,
         side_nav::{OrgSideNav, SideNav, SideNavCollapsedProvider},
         skeleton::{Skeleton, SkeletonVariant},
         toast::Toast,
@@ -37,6 +38,7 @@ pub fn use_org() -> Signal<OrganisationId> {
 pub fn CommonLayout(children: Children) -> impl IntoView {
     view! {
         <main class="relative h-full w-full p-8 overflow-x-hidden transition-all duration-200 ease-soft-in-out">
+            <Breadcrumbs />
             {children()}
         </main>
         {move || {

--- a/crates/frontend/src/types.rs
+++ b/crates/frontend/src/types.rs
@@ -168,6 +168,18 @@ pub struct BreadCrums {
     pub is_link: bool,
 }
 
+/// Breadcrumb segment for global navigation breadcrumbs.
+/// Represents a single item in the breadcrumb trail.
+#[derive(Debug, Clone)]
+pub struct BreadcrumbSegment {
+    /// Human-readable label for the breadcrumb
+    pub label: String,
+    /// URL to navigate to when clicked (empty for current page)
+    pub href: String,
+    /// Whether this is the current/active page (non-clickable)
+    pub is_current: bool,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct ErrorResponse {
     pub message: String,

--- a/crates/frontend/src/types.rs
+++ b/crates/frontend/src/types.rs
@@ -1,3 +1,5 @@
+use std::str::FromStr;
+
 use derive_more::{Deref, DerefMut};
 use leptos::{ReadSignal, WriteSignal};
 use serde::{Deserialize, Serialize};
@@ -295,4 +297,120 @@ impl DropdownOption for DimensionTypeOptions {
     fn label(&self) -> String {
         self.to_string()
     }
+}
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    PartialEq,
+    Eq,
+    Hash,
+    strum_macros::Display,
+    strum_macros::EnumString,
+    strum_macros::EnumIter,
+)]
+pub enum RouteSegment {
+    #[strum(serialize = "types")]
+    Types,
+    #[strum(serialize = "audit-log")]
+    AuditLog,
+    #[strum(serialize = "default-config")]
+    DefaultConfig,
+    #[strum(serialize = "experiment-groups")]
+    ExperimentGroups,
+    #[strum(serialize = "compare")]
+    Compare,
+    #[strum(serialize = "config")]
+    Config,
+    #[strum(serialize = "dimensions")]
+    Dimensions,
+    #[strum(serialize = "experiments")]
+    Experiments,
+    #[strum(serialize = "function")]
+    Function,
+    #[strum(serialize = "resolve")]
+    Resolve,
+    #[strum(serialize = "secrets")]
+    Secrets,
+    #[strum(serialize = "variables")]
+    Variables,
+    #[strum(serialize = "versions")]
+    Versions,
+    #[strum(serialize = "webhooks")]
+    Webhooks,
+    #[strum(serialize = "workspaces")]
+    Workspaces,
+    #[strum(serialize = "overrides")]
+    Overrides,
+    #[strum(serialize = "create")]
+    Create,
+    #[strum(serialize = "edit")]
+    Edit,
+    #[strum(serialize = "admin")]
+    Admin,
+    #[strum(serialize = "settings")]
+    Settings,
+    #[strum(serialize = "authz")]
+    Authz,
+    #[strum(serialize = "organisations")]
+    Organisations,
+    #[strum(serialize = "action")]
+    Action,
+    #[strum(serialize = "org-authz")]
+    OrgAuthz,
+}
+
+impl RouteSegment {
+    pub fn try_from_str(value: &str) -> Result<Self, strum::ParseError> {
+        Self::from_str(value)
+    }
+}
+
+/// A route part can be either a static segment or a dynamic `:param`.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum RoutePart {
+    Static(RouteSegment),
+    Dynamic(&'static str),
+}
+
+impl RoutePart {
+    pub fn to_path_part(&self) -> String {
+        match self {
+            Self::Static(seg) => seg.to_string(),
+            Self::Dynamic(name) => {
+                let trimmed = name.trim_start_matches(':');
+                format!(":{trimmed}")
+            }
+        }
+    }
+}
+
+impl From<RouteSegment> for RoutePart {
+    fn from(value: RouteSegment) -> Self {
+        Self::Static(value)
+    }
+}
+
+impl From<&'static str> for RoutePart {
+    fn from(value: &'static str) -> Self {
+        if let Ok(seg) = RouteSegment::from_str(value) {
+            Self::Static(seg)
+        } else {
+            Self::Dynamic(value.trim_start_matches(':'))
+        }
+    }
+}
+
+/// Join static and dynamic route parts with `/`.
+pub fn join_route_parts<I, T>(parts: I) -> String
+where
+    I: IntoIterator<Item = T>,
+    T: Into<RoutePart>,
+{
+    parts
+        .into_iter()
+        .map(|p| p.into().to_path_part())
+        .collect::<Vec<_>>()
+        .join("/")
 }

--- a/crates/superposition/src/main.rs
+++ b/crates/superposition/src/main.rs
@@ -174,7 +174,9 @@ async fn main() -> Result<()> {
                     .service(web::redirect("/", ui_redirect_path.to_string()))
                     .service(web::redirect("/admin", ui_redirect_path.to_string()))
                     .service(web::redirect("/admin/", ui_redirect_path.to_string()))
+                    .service(web::redirect("/admin/{org_id}", "workspaces"))
                     .service(web::redirect("/admin/{org_id}/", "workspaces"))
+                    .service(web::redirect("/admin/{org_id}/{tenant}", "default-config"))
                     .service(web::redirect("/admin/{org_id}/{tenant}/", "default-config"))
                     /***************************** UI Routes ******************************/
                     .route("/fxn/{tail:.*}", leptos_actix::handle_server_fns())


### PR DESCRIPTION
## Problem
Navigation backwards is hard in superposition if deeply nested

## Solution
Add breadcrumbs so users can see where they are and jump to any previous screen they had visited along the way to the current page


https://github.com/user-attachments/assets/1d46ad90-933a-405a-aa34-37c4b017d35a



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced breadcrumb navigation that dynamically displays your current location within the app and provides convenient shortcuts to navigate to parent pages and sections, making it easier to explore different areas of the platform.

* **Improvements**
  * Enhanced routing and redirect patterns throughout the application to provide a smoother and more intuitive navigation experience when moving between different sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->