### PR TITLE
chore(docs): start pushing docs to S3 as well as github pages

### DIFF
--- a/.github/workflows/generate_docs.yaml
+++ b/.github/workflows/generate_docs.yaml
@@ -1,17 +1,31 @@
-name: Generate Superposition Documentation
+name: Generate and Publish Superposition Documentation
 
 on:
     workflow_dispatch:
+        inputs:
+            deploy-target:
+                description: "Where to deploy the docs"
+                required: false
+                default: "both"
+                type: choice
+                options:
+                    - github
+                    - superposition
+                    - both
     push:
         paths:
-          - 'docs/**'
+            - "docs/**"
         branches:
             - main
 
 jobs:
     build:
-        name: Build Docusaurus
+        name: Build Docusaurus (${{ matrix.deploy-target }})
         runs-on: ubuntu-latest
+        strategy:
+            fail-fast: false
+            matrix:
+                deploy-target: [github, superposition]
         steps:
             - uses: actions/checkout@v4
               with:
@@ -21,21 +35,27 @@ jobs:
 
             - name: Install dependencies
               run: |
-                cd docs
-                bun install --frozen-lockfile
+                  cd docs
+                  bun install --frozen-lockfile
+
             - name: Build website
+              env:
+                  DOCS_DEPLOY_TARGET: ${{ matrix.deploy-target }}
               run: |
-                cd docs
-                bun run build-all
+                  cd docs
+                  bun run build-all
 
-            - name: Upload Build Artifact
-              uses: actions/upload-pages-artifact@v3
+            - name: Upload build artifact
+              uses: actions/upload-artifact@v4
               with:
+                  name: docs-build-${{ matrix.deploy-target }}
                   path: docs/build
+                  retention-days: 1
 
-    deploy:
+    deploy-github:
         name: Deploy to GitHub Pages
         needs: build
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.deploy-target == 'github' || inputs.deploy-target == 'both' }}
 
         permissions:
             pages: write
@@ -48,6 +68,40 @@ jobs:
 
         runs-on: ubuntu-latest
         steps:
+            - name: Download GitHub build
+              uses: actions/download-artifact@v4
+              with:
+                  name: docs-build-github
+                  path: docs/build
+            - name: Upload Pages artifact
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  path: docs/build
             - name: Deploy to GitHub Pages
               id: deployment
               uses: actions/deploy-pages@v4
+
+    deploy-s3:
+        name: Deploy to S3 (Superposition)
+        needs: build
+        if: ${{ github.event_name != 'workflow_dispatch' || inputs.deploy-target == 'superposition' || inputs.deploy-target == 'both' }}
+        permissions:
+            id-token: write
+            contents: read
+        runs-on: ubuntu-latest
+        steps:
+            - name: Download Superposition build
+              uses: actions/download-artifact@v4
+              with:
+                  name: docs-build-superposition
+                  path: docs/build
+
+            - name: Configure AWS credentials
+              uses: aws-actions/configure-aws-credentials@v4
+              with:
+                  role-to-assume: ${{ secrets.DOCS_AWS_ROLE_ARN }}
+                  aws-region: ${{ vars.DOCS_AWS_REGION }}
+
+            - name: Sync to S3
+              run: |
+                  aws s3 sync docs/build s3://${{ vars.DOCS_S3_BUCKET }}/ --delete

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -5,6 +5,43 @@ import type * as OpenApiPlugin from "docusaurus-plugin-openapi-docs";
 
 // This runs in Node.js - Don't use client-side code here (browser APIs, JSX...)
 
+const DEPLOY_TARGET = (
+    process.env.DOCS_DEPLOY_TARGET ?? "github"
+).toLowerCase();
+
+type TargetConfig = {
+    url: string;
+    baseUrl: string;
+    /** GitHub Pages only. */
+    organizationName?: string;
+    /** GitHub Pages only. */
+    projectName?: string;
+    /** Set to `true` for S3 static website hosting (directory-style URLs). */
+    trailingSlash?: boolean;
+};
+
+const DEPLOY_TARGETS: Record<string, TargetConfig> = {
+    github: {
+        url: "https://juspay.io/",
+        // For GitHub pages deployment, baseUrl is "/<projectName>/".
+        baseUrl: "/superposition/",
+        organizationName: "juspay",
+        projectName: "superposition",
+    },
+    superposition: {
+        url: "https://superposition.juspay.io/",
+        // Served from the bucket root.
+        baseUrl: "/",
+        // S3 static website hosting serves `dir/index.html` for `/dir/`
+        // requests, so directory-style URLs (trailing slash) display the docs
+        // and blog out of the box
+        trailingSlash: true,
+    },
+};
+
+const targetConfig: TargetConfig =
+    DEPLOY_TARGETS[DEPLOY_TARGET] ?? DEPLOY_TARGETS.github;
+
 const config: Config = {
     title: "Superposition",
     tagline:
@@ -16,15 +53,11 @@ const config: Config = {
         v4: true, // Improve compatibility with the upcoming Docusaurus v4
     },
 
-    // Set the production url of your site here
-    url: "https://juspay.io/",
-    // Set the /<baseUrl>/ pathname under which your site is served
-    // For GitHub pages deployment, it is often '/<projectName>/'
-    baseUrl: "/superposition/",
-
-    // GitHub pages deployment config.
-    organizationName: "juspay",
-    projectName: "superposition",
+    url: targetConfig.url,
+    baseUrl: targetConfig.baseUrl,
+    organizationName: targetConfig.organizationName,
+    projectName: targetConfig.projectName,
+    trailingSlash: targetConfig.trailingSlash,
 
     onBrokenLinks: "warn",
     onBrokenMarkdownLinks: "warn",
@@ -36,7 +69,7 @@ const config: Config = {
 
     plugins: [
         [
-            'docusaurus-plugin-openapi-docs',
+            "docusaurus-plugin-openapi-docs",
             {
                 id: "superposition-api",
                 docsPluginId: "classic",
@@ -51,7 +84,7 @@ const config: Config = {
                             sidebarCollapsed: false,
                             customProps: {
                                 // Add custom CSS classes for styling
-                            }
+                            },
                         },
                         // Removed template configuration that was causing the error
                         hideSendButton: false,
@@ -66,7 +99,7 @@ const config: Config = {
             "classic",
             {
                 docs: {
-                    routeBasePath: '/docs',
+                    routeBasePath: "/docs",
                     sidebarPath: "./sidebars.ts",
                     docItemComponent: "@theme/ApiItem", // Derived from docusaurus-theme-openapi
                     // Please change this to your repo.
@@ -78,7 +111,8 @@ const config: Config = {
                     path: "blog",
                     routeBasePath: "blog",
                     blogTitle: "Superposition Blog",
-                    blogDescription: "Updates, guides, and technical notes from the Superposition team",
+                    blogDescription:
+                        "Updates, guides, and technical notes from the Superposition team",
                     showReadingTime: true,
                 },
                 theme: {
@@ -93,7 +127,7 @@ const config: Config = {
     themeConfig: {
         image: "img/logo.jpg",
         algolia: {
-            appId: 'ZK6EG087JC',
+            appId: "ZK6EG087JC",
             // Public API key: it is safe to commit it
             apiKey: 'a9402301014892a68b227519cfab738a',
             indexName: 'superposition-docusaurus-1',


### PR DESCRIPTION
## Problem
We want to show documentation on superposition.juspay.io but can't reverse proxy from github without compromises

## Solution
Use our own hosting service which is s3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced documentation deployment process to support multiple deployment targets with environment-specific configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->