### PR TITLE
fix: avoid pinning connections when using PG proxies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4788,9 +4788,9 @@ dependencies = [
 
 [[package]]
 name = "juspay_diesel"
-version = "2.2.4"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "094e23f903983e5756cfe5ccf1546ba44b930b57b4d7031b3fc6eb9e909b38ac"
+checksum = "cfaf941005c71f729ca0540a23e1d0d4e0e7e19cdffba7170e4036065031b091"
 dependencies = [
  "bigdecimal",
  "bitflags 2.9.1",
@@ -6468,7 +6468,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.28",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6507,7 +6507,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7006,7 +7006,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7924,7 +7924,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ blake3 = "1.3.3"
 cfg-if = "1.0.0"
 chrono = { version = "0.4.26", features = ["serde"] }
 derive_more = "^0.99"
-diesel = { version = "2.2.4", package = "juspay_diesel", features = [
+diesel = { version = "2.3.1", package = "juspay_diesel", features = [
     "postgres",
     "r2d2",
     "serde_json",
@@ -60,6 +60,7 @@ diesel = { version = "2.2.4", package = "juspay_diesel", features = [
     "uuid",
     "postgres_backend",
     "numeric",
+    "rds-proxy",
 ] }
 fred = { version = "9.2.1" }
 futures-util = "0.3.28"


### PR DESCRIPTION
## Problem
RDS proxy pins all connections from superposition

## Solution
Update diesel to stop pinning of connections by removing SET commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded Diesel database library from version 2.2.4 to 2.3.1, bringing stability improvements and bug fixes.
  * Extended database infrastructure compatibility by adding support for additional connectivity configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/superposition/pull/1023?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->