### PR TITLE
fix: update experiment groups when experiments change

### DIFF
--- a/crates/experimentation_platform/src/api/experiments/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiments/handlers.rs
@@ -84,7 +84,8 @@ use superposition_types::{
 use crate::api::{
     experiment_groups::helpers::{
         add_members, create_system_generated_experiment_group,
-        detach_experiment_from_group, update_experiment_group_buckets,
+        detach_experiment_from_group, put_experiment_groups_in_redis,
+        update_experiment_group_buckets,
     },
     experiments::{
         helpers::{
@@ -479,6 +480,13 @@ async fn conclude_handler(
         put_experiments_in_redis(&state.redis, &mut conn, &workspace_context.schema_name)
             .await;
 
+    let _ = put_experiment_groups_in_redis(
+        &state.redis,
+        &mut conn,
+        &workspace_context.schema_name,
+    )
+    .await;
+
     let experiment_response = ExperimentResponse::from(response);
 
     let data = WebhookData {
@@ -754,6 +762,12 @@ async fn discard_handler(
         put_experiments_in_redis(&state.redis, &mut conn, &workspace_context.schema_name)
             .await;
 
+    let _ = put_experiment_groups_in_redis(
+        &state.redis,
+        &mut conn,
+        &workspace_context.schema_name,
+    )
+    .await;
     let experiment_response = ExperimentResponse::from(response);
 
     let data = WebhookData {
@@ -1484,6 +1498,13 @@ async fn ramp_handler(
     let _ =
         put_experiments_in_redis(&state.redis, &mut conn, &workspace_context.schema_name)
             .await;
+
+    let _ = put_experiment_groups_in_redis(
+        &state.redis,
+        &mut conn,
+        &workspace_context.schema_name,
+    )
+    .await;
 
     let webhook_event = if matches!(experiment.status, ExperimentStatusType::CREATED) {
         WebhookEvent::ExperimentStarted


### PR DESCRIPTION
## Problem
Experiment allocation is wrong because experiment groups aren't updated in redis when experiments change

## Solution
On every experiment action update experiment groups

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved cache synchronization for experiment state changes (create, conclude, discard, update, pause, resume) to ensure consistency across all related data.
  * Enhanced variant allocation to use authenticated configuration retrieval for more reliable and current variant assignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->