### PR TITLE
fix: re-use x-request-id if sent in request

### DIFF
--- a/crates/service_utils/src/middlewares/request_response_logging.rs
+++ b/crates/service_utils/src/middlewares/request_response_logging.rs
@@ -133,10 +133,14 @@ where
 
             let query_string = req.query_string().to_string();
 
-            let request_id = req
-                .extensions()
-                .get::<tracing_actix_web::RequestId>()
-                .map(|req_id| header::HeaderValue::from_str(&req_id.to_string()));
+            // Check for x-request-id header first, fallback to generated one from extensions
+            let request_id = req.headers().get("x-request-id").cloned().or_else(|| {
+                req.extensions()
+                    .get::<tracing_actix_web::RequestId>()
+                    .and_then(|req_id| {
+                        header::HeaderValue::from_str(&req_id.to_string()).ok()
+                    })
+            });
 
             let (http_req, mut payload) = req.into_parts();
             let mut body_bytes = Vec::new();
@@ -181,7 +185,7 @@ where
             let start_time = Instant::now();
             res = service.call(new_req).await?;
 
-            if let Some(Ok(request_id)) = request_id {
+            if let Some(request_id) = request_id {
                 res.headers_mut()
                     .insert(header::HeaderName::from_static("x-request-id"), request_id);
             }

--- a/crates/superposition/src/log_span.rs
+++ b/crates/superposition/src/log_span.rs
@@ -39,8 +39,13 @@ impl RootSpanBuilder for CustomRootSpanBuilder {
         let org = header_extractor(headers, "x-org-id").unwrap_or_else(|| {
             path_extractor(path, 0).unwrap_or_else(|| "no-org-header".to_string())
         });
+        let request_id = header_extractor(headers, "x-request-id");
         let method = request.method().to_string();
-        tracing_actix_web::root_span!(request, workspace, org, method, path,)
+        if let Some(request_id) = request_id {
+            tracing_actix_web::root_span!(request, request_id = %request_id, workspace, org, method, path,)
+        } else {
+            tracing_actix_web::root_span!(request, workspace, org, method, path,)
+        }
     }
 
     fn on_request_end<B: MessageBody>(


### PR DESCRIPTION
## Problem
Superposition is ignoring x-request-id from proxy

## Solution
Read the header and use in logs, if missing then generate a request ID and use that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved request ID extraction in logging middleware by prioritizing header values with enhanced fallback handling to ensure consistent request tracking across services.
  * Enhanced root span tracing to conditionally populate request ID information when available from incoming request headers, improving request correlation and debugging capabilities in distributed tracing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->