### PR TITLE
docs: add Slack community link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 <a href="https://context7.com/juspay/superposition"><img src="https://img.shields.io/badge/Context7-LLM%20Docs-7c3aed" alt="Context7" height="22"/></a>
 <a href="https://deepwiki.com/juspay/superposition"><img src="https://img.shields.io/badge/DeepWiki-Architecture%20Wiki-0ea5e9" alt="DeepWiki" height="22"/></a>
 <a href="https://discord.gg/jNeUJR9Bwr"><img src="https://img.shields.io/discord/1280216553350107258?label=Discord&logo=discord" alt="Discord" height="22"/></a>
+<a href="https://superpositionjp.slack.com"><img src="https://img.shields.io/badge/Slack-Join%20chat-4A154B?logo=slack&logoColor=white" alt="Slack" height="22"/></a>
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <a href="https://context7.com/juspay/superposition"><img src="https://img.shields.io/badge/Context7-LLM%20Docs-7c3aed" alt="Context7" height="22"/></a>
 <a href="https://deepwiki.com/juspay/superposition"><img src="https://img.shields.io/badge/DeepWiki-Architecture%20Wiki-0ea5e9" alt="DeepWiki" height="22"/></a>
 <a href="https://discord.gg/jNeUJR9Bwr"><img src="https://img.shields.io/discord/1280216553350107258?label=Discord&logo=discord" alt="Discord" height="22"/></a>
-<a href="https://superpositionjp.slack.com"><img src="https://img.shields.io/badge/Slack-Join%20chat-4A154B?logo=slack&logoColor=white" alt="Slack" height="22"/></a>
+<a href="https://superpositionjp.slack.com"><img src="https://img.shields.io/badge/Slack-Community-4A154B?logo=slack&logoColor=white" alt="Slack" height="22"/></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Problem
The README lacks a direct link to the Slack community channel, making it harder for users to discover and join the community chat.

## Solution
Added a Slack badge link to the README's social links section, pointing to the Superposition Slack workspace. This follows the same pattern as existing community links (Discord, Context7, DeepWiki) and provides users with an easy way to access the Slack community.

## Environment variable changes
N/A

## Pre-deployment activity
N/A

## Post-deployment activity
N/A

## API changes
N/A

## Possible Issues in the future
- If the Slack workspace URL changes, the link in the README will need to be updated
- The badge will display as broken if the Slack workspace becomes unavailable or the URL is incorrect

https://claude.ai/code/session_01F4QA9xQiNgRM3EAnmorKju

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Slack community link to the README for easier access to community chat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->