### PR TITLE
chore: publish Helm chart to GHCR OCI registry on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -656,3 +656,4 @@ jobs:
                       artifacts_dir/superposition_core-x86_64-apple-darwin.zip/superposition_core-x86_64-apple-darwin.zip
                       artifacts_dir/superposition_core-aarch64-apple-darwin.zip/superposition_core-aarch64-apple-darwin.zip
                       artifacts_dir/superposition_core-x86_64-pc-windows-msvc.zip/superposition_core-x86_64-pc-windows-msvc.zip
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -147,6 +147,7 @@ jobs:
               with:
                   fetch-depth: 0
                   token: ${{ secrets.SUPERPOSITION_TOKEN }}
+                  ref: ${{ needs.tag-release.outputs.updated_ref }}
 
             - name: Log in to GitHub Container Registry
               uses: docker/login-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,6 +79,7 @@ jobs:
 
             - name: Update Helm chart appVersion
               run: |
+                  yq eval ".version = \"${{ steps.git_tag.outputs.version }}\"" -i helm/Chart.yaml
                   yq eval ".appVersion = \"${{ steps.git_tag.outputs.version }}\"" -i helm/Chart.yaml
                   git add helm/Chart.yaml
                   git commit --amend --no-edit
@@ -166,7 +167,7 @@ jobs:
 
             - name: Package and push Helm chart to OCI registry
               run: |
-                  helm package helm/ --version ${{ needs.tag-release.outputs.version }} --app-version ${{ needs.tag-release.outputs.version }}
+                  helm package helm
                   helm push "superposition-${{ needs.tag-release.outputs.version }}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/helm-charts"
 
     docker-demo-build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,7 +167,7 @@ jobs:
             - name: Package and push Helm chart to OCI registry
               run: |
                   helm package helm/ --version ${{ needs.tag-release.outputs.version }} --app-version ${{ needs.tag-release.outputs.version }}
-                  helm push superposition-${{ needs.tag-release.outputs.version }}.tgz oci://ghcr.io/${{ github.repository_owner }}
+                  helm push "superposition-${{ needs.tag-release.outputs.version }}.tgz" "oci://ghcr.io/${{ github.repository_owner }}/helm-charts"
 
     docker-demo-build:
         needs: [tag-release, create-manifest]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -164,6 +164,11 @@ jobs:
                       ghcr.io/${{ github.repository }}:${{ needs.tag-release.outputs.version }}-linux-amd64 \
                       ghcr.io/${{ github.repository }}:${{ needs.tag-release.outputs.version }}-linux-arm64
 
+            - name: Package and push Helm chart to OCI registry
+              run: |
+                  helm package helm/ --version ${{ needs.tag-release.outputs.version }} --app-version ${{ needs.tag-release.outputs.version }}
+                  helm push superposition-${{ needs.tag-release.outputs.version }}.tgz oci://ghcr.io/${{ github.repository_owner }}
+
     docker-demo-build:
         needs: [tag-release, create-manifest]
         permissions:


### PR DESCRIPTION
## Problem
The Superposition Helm chart had no automated publishing mechanism. Consumers wanting to use it as a dependency in umbrella/stack Helm charts had no way to pull it from a registry — they had to clone the repo or manage the chart manually.



## Solution
Added a "Package and push Helm chart to OCI registry" step to the existing create-manifest job in the release workflow. On every release:
1. The Helm chart is packaged using helm package with the release version.
2. The packaged chart is pushed to GHCR's OCI registry at ghcr.io/juspay/superposition:<version>.

## Environment variable changes

What ENVs need to be added or changed

## Pre-deployment activity
Things needed to be done before deploying this change (if any)

## Post-deployment activity
Things needed to be done after deploying this change (if any)

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
Describe any possible issues that could occur because of this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release pipeline to automatically package and distribute Helm charts to container registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->