### PR TITLE
fix(oidc): fall back to email when preferred_username is missing

### DIFF
--- a/crates/service_utils/src/middlewares/auth_n/oidc/utils.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/utils.rs
@@ -22,8 +22,9 @@ pub(super) fn try_user_from<A: AdditionalClaims, B: GenderClaim>(
         .to_string();
     let username = claims
         .preferred_username()
-        .ok_or(String::from("Username not found"))?
-        .to_string();
+        .map(|u| u.to_string())
+        .or_else(|| claims.email().map(|e| e.to_string()))
+        .ok_or(String::from("Username not found"))?;
 
     Ok(User::new(email, username))
 }


### PR DESCRIPTION
## Problem
Google OIDC ID tokens do not include the `preferred_username` claim. Superposition’s simple OIDC login flow required this claim while building the authenticated `User`, so Google login completed successfully but authenticated routes failed with `Unable to get user`.

## Solution
Updated OIDC user extraction to keep using `preferred_username` when present, and fall back to the `email` claim when it is absent. Added regression tests for both Keycloak-style tokens with `preferred_username` and Google-style tokens without it.

## Environment variable changes
None.

## Pre-deployment activity
None.

## Post-deployment activity
None.

## API changes
| Endpoint | Method | Request body | Response Body |
| -------- | :----: | -----------: | ------------: |
| N/A | N/A | N/A | N/A |

## Possible Issues in the future
For OIDC providers that omit both `preferred_username` and `email`, login will still fail because Superposition requires an email to identify the user. Providers should be configured to include the `email` claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user sign-in data handling by adding fallback behavior for missing username information.
  * If a preferred username is unavailable, the app now uses the email address when possible, and returns clearer errors when required user details are missing.

* **Tests**
  * Added coverage for username fallback behavior and missing-email error cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->