### PR TITLE
fix: allow TOML and JSON config without overrides section

### DIFF
--- a/crates/superposition_core/src/format/json.rs
+++ b/crates/superposition_core/src/format/json.rs
@@ -64,6 +64,7 @@ struct JsonConfig {
     #[serde(rename = "default-configs")]
     default_configs: DefaultConfigsWithSchema,
     dimensions: HashMap<String, DimensionInfoJson>,
+    #[serde(default)]
     overrides: Vec<JsonContext>,
 }
 

--- a/crates/superposition_core/src/format/tests/json.rs
+++ b/crates/superposition_core/src/format/tests/json.rs
@@ -548,6 +548,26 @@ fn test_json_valid_parsing() {
 }
 
 #[test]
+fn test_json_missing_overrides_section() {
+    let json_str = r#"{
+        "default-configs": {
+            "timeout": { "value": 30, "schema": { "type": "integer" } }
+        },
+        "dimensions": {
+            "os": { "position": 1, "schema": { "type": "string" } }
+        }
+    }"#;
+
+    let result = JsonFormat::parse_config(json_str);
+    assert!(result.is_ok());
+    let parsed = result.unwrap();
+    assert_eq!(parsed.default_configs.len(), 1);
+    assert_eq!(parsed.dimensions.len(), 1);
+    assert!(parsed.contexts.is_empty());
+    assert!(parsed.overrides.is_empty());
+}
+
+#[test]
 fn test_json_missing_section_error() {
     let json_str = r#"{
         "default-configs": {

--- a/crates/superposition_core/src/format/tests/toml.rs
+++ b/crates/superposition_core/src/format/tests/toml.rs
@@ -237,6 +237,25 @@ timeout = 60
 }
 
 #[test]
+fn test_missing_overrides_section() {
+    let toml = r#"
+[default-configs]
+timeout = { value = 30, schema = { type = "integer" } }
+
+[dimensions]
+os = { position = 1, schema = { type = "string" } }
+"#;
+
+    let result = TomlFormat::parse_config(toml);
+    assert!(result.is_ok());
+    let parsed = result.unwrap();
+    assert_eq!(parsed.default_configs.len(), 1);
+    assert_eq!(parsed.dimensions.len(), 1);
+    assert!(parsed.contexts.is_empty());
+    assert!(parsed.overrides.is_empty());
+}
+
+#[test]
 fn test_dimension_type_regular() {
     let toml = r#"
 [default-configs]

--- a/crates/superposition_core/src/format/toml.rs
+++ b/crates/superposition_core/src/format/toml.rs
@@ -105,6 +105,7 @@ struct DetailedConfigToml {
     #[serde(rename = "default-configs")]
     default_configs: DefaultConfigsWithSchema,
     dimensions: BTreeMap<String, DimensionInfoToml>,
+    #[serde(default)]
     overrides: Vec<ContextToml>,
 }
 


### PR DESCRIPTION
## Summary
- Fixes #1027: the TOML parser failed to deserialize config files that omit the `[[overrides]]` section.
- Both the TOML and JSON parsers required an `overrides` field, so a config with only `default-configs` and `dimensions` errored with "missing field `overrides`".
- Marked the `overrides` field with `#[serde(default)]` in both `DetailedConfigToml` and `JsonConfig` so it defaults to an empty vector when the section is absent.

## Test plan
- [x] Added `test_missing_overrides_section` (TOML) and `test_json_missing_overrides_section` (JSON) covering configs with no overrides
- [x] `cargo test -p superposition_core --lib format::tests::toml` (26 passed)
- [x] `cargo test -p superposition_core --lib format::tests::json` (28 passed)

https://claude.ai/code/session_01JNFhzR5UjoXwcRqSDxUvgE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration files no longer require the `overrides` section; parsing now succeeds when omitted in both JSON and TOML formats.

* **Tests**
  * Added tests verifying that configuration parsing handles missing `overrides` sections correctly, producing valid configurations with empty overrides and contexts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/superposition/pull/1028?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->