### PR TITLE
fix(openfeature): block evaluation until experiments cache is ready

### DIFF
--- a/clients/java/openfeature-provider/src/main/java/io/juspay/superposition/openfeature/SuperpositionOpenFeatureProvider.java
+++ b/clients/java/openfeature-provider/src/main/java/io/juspay/superposition/openfeature/SuperpositionOpenFeatureProvider.java
@@ -77,7 +77,9 @@ public class SuperpositionOpenFeatureProvider implements FeatureProvider {
     private Optional<EvaluationContext> defaultCtx;
     private final Optional<EvaluationArgs> fallbackArgs;
     private final CompletableFuture<Void> cacheReady = new CompletableFuture<>();
+    private volatile CompletableFuture<Void> experimentsReady = new CompletableFuture<>();
     private final int configTimeout;
+    private final int experimentationTimeout;
 
     public SuperpositionOpenFeatureProvider(@NonNull SuperpositionProviderOptions options) {
         if (options.fallbackConfig != null) {
@@ -107,6 +109,8 @@ public class SuperpositionOpenFeatureProvider implements FeatureProvider {
         );
 
         if (options.experimentationOptions != null) {
+            this.experimentationTimeout =
+                options.experimentationOptions.refreshStrategy.getTimeout();
             var listExpInput = ListExperimentInput.builder()
                 .orgId(options.orgId)
                 .workspaceId(options.workspaceId)
@@ -145,6 +149,9 @@ public class SuperpositionOpenFeatureProvider implements FeatureProvider {
         } else {
             this.expRefresh = Optional.empty();
             this.expGroupRefresh = Optional.empty();
+            this.experimentationTimeout = 0;
+            // No experimentation configured: unblock the evaluation path immediately.
+            this.experimentsReady.complete(null);
         }
     }
 
@@ -311,6 +318,16 @@ public class SuperpositionOpenFeatureProvider implements FeatureProvider {
                 throw new Exception("Config cache not initialized within timeout (" + configTimeout + "ms).");
             }
         }
+        // When experimentation is configured, also block until cache.initExperiments has
+        // been called, otherwise evalConfig may apply an empty experiment set and silently
+        // fall back to the default config for users that should be bucketed into a variant.
+        if (!experimentsReady.isDone()) {
+            try {
+                experimentsReady.get(experimentationTimeout, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException e) {
+                throw new Exception("Experiments cache not initialized within timeout (" + experimentationTimeout + "ms).");
+            }
+        }
         var ctx_ = defaultCtx.isPresent() ? ctx.merge(defaultCtx.get()) : ctx;
         var queryData = EvaluationArgs.Companion.buildQueryData(ctx_);
         String targetingKey = ctx_.getTargetingKey();
@@ -368,9 +385,11 @@ public class SuperpositionOpenFeatureProvider implements FeatureProvider {
             if (exps.isPresent() && groups.isPresent()) {
                 try {
                     cache.initExperiments(exps.get(), groups.get());
+                    experimentsReady.complete(null);
                     log.debug("Experiments cache re-initialized");
                 } catch (Exception e) {
                     log.error("Failed to reinitialize experiments cache: {}", e.getMessage());
+                    experimentsReady = new CompletableFuture<>();
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Fix a race in the Java/Kotlin OpenFeature provider where `evaluateConfigInternal` only awaits the config cache (`cacheReady`) before calling `cache.evalConfig`, while the experiments cache is initialized by an independent refresh job.
- In the window between `cache.initConfig` and `cache.initExperiments`, an eval applies an empty experiment set and silently returns the default config for users that should have been bucketed into a variant.
- This is the root cause of intermittent Kotlin provider Test 9 failures (`Bangalore customer` returning `10000` — the default — instead of `7000`/`8000`).

## Fix
In `SuperpositionOpenFeatureProvider.java`:
- Add `experimentsReady` (a parallel `CompletableFuture<Void>` to `cacheReady`).
- Initialize a new `experimentationTimeout` field from `options.experimentationOptions.refreshStrategy.getTimeout()`. When `experimentationOptions` is `null`, complete `experimentsReady` eagerly so the eval path never blocks.
- Complete `experimentsReady` inside `reinitExperimentsCache` immediately after `cache.initExperiments(...)` succeeds.
- In `evaluateConfigInternal`, after waiting on `cacheReady`, also wait on `experimentsReady` (bounded by `experimentationTimeout`) before calling `cache.evalConfig`. On timeout, throw — caller maps that to `PROVIDER_NOT_READY`, matching the existing config-cache timeout behavior.

The pattern mirrors the existing `cacheReady` plumbing 1:1.

## Test plan
- [ ] CI: `Provider Tests (kotlin)` — Test 9 (`Experimentation - Bangalore customer`) should now be deterministic
- [ ] CI: existing JUnit `ProviderTest` suite passes
- [ ] Manual: configure provider without `experimentationOptions` — eval path should not block

https://claude.ai/code/session_01JNFhzR5UjoXwcRqSDxUvgE

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNFhzR5UjoXwcRqSDxUvgE)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Experimentation data now waits for proper initialization before use
  * Added timeout protection to prevent indefinite evaluation delays
  * Graceful error handling when experiment initialization doesn't complete within the timeout window

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/juspay/superposition/pull/1032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->