### PR TITLE
fix: minor changes to how webhooks send requests

### DIFF
--- a/crates/context_aware_config/src/api/context/handlers.rs
+++ b/crates/context_aware_config/src/api/context/handlers.rs
@@ -281,8 +281,8 @@ async fn update_handler(
     )
     .await?;
 
-    let (override_resp, config_version) =
-        conn.transaction::<_, superposition::AppError, _>(|transaction_conn| {
+    let (override_resp, config_version) = conn
+        .transaction::<_, superposition::AppError, _>(|transaction_conn| {
             let override_resp = operations::update(
                 &workspace_context,
                 req.into_inner(),
@@ -423,8 +423,8 @@ async fn move_handler(
     )
     .await?;
 
-    let (move_response, config_version) =
-        conn.transaction::<_, superposition::AppError, _>(|transaction_conn| {
+    let (move_response, config_version) = conn
+        .transaction::<_, superposition::AppError, _>(|transaction_conn| {
             let move_response = operations::r#move(
                 &workspace_context,
                 ctx_id,

--- a/crates/service_utils/src/helpers.rs
+++ b/crates/service_utils/src/helpers.rs
@@ -15,10 +15,7 @@ use diesel::{
 use log::warn;
 use once_cell::sync::Lazy;
 use regex::Regex;
-use reqwest::{
-    StatusCode,
-    header::{HeaderMap, HeaderName, HeaderValue},
-};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use secrecy::ExposeSecret;
 use serde::Serialize;
 use superposition_macros::unexpected_error;
@@ -427,25 +424,32 @@ where
         HttpMethod::Head => state.http_client.head(&*webhook.url),
     };
 
-    let response = request_builder
-        .headers(headers)
-        .json(&WebhookResponse {
-            event_info: WebhookEventInfo {
-                webhook_event: event,
-                resource,
-                action,
-                time: Utc::now().to_string(),
-                workspace_id: workspace_context.workspace_id.to_string(),
-                organisation_id: workspace_context.organisation_id.to_string(),
-                config_version: config_version_opt,
-            },
-            payload,
-        })
-        .send()
-        .await;
+    let request_builder =
+        if webhook.method != HttpMethod::Get && webhook.method != HttpMethod::Head {
+            headers.insert(
+                reqwest::header::CONTENT_TYPE,
+                HeaderValue::from_static("application/json"),
+            );
+            request_builder.json(&WebhookResponse {
+                event_info: WebhookEventInfo {
+                    webhook_event: event,
+                    resource,
+                    action,
+                    time: Utc::now().to_string(),
+                    workspace_id: workspace_context.workspace_id.to_string(),
+                    organisation_id: workspace_context.organisation_id.to_string(),
+                    config_version: config_version_opt,
+                },
+                payload,
+            })
+        } else {
+            request_builder
+        };
+
+    let response = request_builder.headers(headers).send().await;
 
     match response {
-        Ok(res) if res.status() == StatusCode::OK => {
+        Ok(res) if res.status().is_success() => {
             log::info!("webhook call succeeded: {:?}", res.status());
             true
         }


### PR DESCRIPTION
## Problem
Sending a body with a GET and HEAD request breaks server requests, and we're not sending content type as a header

## Solution
Remove body for GET and HEAD, and send the content type of the body

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Webhooks now correctly handle GET and HEAD request methods without forcing JSON payloads.
  * Improved HTTP status validation for webhook calls to recognize all successful 2xx+ responses.
  * Enhanced request formatting with proper header attachment for all webhook requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->