### PR TITLE
fix: send a more user friendly message on unique constraint violation

### DIFF
--- a/crates/superposition_types/src/result.rs
+++ b/crates/superposition_types/src/result.rs
@@ -66,8 +66,11 @@ impl AppError {
                 String::from("Something went wrong")
             }
             AppError::DbError(diesel_error::DatabaseError(
-                diesel_error_kind::UniqueViolation
-                | diesel_error_kind::CheckViolation
+                diesel_error_kind::UniqueViolation,
+                _,
+            )) => "the data you are trying to create already exists".to_string(),
+            AppError::DbError(diesel_error::DatabaseError(
+                diesel_error_kind::CheckViolation
                 | diesel_error_kind::NotNullViolation
                 | diesel_error_kind::ForeignKeyViolation,
                 error,
@@ -112,10 +115,15 @@ impl error::ResponseError for AppError {
                 StatusCode::NOT_FOUND,
                 "No records found. Please refine or correct your search parameters",
             ),
-
             AppError::DbError(diesel_error::DatabaseError(
-                diesel_error_kind::UniqueViolation
-                | diesel_error_kind::CheckViolation
+                diesel_error_kind::UniqueViolation,
+                _,
+            )) => Self::generate_err_response(
+                StatusCode::CONFLICT,
+                "The data you are trying to create already exists",
+            ),
+            AppError::DbError(diesel_error::DatabaseError(
+                diesel_error_kind::CheckViolation
                 | diesel_error_kind::NotNullViolation
                 | diesel_error_kind::ForeignKeyViolation,
                 error,

--- a/crates/superposition_types/src/result.rs
+++ b/crates/superposition_types/src/result.rs
@@ -68,7 +68,7 @@ impl AppError {
             AppError::DbError(diesel_error::DatabaseError(
                 diesel_error_kind::UniqueViolation,
                 _,
-            )) => "the data you are trying to create already exists".to_string(),
+            )) => "The data you are trying to create already exists".to_string(),
             AppError::DbError(diesel_error::DatabaseError(
                 diesel_error_kind::CheckViolation
                 | diesel_error_kind::NotNullViolation

--- a/tests/src/secrets.test.ts
+++ b/tests/src/secrets.test.ts
@@ -252,7 +252,7 @@ describe("Secret Operations", () => {
 
             await expect(
                 superpositionClient.send(duplicateCommand),
-            ).rejects.toThrow("duplicate key value violates unique constraint");
+            ).rejects.toThrow("The data you are trying to create already exists");
         } catch (error: any) {
             console.log("Error testing duplicate prevention:", error.message);
             throw error;

--- a/tests/src/variables.test.ts
+++ b/tests/src/variables.test.ts
@@ -281,7 +281,7 @@ describe("Variable Operations", () => {
 
             await expect(
                 superpositionClient.send(duplicateCommand),
-            ).rejects.toThrow("duplicate key value violates unique constraint");
+            ).rejects.toThrow("The data you are trying to create already exists");
         } catch (error: any) {
             console.log("Error testing duplicate prevention:", error.message);
             throw error;


### PR DESCRIPTION
## Problem
The error message when a user tries to create a duplicate entry is confusing

## Solution
Add a more generic message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for duplicate data entries, now providing clearer feedback when attempting to create data that already exists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/superposition/pull/1007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->