### PR TITLE
fix: sort keys in TOML config download for default-config and overrides

### DIFF
--- a/crates/superposition_core/src/format/tests/toml.rs
+++ b/crates/superposition_core/src/format/tests/toml.rs
@@ -71,6 +71,47 @@ _context_ = { os = "linux" }
 }
 
 #[test]
+fn test_toml_serialize_sorts_keys() {
+    // Keys are intentionally declared out of alphabetical order, including a
+    // nested object value, to verify the serializer emits them sorted.
+    let toml = r#"
+[default-configs]
+zebra = { value = 1, schema = { type = "integer" } }
+alpha = { value = 2, schema = { type = "integer" } }
+nested = { value = { zoo = 1, ant = 2 }, schema = { type = "object" } }
+
+[dimensions]
+os = { position = 1, schema = { type = "string" } }
+
+[[overrides]]
+_context_ = { os = "linux" }
+zebra = 10
+alpha = 20
+nested = { zoo = 100, ant = 200 }
+"#;
+
+    let config = TomlFormat::parse_config(toml).unwrap();
+    let serialized = TomlFormat::serialize(config_to_detailed(&config)).unwrap();
+
+    let overrides_section = serialized.split("[[overrides]]").nth(1).unwrap();
+    let alpha = overrides_section.find("\nalpha = ").unwrap();
+    let zebra = overrides_section.find("\nzebra = ").unwrap();
+    assert!(
+        alpha < zebra,
+        "override keys not sorted:\n{overrides_section}"
+    );
+
+    // Nested object keys within an override value should also be sorted.
+    let nested = overrides_section.find("nested = {").unwrap();
+    let ant = overrides_section[nested..].find("ant").unwrap();
+    let zoo = overrides_section[nested..].find("zoo").unwrap();
+    assert!(
+        ant < zoo,
+        "nested object keys not sorted:\n{overrides_section}"
+    );
+}
+
+#[test]
 fn test_dimension_type_local_cohort() {
     let toml = r#"
 [default-configs]

--- a/crates/superposition_core/src/format/toml.rs
+++ b/crates/superposition_core/src/format/toml.rs
@@ -159,7 +159,9 @@ impl DetailedConfigToml {
         let context_str = format_toml_value(&TomlValue::Table(ctx.context));
         out.push_str(&format!("_context_ = {}\n", context_str));
 
-        for (k, v) in ctx.overrides {
+        let mut overrides: Vec<(String, TomlValue)> = ctx.overrides.into_iter().collect();
+        overrides.sort_by(|(a, _), (b, _)| a.cmp(b));
+        for (k, v) in overrides {
             let v_str = format_toml_value(&v);
             out.push_str(&format!("{} = {}\n", format_key(&k), v_str));
         }

--- a/crates/superposition_core/src/format/toml/helpers.rs
+++ b/crates/superposition_core/src/format/toml/helpers.rs
@@ -55,9 +55,13 @@ pub fn format_toml_value(value: &TomlValue) -> String {
             format!("[{}]", items.join(", "))
         }
         TomlValue::Table(table) => {
-            let entries: Vec<String> = table
-                .iter()
-                .map(|(k, v)| format!("{} = {}", format_key(k), format_toml_value(v)))
+            let mut keys: Vec<&String> = table.keys().collect();
+            keys.sort();
+            let entries: Vec<String> = keys
+                .into_iter()
+                .map(|k| {
+                    format!("{} = {}", format_key(k), format_toml_value(&table[k]))
+                })
                 .collect();
             format!("{{ {} }}", entries.join(", "))
         }


### PR DESCRIPTION
## Summary

The TOML config download (`/config/toml` endpoint → `TomlFormat::serialize`) emitted keys in insertion order rather than sorted order. The `toml` crate is built with `preserve_order`, and `serde_json::Map` (wrapped by `Overrides`/`Condition`) transitively pulls in `preserve_order` too — so override keys and any nested object values came out in arbitrary DB-insertion order, producing non-deterministic, hard-to-diff output.

## Changes (`crates/superposition_core/src/format/toml`)

- `helpers.rs` — `format_toml_value` now sorts keys when formatting any nested `TomlValue::Table`. This covers nested default-config values/schemas, dimension schemas, `_context_` conditions, and nested override objects.
- `toml.rs` — `emit_overrides` now sorts the top-level override keys before emitting them.

Top-level default-config and dimension keys were already sorted (both are `BTreeMap`), so those were left as-is.

Note: nested objects (including the `value`/`schema` pairs inside each default-config entry) are now emitted alphabetically, so e.g. `schema` prints before `value`. Output remains valid and round-trips correctly — it's just deterministic now.

Fixes #1024

## Test plan

- [x] Added `test_toml_serialize_sorts_keys` covering both override-key and nested-object-key sorting
- [x] `cargo test -p superposition_core --lib format::` — all 53 format tests pass

https://claude.ai/code/session_012rJ3YRiC18p1xnLMGYBD5B

---
_Generated by [Claude Code](https://claude.ai/code/session_012rJ3YRiC18p1xnLMGYBD5B)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * TOML serialization now generates deterministic output with keys consistently sorted in override entries and inline table formatting, ensuring reproducible configuration output across multiple runs.

* **Tests**
  * Added test suite verifying deterministic key ordering during TOML serialization, validating proper sorting of override entries and nested object keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->