### PR TITLE
fix: publish python bindings correctly

### DIFF
--- a/clients/python/bindings/pyproject.toml
+++ b/clients/python/bindings/pyproject.toml
@@ -10,7 +10,8 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
-include = ["libsuperposition_core.*", "superposition_core.*"]
+packages = ["superposition_bindings"]
+artifacts = ["superposition_bindings/libsuperposition_core.*"]
 
 [tool.hatch.version]
 source = "env"


### PR DESCRIPTION
## Problem
The python bindings package is empty when installed in isolation

## Solution
include was matching files in the parent directory, not in bindings. I've added the better way to do this (tested) 

Addresses #1035 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Python bindings package build configuration, modifying how components are bundled into the distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->