### PR TITLE
fix: add description field to SuperTOML/JSON dimension and default-config export

### DIFF
--- a/clients/java/bindings/src/main/kotlin/uniffi/superposition_types/superposition_types.kt
+++ b/clients/java/bindings/src/main/kotlin/uniffi/superposition_types/superposition_types.kt
@@ -1179,7 +1179,14 @@ data class DimensionInfo (
     var `position`: kotlin.Int, 
     var `dimensionType`: DimensionType, 
     var `dependencyGraph`: DependencyGraph, 
-    var `valueComputeFunctionName`: kotlin.String?
+    var `valueComputeFunctionName`: kotlin.String?, 
+    /**
+     * Human-readable description of the dimension. Carried through the
+     * detailed (import/export) flow; intentionally not part of the config
+     * resolution response, so it is skipped during serialization and
+     * defaults to empty when absent.
+     */
+    var `description`: kotlin.String
 ) {
     
     companion object
@@ -1196,6 +1203,7 @@ public object FfiConverterTypeDimensionInfo: FfiConverterRustBuffer<DimensionInf
             FfiConverterTypeDimensionType.read(buf),
             FfiConverterTypeDependencyGraph.read(buf),
             FfiConverterOptionalString.read(buf),
+            FfiConverterString.read(buf),
         )
     }
 
@@ -1204,7 +1212,8 @@ public object FfiConverterTypeDimensionInfo: FfiConverterRustBuffer<DimensionInf
             FfiConverterInt.allocationSize(value.`position`) +
             FfiConverterTypeDimensionType.allocationSize(value.`dimensionType`) +
             FfiConverterTypeDependencyGraph.allocationSize(value.`dependencyGraph`) +
-            FfiConverterOptionalString.allocationSize(value.`valueComputeFunctionName`)
+            FfiConverterOptionalString.allocationSize(value.`valueComputeFunctionName`) +
+            FfiConverterString.allocationSize(value.`description`)
     )
 
     override fun write(value: DimensionInfo, buf: ByteBuffer) {
@@ -1213,6 +1222,7 @@ public object FfiConverterTypeDimensionInfo: FfiConverterRustBuffer<DimensionInf
             FfiConverterTypeDimensionType.write(value.`dimensionType`, buf)
             FfiConverterTypeDependencyGraph.write(value.`dependencyGraph`, buf)
             FfiConverterOptionalString.write(value.`valueComputeFunctionName`, buf)
+            FfiConverterString.write(value.`description`, buf)
     }
 }
 

--- a/clients/java/openfeature-provider/src/main/kotlin/io/juspay/superposition/openfeature/EvaluationArgs.kt
+++ b/clients/java/openfeature-provider/src/main/kotlin/io/juspay/superposition/openfeature/EvaluationArgs.kt
@@ -191,7 +191,8 @@ internal class EvaluationArgs {
                 dim.position(),
                 toFfiDimensionType (dim.dimensionType() ),
                 dim.dependencyGraph(),
-                dim.valueComputeFunctionName()
+                dim.valueComputeFunctionName(),
+                ""
             )
         }
 

--- a/clients/python/bindings/superposition_bindings/superposition_types.py
+++ b/clients/python/bindings/superposition_bindings/superposition_types.py
@@ -1039,15 +1039,24 @@ class DimensionInfo:
     dimension_type: "DimensionType"
     dependency_graph: "DependencyGraph"
     value_compute_function_name: "typing.Optional[str]"
-    def __init__(self, *, schema: "ExtendedMap", position: "int", dimension_type: "DimensionType", dependency_graph: "DependencyGraph", value_compute_function_name: "typing.Optional[str]"):
+    description: "str"
+    """
+    Human-readable description of the dimension. Carried through the
+    detailed (import/export) flow; intentionally not part of the config
+    resolution response, so it is skipped during serialization and
+    defaults to empty when absent.
+    """
+
+    def __init__(self, *, schema: "ExtendedMap", position: "int", dimension_type: "DimensionType", dependency_graph: "DependencyGraph", value_compute_function_name: "typing.Optional[str]", description: "str"):
         self.schema = schema
         self.position = position
         self.dimension_type = dimension_type
         self.dependency_graph = dependency_graph
         self.value_compute_function_name = value_compute_function_name
+        self.description = description
 
     def __str__(self):
-        return "DimensionInfo(schema={}, position={}, dimension_type={}, dependency_graph={}, value_compute_function_name={})".format(self.schema, self.position, self.dimension_type, self.dependency_graph, self.value_compute_function_name)
+        return "DimensionInfo(schema={}, position={}, dimension_type={}, dependency_graph={}, value_compute_function_name={}, description={})".format(self.schema, self.position, self.dimension_type, self.dependency_graph, self.value_compute_function_name, self.description)
 
     def __eq__(self, other):
         if self.schema != other.schema:
@@ -1060,6 +1069,8 @@ class DimensionInfo:
             return False
         if self.value_compute_function_name != other.value_compute_function_name:
             return False
+        if self.description != other.description:
+            return False
         return True
 
 class _UniffiConverterTypeDimensionInfo(_UniffiConverterRustBuffer):
@@ -1071,6 +1082,7 @@ class _UniffiConverterTypeDimensionInfo(_UniffiConverterRustBuffer):
             dimension_type=_UniffiConverterTypeDimensionType.read(buf),
             dependency_graph=_UniffiConverterTypeDependencyGraph.read(buf),
             value_compute_function_name=_UniffiConverterOptionalString.read(buf),
+            description=_UniffiConverterString.read(buf),
         )
 
     @staticmethod
@@ -1080,6 +1092,7 @@ class _UniffiConverterTypeDimensionInfo(_UniffiConverterRustBuffer):
         _UniffiConverterTypeDimensionType.check_lower(value.dimension_type)
         _UniffiConverterTypeDependencyGraph.check_lower(value.dependency_graph)
         _UniffiConverterOptionalString.check_lower(value.value_compute_function_name)
+        _UniffiConverterString.check_lower(value.description)
 
     @staticmethod
     def write(value, buf):
@@ -1088,6 +1101,7 @@ class _UniffiConverterTypeDimensionInfo(_UniffiConverterRustBuffer):
         _UniffiConverterTypeDimensionType.write(value.dimension_type, buf)
         _UniffiConverterTypeDependencyGraph.write(value.dependency_graph, buf)
         _UniffiConverterOptionalString.write(value.value_compute_function_name, buf)
+        _UniffiConverterString.write(value.description, buf)
 
 
 class Variant:

--- a/clients/python/provider/superposition_provider/cac_config.py
+++ b/clients/python/provider/superposition_provider/cac_config.py
@@ -66,6 +66,7 @@ def convert_fallback_config(fallback_config: Optional[Dict[str, Any]]) -> Option
                 dimension_type=dimension['dimension_type'],
                 dependency_graph=dimension['dependency_graph'],
                 value_compute_function_name=dimension.get('value_compute_function_name'),
+                description=dimension.get('description', key),
             )
             for key, dimension in fallback_config['dimensions'].items()
         }
@@ -227,6 +228,7 @@ class CacConfig:
                         dimension_type=to_dimension_type(dim_info.dimension_type),
                         dependency_graph=dim_info.dependency_graph,
                         value_compute_function_name=dim_info.value_compute_function_name,
+                        description="",
                     )
                     dimensions[key] = dimension
                 config_data['dimensions'] = dimensions

--- a/clients/python/provider/superposition_provider/conversions.py
+++ b/clients/python/provider/superposition_provider/conversions.py
@@ -61,6 +61,7 @@ def config_response_to_ffi_config(response: GetConfigOutput) -> Config:
             dimension_type=to_dimension_type(dim_info.dimension_type),
             dependency_graph=dim_info.dependency_graph,
             value_compute_function_name=dim_info.value_compute_function_name,
+            description="",
         )
         dimensions[key] = dimension
 

--- a/crates/context_aware_config/src/helpers.rs
+++ b/crates/context_aware_config/src/helpers.rs
@@ -167,11 +167,16 @@ pub fn generate_detailed_cac(
 ) -> superposition::Result<DetailedConfig> {
     let (contexts, overrides) = get_context_data(conn, schema_name)?;
 
-    // Fetch default_configs with both value and schema
+    // Fetch default_configs with value, schema and description
     let default_config_vec = def_conf::default_configs
-        .select((def_conf::key, def_conf::value, def_conf::schema))
+        .select((
+            def_conf::key,
+            def_conf::value,
+            def_conf::schema,
+            def_conf::description,
+        ))
         .schema_name(schema_name)
-        .load::<(String, Value, Value)>(conn)
+        .load::<(String, Value, Value, String)>(conn)
         .map_err(|err| {
             log::error!("failed to fetch default_configs with error: {}", err);
             db_error!(err)
@@ -179,8 +184,15 @@ pub fn generate_detailed_cac(
 
     let default_configs = default_config_vec.into_iter().fold(
         std::collections::BTreeMap::new(),
-        |mut acc, (key, value, schema)| {
-            acc.insert(key, DefaultConfigInfo { value, schema });
+        |mut acc, (key, value, schema, description)| {
+            acc.insert(
+                key,
+                DefaultConfigInfo {
+                    value,
+                    schema,
+                    description,
+                },
+            );
             acc
         },
     );

--- a/crates/superposition_core/src/format/json.rs
+++ b/crates/superposition_core/src/format/json.rs
@@ -22,6 +22,10 @@ struct DimensionInfoJson {
     schema: Value,
     #[serde(rename = "type", default = "dim_type_default")]
     dimension_type: String,
+    /// Optional on parse (the dimension name is used as a fallback when
+    /// missing) and always present on export.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
 }
 
 impl TryFrom<DimensionInfo> for DimensionInfoJson {
@@ -31,6 +35,7 @@ impl TryFrom<DimensionInfo> for DimensionInfoJson {
             position: d.position,
             schema: Value::from(&d.schema),
             dimension_type: d.dimension_type.to_string(),
+            description: Some(d.description),
         })
     }
 }
@@ -51,6 +56,7 @@ impl TryFrom<DimensionInfoJson> for DimensionInfo {
                 .map_err(JsonFormat::conversion_error)?,
             dependency_graph: DependencyGraph(HashMap::new()),
             value_compute_function_name: None,
+            description: d.description.unwrap_or_default(),
         })
     }
 }
@@ -85,11 +91,27 @@ impl TryFrom<JsonConfig> for DetailedConfig {
         let dimensions: HashMap<String, DimensionInfo> = json_config
             .dimensions
             .into_iter()
-            .map(|(k, v)| Ok((k, DimensionInfo::try_from(v)?)))
+            .map(|(k, v)| {
+                let mut dim_info = DimensionInfo::try_from(v)?;
+                // Fall back to the dimension name when the description is
+                // absent in the imported file.
+                if dim_info.description.trim().is_empty() {
+                    dim_info.description = k.clone();
+                }
+                Ok((k, dim_info))
+            })
             .collect::<Result<_, FormatError>>()?;
 
+        let mut default_configs = json_config.default_configs;
+        for (k, info) in default_configs.iter_mut() {
+            // Fall back to the key name when the description is absent.
+            if info.description.trim().is_empty() {
+                info.description = k.clone();
+            }
+        }
+
         JsonFormat::try_into_detailed(
-            json_config.default_configs,
+            default_configs,
             dimensions,
             json_config.overrides,
             |ctx| {
@@ -118,7 +140,15 @@ impl TryFrom<DetailedConfig> for JsonConfig {
         let dimensions: HashMap<String, DimensionInfoJson> = detailed_config
             .dimensions
             .iter()
-            .map(|(k, v)| Ok((k.clone(), DimensionInfoJson::try_from(v.clone())?)))
+            .map(|(k, v)| {
+                let mut dim = DimensionInfoJson::try_from(v.clone())?;
+                // Description is mandatory in the exported file; fall back to
+                // the dimension name when it is missing.
+                if dim.description.as_ref().map_or(true, |d| d.trim().is_empty()) {
+                    dim.description = Some(k.clone());
+                }
+                Ok((k.clone(), dim))
+            })
             .collect::<Result<_, FormatError>>()?;
 
         let overrides = detailed_config
@@ -146,8 +176,17 @@ impl TryFrom<DetailedConfig> for JsonConfig {
             })
             .collect();
 
+        let mut default_configs = detailed_config.default_configs;
+        for (k, info) in default_configs.iter_mut() {
+            // Description is mandatory in the exported file; fall back to the
+            // key name when it is missing.
+            if info.description.trim().is_empty() {
+                info.description = k.clone();
+            }
+        }
+
         Ok(Self {
-            default_configs: detailed_config.default_configs,
+            default_configs,
             dimensions,
             overrides,
         })

--- a/crates/superposition_core/src/format/json.rs
+++ b/crates/superposition_core/src/format/json.rs
@@ -144,7 +144,7 @@ impl TryFrom<DetailedConfig> for JsonConfig {
                 let mut dim = DimensionInfoJson::try_from(v.clone())?;
                 // Description is mandatory in the exported file; fall back to
                 // the dimension name when it is missing.
-                if dim.description.as_ref().map_or(true, |d| d.trim().is_empty()) {
+                if dim.description.as_ref().is_none_or(|d| d.trim().is_empty()) {
                     dim.description = Some(k.clone());
                 }
                 Ok((k.clone(), dim))

--- a/crates/superposition_core/src/format/tests/json.rs
+++ b/crates/superposition_core/src/format/tests/json.rs
@@ -105,9 +105,15 @@ fn test_json_description_exported_and_falls_back_to_name() {
     }"#;
 
     let detailed = JsonFormat::parse_into_detailed(json_str).unwrap();
-    assert_eq!(detailed.dimensions.get("os").unwrap().description, "operating system");
+    assert_eq!(
+        detailed.dimensions.get("os").unwrap().description,
+        "operating system"
+    );
     // Missing descriptions fall back to the name.
-    assert_eq!(detailed.dimensions.get("region").unwrap().description, "region");
+    assert_eq!(
+        detailed.dimensions.get("region").unwrap().description,
+        "region"
+    );
     assert_eq!(
         detailed.default_configs.get("timeout").unwrap().description,
         "request timeout"

--- a/crates/superposition_core/src/format/tests/json.rs
+++ b/crates/superposition_core/src/format/tests/json.rs
@@ -34,6 +34,7 @@ fn config_to_detailed(config: &Config) -> DetailedConfig {
                 DefaultConfigInfo {
                     value: value.clone(),
                     schema,
+                    description: key.clone(),
                 },
             )
         })
@@ -84,6 +85,43 @@ fn test_json_round_trip() {
     assert_eq!(config.default_configs, reparsed.default_configs);
     assert_eq!(config.dimensions.len(), reparsed.dimensions.len());
     assert_eq!(config.contexts.len(), reparsed.contexts.len());
+}
+
+#[test]
+fn test_json_description_exported_and_falls_back_to_name() {
+    // `os` and `timeout` declare descriptions; `region` and `retries` don't.
+    let json_str = r#"{
+        "default-configs": {
+            "timeout": { "value": 30, "schema": { "type": "integer" }, "description": "request timeout" },
+            "retries": { "value": 3, "schema": { "type": "integer" } }
+        },
+        "dimensions": {
+            "os": { "position": 1, "schema": { "type": "string" }, "description": "operating system" },
+            "region": { "position": 2, "schema": { "type": "string" } }
+        },
+        "overrides": [
+            { "_context_": { "os": "linux" }, "timeout": 60 }
+        ]
+    }"#;
+
+    let detailed = JsonFormat::parse_into_detailed(json_str).unwrap();
+    assert_eq!(detailed.dimensions.get("os").unwrap().description, "operating system");
+    // Missing descriptions fall back to the name.
+    assert_eq!(detailed.dimensions.get("region").unwrap().description, "region");
+    assert_eq!(
+        detailed.default_configs.get("timeout").unwrap().description,
+        "request timeout"
+    );
+    assert_eq!(
+        detailed.default_configs.get("retries").unwrap().description,
+        "retries"
+    );
+
+    let serialized = JsonFormat::serialize(detailed).unwrap();
+    assert!(serialized.contains(r#""description": "operating system""#));
+    assert!(serialized.contains(r#""description": "region""#));
+    assert!(serialized.contains(r#""description": "request timeout""#));
+    assert!(serialized.contains(r#""description": "retries""#));
 }
 
 #[test]

--- a/crates/superposition_core/src/format/tests/toml.rs
+++ b/crates/superposition_core/src/format/tests/toml.rs
@@ -86,7 +86,10 @@ timeout = 60
 "#;
 
     let detailed = TomlFormat::parse_into_detailed(toml).unwrap();
-    assert_eq!(detailed.dimensions.get("os").unwrap().description, "operating system");
+    assert_eq!(
+        detailed.dimensions.get("os").unwrap().description,
+        "operating system"
+    );
     assert_eq!(
         detailed.default_configs.get("timeout").unwrap().description,
         "request timeout"
@@ -98,7 +101,10 @@ timeout = 60
 
     // Description survives a full round-trip.
     let reparsed = TomlFormat::parse_into_detailed(&serialized).unwrap();
-    assert_eq!(reparsed.dimensions.get("os").unwrap().description, "operating system");
+    assert_eq!(
+        reparsed.dimensions.get("os").unwrap().description,
+        "operating system"
+    );
     assert_eq!(
         reparsed.default_configs.get("timeout").unwrap().description,
         "request timeout"

--- a/crates/superposition_core/src/format/tests/toml.rs
+++ b/crates/superposition_core/src/format/tests/toml.rs
@@ -34,6 +34,7 @@ fn config_to_detailed(config: &Config) -> DetailedConfig {
                 DefaultConfigInfo {
                     value: value.clone(),
                     schema,
+                    description: key.clone(),
                 },
             )
         })
@@ -68,6 +69,69 @@ _context_ = { os = "linux" }
     assert_eq!(config.default_configs, reparsed.default_configs);
     assert_eq!(config.dimensions.len(), reparsed.dimensions.len());
     assert_eq!(config.contexts.len(), reparsed.contexts.len());
+}
+
+#[test]
+fn test_toml_description_exported_and_round_trips() {
+    let toml = r#"
+[default-configs]
+timeout = { value = 30, schema = { type = "integer" }, description = "request timeout" }
+
+[dimensions]
+os = { position = 1, schema = { type = "string" }, description = "operating system" }
+
+[[overrides]]
+_context_ = { os = "linux" }
+timeout = 60
+"#;
+
+    let detailed = TomlFormat::parse_into_detailed(toml).unwrap();
+    assert_eq!(detailed.dimensions.get("os").unwrap().description, "operating system");
+    assert_eq!(
+        detailed.default_configs.get("timeout").unwrap().description,
+        "request timeout"
+    );
+
+    let serialized = TomlFormat::serialize(detailed).unwrap();
+    assert!(serialized.contains(r#"description = "operating system""#));
+    assert!(serialized.contains(r#"description = "request timeout""#));
+
+    // Description survives a full round-trip.
+    let reparsed = TomlFormat::parse_into_detailed(&serialized).unwrap();
+    assert_eq!(reparsed.dimensions.get("os").unwrap().description, "operating system");
+    assert_eq!(
+        reparsed.default_configs.get("timeout").unwrap().description,
+        "request timeout"
+    );
+}
+
+#[test]
+fn test_toml_description_falls_back_to_name_when_missing() {
+    // Neither the dimension nor the default config declare a description.
+    let toml = r#"
+[default-configs]
+timeout = { value = 30, schema = { type = "integer" } }
+
+[dimensions]
+os = { position = 1, schema = { type = "string" } }
+
+[[overrides]]
+_context_ = { os = "linux" }
+timeout = 60
+"#;
+
+    let detailed = TomlFormat::parse_into_detailed(toml).unwrap();
+    // Missing description falls back to the key / dimension name.
+    assert_eq!(detailed.dimensions.get("os").unwrap().description, "os");
+    assert_eq!(
+        detailed.default_configs.get("timeout").unwrap().description,
+        "timeout"
+    );
+
+    // Export is mandatory: the fallback value is emitted in the file.
+    let serialized = TomlFormat::serialize(detailed).unwrap();
+    assert!(serialized.contains(r#"description = "os""#));
+    assert!(serialized.contains(r#"description = "timeout""#));
 }
 
 #[test]

--- a/crates/superposition_core/src/format/toml.rs
+++ b/crates/superposition_core/src/format/toml.rs
@@ -211,11 +211,7 @@ impl TryFrom<DetailedConfig> for DetailedConfigToml {
                     DimensionInfoToml::try_from(v).map(|mut dim| {
                         // Description is mandatory in the exported file; fall
                         // back to the dimension name when it is missing.
-                        if dim
-                            .description
-                            .as_ref()
-                            .map_or(true, |d| d.trim().is_empty())
-                        {
+                        if dim.description.as_ref().is_none_or(|d| d.trim().is_empty()) {
                             dim.description = Some(k.clone());
                         }
                         (k, dim)

--- a/crates/superposition_core/src/format/toml.rs
+++ b/crates/superposition_core/src/format/toml.rs
@@ -29,6 +29,10 @@ struct DimensionInfoToml {
     schema: toml::Table,
     #[serde(rename = "type", default = "dim_type_default")]
     dimension_type: String,
+    /// Optional on parse (the dimension name is used as a fallback when
+    /// missing) and always present on export.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
 }
 
 fn dim_type_default() -> String {
@@ -48,6 +52,7 @@ impl TryFrom<DimensionInfo> for DimensionInfoToml {
             position: d.position,
             schema,
             dimension_type: d.dimension_type.to_string(),
+            description: Some(d.description),
         })
     }
 }
@@ -69,6 +74,7 @@ impl TryFrom<DimensionInfoToml> for DimensionInfo {
                 .map_err(TomlFormat::conversion_error)?,
             dependency_graph: DependencyGraph(HashMap::new()),
             value_compute_function_name: None,
+            description: d.description.unwrap_or_default(),
         })
     }
 }
@@ -115,7 +121,12 @@ impl DetailedConfigToml {
         let mut out = String::new();
         out.push_str("[default-configs]\n");
 
-        for (k, v) in default_configs.into_inner() {
+        for (k, mut v) in default_configs.into_inner() {
+            // Description is mandatory in the exported file; fall back to the
+            // key name when it is missing so importing remains lossless.
+            if v.description.trim().is_empty() {
+                v.description = k.clone();
+            }
             let v_toml = TomlValue::try_from(v).map_err(|e| {
                 TomlFormat::serialization_error(format!(
                     "Failed to serialize '{}': {}",
@@ -196,7 +207,20 @@ impl TryFrom<DetailedConfig> for DetailedConfigToml {
             dimensions: d
                 .dimensions
                 .into_iter()
-                .map(|(k, v)| DimensionInfoToml::try_from(v).map(|dim| (k, dim)))
+                .map(|(k, v)| {
+                    DimensionInfoToml::try_from(v).map(|mut dim| {
+                        // Description is mandatory in the exported file; fall
+                        // back to the dimension name when it is missing.
+                        if dim
+                            .description
+                            .as_ref()
+                            .map_or(true, |d| d.trim().is_empty())
+                        {
+                            dim.description = Some(k.clone());
+                        }
+                        (k, dim)
+                    })
+                })
                 .collect::<Result<BTreeMap<_, _>, _>>()?,
             overrides: d
                 .contexts
@@ -213,10 +237,27 @@ impl TryFrom<DetailedConfigToml> for DetailedConfig {
         let dimensions = d
             .dimensions
             .into_iter()
-            .map(|(k, v)| v.try_into().map(|dim_info| (k, dim_info)))
+            .map(|(k, v)| {
+                DimensionInfo::try_from(v).map(|mut dim_info| {
+                    // Fall back to the dimension name when the description is
+                    // absent in the imported file.
+                    if dim_info.description.trim().is_empty() {
+                        dim_info.description = k.clone();
+                    }
+                    (k, dim_info)
+                })
+            })
             .collect::<Result<HashMap<_, DimensionInfo>, FormatError>>()?;
 
-        TomlFormat::try_into_detailed(d.default_configs, dimensions, d.overrides, |ctx| {
+        let mut default_configs = d.default_configs;
+        for (k, info) in default_configs.iter_mut() {
+            // Fall back to the key name when the description is absent.
+            if info.description.trim().is_empty() {
+                info.description = k.clone();
+            }
+        }
+
+        TomlFormat::try_into_detailed(default_configs, dimensions, d.overrides, |ctx| {
             let condition = try_condition_from_toml(ctx.context)?;
             let override_vals = try_overrides_from_toml(ctx.overrides)?;
             Ok((condition, override_vals))

--- a/crates/superposition_core/tests/test_filter_debug.rs
+++ b/crates/superposition_core/tests/test_filter_debug.rs
@@ -30,6 +30,7 @@ fn config_to_detailed(config: &Config) -> DetailedConfig {
                 DefaultConfigInfo {
                     value: value.clone(),
                     schema,
+                    description: key.clone(),
                 },
             )
         })

--- a/crates/superposition_provider/src/utils.rs
+++ b/crates/superposition_provider/src/utils.rs
@@ -93,6 +93,9 @@ impl ConversionUtils {
                     dependency_graph: DependencyGraph(dimension_info.dependency_graph),
                     value_compute_function_name: dimension_info
                         .value_compute_function_name,
+                    // Description is not part of the config resolution
+                    // response; runtime evaluation does not use it.
+                    description: String::new(),
                 };
                 Ok((key, dim_info))
             })

--- a/crates/superposition_types/src/config.rs
+++ b/crates/superposition_types/src/config.rs
@@ -388,6 +388,12 @@ pub struct DimensionInfo {
     pub dependency_graph: DependencyGraph,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value_compute_function_name: Option<String>,
+    /// Human-readable description of the dimension. Carried through the
+    /// detailed (import/export) flow; intentionally not part of the config
+    /// resolution response, so it is skipped during serialization and
+    /// defaults to empty when absent.
+    #[serde(default, skip_serializing)]
+    pub description: String,
 }
 
 /// Information about a default config key including its value and schema
@@ -396,6 +402,11 @@ pub struct DimensionInfo {
 pub struct DefaultConfigInfo {
     pub value: Value,
     pub schema: Value,
+    /// Human-readable description of the default config key. Optional on
+    /// parse (falls back to the key name when missing) and always emitted
+    /// on export.
+    #[serde(default)]
+    pub description: String,
 }
 
 /// A map of config keys to their values and schemas

--- a/docs/docs/superposition-config-file/format-specification.md
+++ b/docs/docs/superposition-config-file/format-specification.md
@@ -63,16 +63,16 @@ The `[default-configs]` section defines all possible configuration keys for your
 
 ```toml
 [default-configs]
-<key> = { value = <default_value>, schema = <json_schema>, description = <string> }
+<key> = { value = <default_value>, schema = <json_schema> [, description = <string>] }
 ```
 
 ### Parameters
 
-| Parameter     | Type        | Required | Description                                                            |
-| ------------- | ----------- | -------- | --------------------------------------------------------------------- |
-| `value`       | Any         | Yes      | The default value for this configuration key                          |
-| `schema`      | JSON Schema | Yes      | JSON Schema that validates the value                                  |
-| `description` | String      | Yes      | Human-readable description. If omitted on import, the key name is used |
+| Parameter     | Type        | Required        | Description                                                                          |
+| ------------- | ----------- | --------------- | ----------------------------------------------------------------------------------- |
+| `value`       | Any         | Yes             | The default value for this configuration key                                        |
+| `schema`      | JSON Schema | Yes             | JSON Schema that validates the value                                                |
+| `description` | String      | No (on import)  | Human-readable description. Optional on import (falls back to the key name when omitted); always emitted on export |
 
 ### Examples
 
@@ -145,17 +145,17 @@ The `[dimensions]` section defines the attributes that segment your configuratio
 
 ```toml
 [dimensions]
-<dimension_name> = { position = <number>, schema = <json_schema>, description = <string> [, type = <dimension_type>] }
+<dimension_name> = { position = <number>, schema = <json_schema> [, description = <string>] [, type = <dimension_type>] }
 ```
 
 ### Parameters
 
-| Parameter     | Type        | Required | Description                                                                                |
-| ------------- | ----------- | -------- | ----------------------------------------------------------------------------------------- |
-| `position`    | Integer     | Yes      | Position for priority calculation (higher = more specific)                                |
-| `schema`      | JSON Schema | Yes      | Schema validating dimension values                                                        |
-| `description` | String      | Yes      | Human-readable description. If omitted on import, the dimension name is used               |
-| `type`        | String      | No       | Dimension type: `"REGULAR"` (default), `"LOCAL_COHORT:<dim>"`, or `"REMOTE_COHORT:<dim>"` |
+| Parameter     | Type        | Required        | Description                                                                                |
+| ------------- | ----------- | --------------- | ----------------------------------------------------------------------------------------- |
+| `position`    | Integer     | Yes             | Position for priority calculation (higher = more specific)                                |
+| `schema`      | JSON Schema | Yes             | Schema validating dimension values                                                        |
+| `description` | String      | No (on import)  | Human-readable description. Optional on import (falls back to the dimension name when omitted); always emitted on export |
+| `type`        | String      | No              | Dimension type: `"REGULAR"` (default), `"LOCAL_COHORT:<dim>"`, or `"REMOTE_COHORT:<dim>"` |
 
 ### Position and Priority
 

--- a/docs/docs/superposition-config-file/format-specification.md
+++ b/docs/docs/superposition-config-file/format-specification.md
@@ -39,10 +39,10 @@ _context_ = { /* context condition */ }
 ```json
 {
   "default-configs": {
-    "key": { "value": <default_value>, "schema": <json_schema> }
+    "key": { "value": <default_value>, "schema": <json_schema>, "description": <string> }
   },
   "dimensions": {
-    "dimension_name": { "position": <number>, "schema": <json_schema> }
+    "dimension_name": { "position": <number>, "schema": <json_schema>, "description": <string> }
   },
   "overrides": [
     {
@@ -63,15 +63,16 @@ The `[default-configs]` section defines all possible configuration keys for your
 
 ```toml
 [default-configs]
-<key> = { value = <default_value>, schema = <json_schema> }
+<key> = { value = <default_value>, schema = <json_schema>, description = <string> }
 ```
 
 ### Parameters
 
-| Parameter | Type        | Required | Description                                  |
-| --------- | ----------- | -------- | -------------------------------------------- |
-| `value`   | Any         | Yes      | The default value for this configuration key |
-| `schema`  | JSON Schema | Yes      | JSON Schema that validates the value         |
+| Parameter     | Type        | Required | Description                                                            |
+| ------------- | ----------- | -------- | --------------------------------------------------------------------- |
+| `value`       | Any         | Yes      | The default value for this configuration key                          |
+| `schema`      | JSON Schema | Yes      | JSON Schema that validates the value                                  |
+| `description` | String      | Yes      | Human-readable description. If omitted on import, the key name is used |
 
 ### Examples
 
@@ -144,16 +145,17 @@ The `[dimensions]` section defines the attributes that segment your configuratio
 
 ```toml
 [dimensions]
-<dimension_name> = { position = <number>, schema = <json_schema> [, type = <dimension_type>] }
+<dimension_name> = { position = <number>, schema = <json_schema>, description = <string> [, type = <dimension_type>] }
 ```
 
 ### Parameters
 
-| Parameter  | Type        | Required | Description                                                                               |
-| ---------- | ----------- | -------- | ----------------------------------------------------------------------------------------- |
-| `position` | Integer     | Yes      | Position for priority calculation (higher = more specific)                                |
-| `schema`   | JSON Schema | Yes      | Schema validating dimension values                                                        |
-| `type`     | String      | No       | Dimension type: `"REGULAR"` (default), `"LOCAL_COHORT:<dim>"`, or `"REMOTE_COHORT:<dim>"` |
+| Parameter     | Type        | Required | Description                                                                                |
+| ------------- | ----------- | -------- | ----------------------------------------------------------------------------------------- |
+| `position`    | Integer     | Yes      | Position for priority calculation (higher = more specific)                                |
+| `schema`      | JSON Schema | Yes      | Schema validating dimension values                                                        |
+| `description` | String      | Yes      | Human-readable description. If omitted on import, the dimension name is used               |
+| `type`        | String      | No       | Dimension type: `"REGULAR"` (default), `"LOCAL_COHORT:<dim>"`, or `"REMOTE_COHORT:<dim>"` |
 
 ### Position and Priority
 


### PR DESCRIPTION
Export dimension and default-config descriptions in the detailed
TOML/JSON config so they survive an export/import round-trip. The
description is always emitted on export (mandatory in the file) and,
when absent on import, falls back to the dimension/key name.

The description is carried on the detailed import/export types only and
is skipped during config-resolution serialization, leaving the /config
response and cache shape unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration entries and dimensions now support optional description fields
  * Missing descriptions automatically default to the corresponding entry name
* **Documentation**
  * Updated format specification documentation to include description field usage for configurations and dimensions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->