### PR TITLE
fix: send auth and x-user when validating change reason

### DIFF
--- a/crates/experimentation_platform/src/api/experiment_groups/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiment_groups/handlers.rs
@@ -64,7 +64,7 @@ use crate::api::{
     experiments::{
         cac_api::validate_context,
         helpers::{
-            fetch_and_validate_change_reason_with_function, hash,
+            validate_change_reason_with_function, hash,
             validate_and_add_experiment_group_id,
             validate_and_remove_experiment_group_id,
         },
@@ -110,10 +110,11 @@ async fn create_handler(
         Vec::new()
     };
 
-    fetch_and_validate_change_reason_with_function(
+    validate_change_reason_with_function(
         &workspace_context,
         &req.change_reason,
         &state,
+        &user,
     )
     .await?;
 
@@ -194,10 +195,11 @@ async fn update_handler(
 
     let req = req.into_inner();
 
-    fetch_and_validate_change_reason_with_function(
+    validate_change_reason_with_function(
         &workspace_context,
         &req.change_reason,
         &state,
+        &user,
     )
     .await?;
 
@@ -233,10 +235,11 @@ async fn add_members_handler(
     let req = req.into_inner();
     let DbConnection(mut conn) = db_conn;
 
-    fetch_and_validate_change_reason_with_function(
+    validate_change_reason_with_function(
         &workspace_context,
         &req.change_reason,
         &state,
+        &user,
     )
     .await?;
 
@@ -289,10 +292,11 @@ async fn remove_members_handler(
     let DbConnection(mut conn) = db_conn;
     let id = exp_group_id.into_inner();
 
-    fetch_and_validate_change_reason_with_function(
+    validate_change_reason_with_function(
         &workspace_context,
         &req.change_reason,
         &state,
+        &user,
     )
     .await?;
 

--- a/crates/experimentation_platform/src/api/experiments/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiments/handlers.rs
@@ -89,7 +89,7 @@ use crate::api::{
     },
     experiments::{
         helpers::{
-            fetch_and_validate_change_reason_with_function,
+            validate_change_reason_with_function,
             get_control_overrides_from_exp_id, put_experiments_in_redis,
             validate_control_overrides, validate_delete_experiment_variants,
         },
@@ -166,10 +166,11 @@ async fn create_handler(
     let description = req.description.clone();
     let change_reason = req.change_reason.clone();
 
-    fetch_and_validate_change_reason_with_function(
+    validate_change_reason_with_function(
         &workspace_context,
         &change_reason,
         &state,
+        &user
     )
     .await?;
 
@@ -457,10 +458,11 @@ async fn conclude_handler(
     action_authorized(_auth_z, &exp_id, &workspace_context.schema_name, &mut conn)
         .await?;
 
-    fetch_and_validate_change_reason_with_function(
+    validate_change_reason_with_function(
         &workspace_context,
         &req.change_reason,
         &state,
+        &user
     )
     .await?;
 
@@ -739,10 +741,11 @@ async fn discard_handler(
     action_authorized(_auth_z, &exp_id, &workspace_context.schema_name, &mut conn)
         .await?;
 
-    fetch_and_validate_change_reason_with_function(
+    validate_change_reason_with_function(
         &workspace_context,
         &req.change_reason,
         &state,
+        &user
     )
     .await?;
 
@@ -1352,10 +1355,11 @@ async fn ramp_handler(
 
     let change_reason = req.change_reason.clone();
 
-    fetch_and_validate_change_reason_with_function(
+    validate_change_reason_with_function(
         &workspace_context,
         &change_reason,
         &state,
+        &user
     )
     .await?;
 
@@ -1560,10 +1564,11 @@ async fn update_handler(
     let description = req.description.clone();
     let change_reason = req.change_reason.clone();
 
-    fetch_and_validate_change_reason_with_function(
+    validate_change_reason_with_function(
         &workspace_context,
         &change_reason,
         &state,
+        &user
     )
     .await?;
 
@@ -1898,10 +1903,11 @@ async fn pause_handler(
     action_authorized(_auth_z, &exp_id, &workspace_context.schema_name, &mut conn)
         .await?;
 
-    fetch_and_validate_change_reason_with_function(
+    validate_change_reason_with_function(
         &workspace_context,
         &req.change_reason,
         &state,
+        &user
     )
     .await?;
 
@@ -1994,10 +2000,11 @@ async fn resume_handler(
     action_authorized(_auth_z, &exp_id, &workspace_context.schema_name, &mut conn)
         .await?;
 
-    fetch_and_validate_change_reason_with_function(
+    validate_change_reason_with_function(
         &workspace_context,
         &req.change_reason,
         &state,
+        &user
     )
     .await?;
 

--- a/crates/experimentation_platform/src/api/experiments/helpers.rs
+++ b/crates/experimentation_platform/src/api/experiments/helpers.rs
@@ -760,10 +760,11 @@ pub async fn validate_control_overrides(
     Ok(())
 }
 
-pub async fn fetch_and_validate_change_reason_with_function(
+pub async fn validate_change_reason_with_function(
     workspace_context: &WorkspaceContext,
     change_reason: &ChangeReason,
     state: &Data<AppState>,
+    user: &User,
 ) -> superposition::Result<()> {
     if !workspace_context.settings.enable_change_reason_validation {
         return Ok(());
@@ -777,15 +778,27 @@ pub async fn fetch_and_validate_change_reason_with_function(
         Stage::Published
     );
 
+    let user_str = serde_json::to_string(user).map_err(|err| {
+        log::error!("Something went wrong, failed to stringify user data {err}");
+        unexpected_error!(
+            "Something went wrong, failed to stringify user data {}",
+            err
+        )
+    })?;
+
     let payload = FunctionExecutionRequest::ChangeReasonValidationFunctionRequest {
         change_reason: change_reason.clone(),
     };
 
-    let headers_map = construct_header_map(workspace_context, vec![])?;
+    let headers_map = construct_header_map(workspace_context, vec![("x-user", user_str)])?;
 
     let response = http_client
         .post(&url)
         .headers(headers_map.into())
+        .header(
+            header::AUTHORIZATION,
+            format!("Internal {}", state.superposition_token),
+        )
         .json(&payload)
         .send()
         .await;


### PR DESCRIPTION
## Problem
Change reason function is being redirected to login page because of missing x-user and auth token

## Solution
Add x-user and auth token

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated change-reason validation across experiment and experiment group operations to include authenticated user context. This affects create, update, add/remove members operations for groups and create, conclude, discard, ramp, update overrides, pause, and resume operations for experiments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->