### PR TITLE
feat: Add Clone Button and flow for Experiments

### DIFF
--- a/crates/frontend/src/components/experiment.rs
+++ b/crates/frontend/src/components/experiment.rs
@@ -289,7 +289,7 @@ pub fn gen_variant_table(variants: &[Variant]) -> (Vec<Map<String, Value>>, Vec<
 }
 
 #[component]
-pub fn Experiment<HS, HR, HC, HE, HD, HP, HRS>(
+pub fn Experiment<HS, HR, HC, HE, HD, HP, HRS, HCL>(
     experiment: ExperimentResponse,
     handle_start: HS,
     handle_ramp: HR,
@@ -298,6 +298,7 @@ pub fn Experiment<HS, HR, HC, HE, HD, HP, HRS>(
     handle_discard: HD,
     handle_pause: HP,
     handle_resume: HRS,
+    handle_clone: HCL,
 ) -> impl IntoView
 where
     HS: Fn() + 'static + Clone,
@@ -307,6 +308,7 @@ where
     HD: Fn() + 'static + Clone,
     HP: Fn() + 'static + Clone,
     HRS: Fn() + 'static + Clone,
+    HCL: Fn() + 'static + Clone,
 {
     let experiment = store_value(experiment);
     let metrics_load_err = RwSignal::new(false);
@@ -326,6 +328,12 @@ where
                 <span class=badge_class>{experiment.with_value(|v| v.status.to_string())}</span>
             </h1>
             <div class="-mt-5 flex flex-row justify-end join">
+                <Button
+                    force_style="btn join-item px-5 py-2.5 text-white bg-gradient-to-r from-purple-500 via-purple-600 to-purple-700 shadow-lg rounded-lg"
+                    on_click=move |_| handle_clone()
+                    icon_class="ri-file-copy-line"
+                    text="Clone"
+                />
 
                 {move || {
                     let handle_start = handle_start.clone();

--- a/crates/frontend/src/pages/experiment.rs
+++ b/crates/frontend/src/pages/experiment.rs
@@ -1,6 +1,6 @@
 use futures::join;
 use leptos::*;
-use leptos_router::use_params_map;
+use leptos_router::{use_params_map, use_navigate};
 use serde::{Deserialize, Serialize};
 use superposition_types::{
     api::{
@@ -93,6 +93,15 @@ pub fn ExperimentPage() -> impl IntoView {
     let handle_discard = move || set_show_popup.set(PopupType::ExperimentDiscard);
     let handle_pause = move || set_show_popup.set(PopupType::ExperimentPause);
     let handle_resume = move || set_show_popup.set(PopupType::ExperimentResume);
+    let handle_clone = move || {
+        let navigate = use_navigate();
+        let workspace = workspace.get().0;
+        let org = org.get().0;
+        let exp_id =
+            exp_params.with(|params| params.get("id").cloned().unwrap_or("1".into()));
+        let redirect_url = format!("/admin/{}/{}/experiments?clone={}", org, workspace, exp_id);
+        navigate(&redirect_url, Default::default());
+    };
 
     view! {
         <Suspense fallback=move || {
@@ -120,6 +129,7 @@ pub fn ExperimentPage() -> impl IntoView {
                                 handle_discard
                                 handle_pause
                                 handle_resume
+                                handle_clone
                             />
                             <Modal
                                 id="ramp_form_modal".to_string()

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -4,6 +4,7 @@ pub mod utils;
 use filter::{ExperimentTableFilterWidget, FilterSummary};
 use futures::join;
 use leptos::*;
+use leptos_router::use_navigate;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value, json};
 use superposition_types::{
@@ -20,9 +21,9 @@ use superposition_types::{
 use utils::experiment_table_columns;
 
 use crate::{
-    api::{default_configs, dimensions, fetch_experiments},
+    api::{default_configs, dimensions, fetch_experiments, fetch_experiment},
     components::{
-        drawer::{Drawer, DrawerBtn, close_drawer},
+        drawer::{Drawer, DrawerBtn, close_drawer, open_drawer},
         experiment_form::ExperimentForm,
         skeleton::Skeleton,
         stat::Stat,
@@ -100,6 +101,25 @@ pub fn ExperimentList() -> impl IntoView {
         },
     );
 
+    let query = leptos_router::use_query_map();
+    let clone_id = Memo::new(move |_| query.with(|q| q.get("clone").cloned()));
+
+    let clone_experiment = create_blocking_resource(
+        move || clone_id.get(),
+        move |id| async move {
+            let id = id?;
+            fetch_experiment(id, &workspace.get().0, &org.get().0)
+                .await
+                .ok()
+        },
+    );
+
+    create_effect(move |_| {
+        if clone_id.get().is_some() {
+            open_drawer("create_exp_drawer");
+        }
+    });
+
     let handle_submit_experiment_form = move |_| {
         filters_rws.set(ExperimentListFilters::default());
         pagination_params_rws.update(|f| f.reset_page());
@@ -108,6 +128,11 @@ pub fn ExperimentList() -> impl IntoView {
             *val += 1;
         });
         close_drawer("create_exp_drawer");
+        let navigate = use_navigate();
+        let workspace = workspace.get().0;
+        let org = org.get().0;
+        let redirect_url = format!("/admin/{}/{}/experiments", org, workspace);
+        navigate(&redirect_url, Default::default());
     };
 
     let handle_page_change = Callback::new(move |page: i64| {
@@ -197,6 +222,27 @@ pub fn ExperimentList() -> impl IntoView {
                     experiments: _,
                 } = combined_resource.get().unwrap_or_default();
                 let _ = reset_exp_form.get();
+
+                let cloned_experiment = clone_experiment.get().flatten();
+                let (name, context, variants, description, metrics, experiment_group_id) = match cloned_experiment {
+                    Some(exp) => (
+                        format!("{} (Copy)", exp.name),
+                        Conditions::from_iter(exp.context.clone().into_inner()),
+                        VariantFormTs::from_iter(exp.variants.clone()),
+                        exp.description.to_string(),
+                        exp.metrics.clone(),
+                        exp.experiment_group_id.clone(),
+                    ),
+                    None => (
+                        String::new(),
+                        Conditions::default(),
+                        VariantFormTs::default(),
+                        String::new(),
+                        workspace_settings.with_value(|w| w.metrics.clone()),
+                        None,
+                    ),
+                };
+
                 view! {
                     <Drawer
                         id="create_exp_drawer"
@@ -205,17 +251,25 @@ pub fn ExperimentList() -> impl IntoView {
                         handle_close=move || {
                             close_drawer("create_exp_drawer");
                             set_exp_form.update(|i| *i += 1);
+                            let navigate = use_navigate();
+                            let workspace = workspace.get().0;
+                            let org = org.get().0;
+                            let redirect_url = format!("/admin/{}/{}/experiments", org, workspace);
+                            navigate(&redirect_url, Default::default());
                         }
                     >
 
                         <EditorProvider>
                             <ExperimentForm
-                                context=Conditions::default()
-                                variants=VariantFormTs::default()
+                                name=name
+                                context=context
+                                variants=variants
                                 dimensions=dim.clone()
                                 default_config=def_conf.clone()
                                 handle_submit=handle_submit_experiment_form
-                                metrics=workspace_settings.with_value(|w| w.metrics.clone())
+                                description=description
+                                metrics=metrics
+                                experiment_group_id=experiment_group_id
                             />
                         </EditorProvider>
                     </Drawer>

--- a/crates/frontend/src/pages/experiment_list/utils.rs
+++ b/crates/frontend/src/pages/experiment_list/utils.rs
@@ -76,16 +76,20 @@ pub fn experiment_table_columns(
                         Err(_) => logging::log!("unable to copy to clipboard"),
                     }
                 };
+                let experiment_id_link = experiment_id.clone();
                 view! {
                         <div>
                             <A href=experiment_id.to_string() class="text-blue-500 underline underline-offset-2">
                                 {experiment_name}
                             </A>
-                            <div class="text-gray-500">
+                            <div class="text-gray-500 flex items-center">
                                 <span class="text-xs">
                                     {experiment_id}
                                 </span>
                                 <i class="ri-file-copy-line ml-2 cursor-pointer" on:click:undelegated=handle_copy></i>
+                                <A href=format!("?clone={}", experiment_id_link) class="text-gray-500 hover:text-blue-500 ml-2">
+                                    <i class="ri-file-copy-2-line" title="Clone Experiment"></i>
+                                </A>
                                 <Show when=move || copied.get()>
                                     <div class="w-fit ml-2 px-2 flex justify-center items-center bg-gray-600 rounded-xl">
                                         <span class="text-white text-xs font-semibold">


### PR DESCRIPTION
## Problem
Describe the problem you are trying to solve here

## Solution
Provide a brief summary of your solution so that reviewers can understand your code

## Environment variable changes

What ENVs need to be added or changed

## Pre-deployment activity
Things needed to be done before deploying this change (if any)

## Post-deployment activity
Things needed to be done after deploying this change (if any)

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
Describe any possible issues that could occur because of this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Clone" button to experiments, enabling users to duplicate existing experiments with settings pre-filled.
  * Clone functionality is accessible from both the experiment details page and the experiment list table.
  * When cloning, the creation form is automatically populated with the original experiment's configuration, variants, description, metrics, and group settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->