### PR TITLE
perf(core/provider): reduce resolve-time cloning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -404,7 +410,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1645,6 +1651,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2190,6 +2202,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap 4.5.60",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -3435,7 +3483,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4250,6 +4298,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4882,6 +4936,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi 0.5.2",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6074,6 +6139,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6688,6 +6759,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "polyval"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6987,7 +7086,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.28",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7026,7 +7125,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -8496,7 +8595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8936,6 +9035,7 @@ dependencies = [
  "bigdecimal",
  "blake3",
  "cbindgen",
+ "criterion",
  "itertools 0.10.5",
  "jsonschema 0.17.0",
  "log",
@@ -9828,6 +9928,16 @@ checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/PERF_ANALYSIS_RESOLUTION.md
+++ b/PERF_ANALYSIS_RESOLUTION.md
@@ -1,0 +1,175 @@
+# Performance Analysis: Rust OpenFeature Provider — Resolution Logic
+
+This document analyzes the resolution (config evaluation) hot path of the Rust
+OpenFeature provider (`crates/superposition_provider`) and its underlying core
+library (`crates/superposition_core`), identifies the dominant cost at scale,
+and describes the optimizations applied along with a reproducible benchmark.
+
+## Context
+
+A performance test was run against a production-scale dataset:
+
+```
+Dataset:
+- Context override rules / contexts: 468,006
+- Default configs: 3
+- Dimensions: 18
+
+Provider startup:
+- fetch_config: 11.69s
+- cache_init: 0.73s
+
+Resolve benchmark (before optimization):
+- Mode: resolve all config
+- Input: 100 actual context conditions sampled from data
+- Total time: 44.40s
+- Throughput: ~2 resolves/sec
+- Avg: 443.95ms
+- p50: 438.45ms
+- p90: 471.95ms
+- p95: 475.05ms
+- p99: 547.55ms
+```
+
+At ~444ms per resolve, resolution — not startup — was the bottleneck for
+high-throughput evaluation.
+
+## The resolution path
+
+A single flag evaluation flows through:
+
+```
+SuperpositionProvider::resolve_{bool,string,int,float,struct}_value
+  └─ SuperpositionProvider::eval_config                 (provider.rs)
+       ├─ get_dimensions_info()                          (provider.rs)
+       │    └─ CacConfig::get_cached_config()            (client.rs)
+       └─ CacConfig::evaluate_config()                   (client.rs)
+            └─ superposition_core::eval_config()         (core/config.rs)
+                 ├─ evaluate_local_cohorts()
+                 ├─ get_overrides()   // scans all contexts, calls `apply`
+                 └─ merge_overrides_on_default_config()
+```
+
+## Root cause: the entire context set was deep-cloned on every resolve
+
+The actual matching work — iterating contexts and testing each condition with
+`apply()` — is inherent and comparatively cheap. The dominant cost was
+**deep-cloning all 468,006 contexts (plus the overrides map) multiple times per
+resolve**. Each `Context` owns a `String` id, a `Condition` (a `BTreeMap`), and
+an override key `String`; cloning ~468k of them repeatedly allocates on the
+order of a million heap objects per resolve.
+
+Three distinct clone sites were found in the hot path:
+
+### 1. `get_dimensions_info` cloned the whole `Config` to read 18 entries
+
+`provider.rs::get_dimensions_info` called `CacConfig::get_cached_config()`,
+which clones the **entire** `Config` (all contexts + all overrides + dimensions)
+and then kept only `.dimensions` (18 entries), discarding the rest:
+
+```rust
+// provider.rs (before)
+cac_config
+    .get_cached_config()        // clones ALL 468k contexts + overrides
+    .await
+    .map(|c| c.dimensions.clone())   // keeps 18 entries, drops the rest
+    .unwrap_or_default()
+```
+
+```rust
+// client.rs (before)
+pub async fn get_cached_config(&self) -> Option<Config> {
+    let cached_config = self.cached_config.read().await;
+    cached_config.clone()       // full deep clone of the config
+}
+```
+
+Worse, this ran on **every** resolve even when experimentation was disabled, in
+which case the dimensions were computed and then never used.
+
+### 2. `eval_config` cloned contexts + overrides for optional prefix filtering
+
+`superposition_core::eval_config` built a throwaway `Config` purely so it could
+call `filter_by_prefix` — but the provider always passes `filter_prefixes =
+None`, so the clone was pure waste on the provider path:
+
+```rust
+// core/config.rs (before)
+let mut config = Config {
+    default_configs: default_config.into(),
+    contexts: contexts.to_vec(),   // clone of all 468k contexts, again
+    overrides: overrides.clone(),  // clone of the whole overrides map, again
+    dimensions: dimensions.clone(),
+};
+if let Some(prefixes) = filter_prefixes.filter(|p| !p.is_empty()) {
+    config = config.filter_by_prefix(...);
+}
+```
+
+### 3. `get_overrides` cloned each matched context and each override value
+
+For every matching context, the matched `Context` was cloned unconditionally
+(even when no callback consumed it), and each override map was cloned into a
+temporary `Value::Object` before merging:
+
+```rust
+// core/config.rs (before)
+MergeStrategy::MERGE => {
+    merge(&mut required_overrides,
+          &Value::Object(overriden_value.clone().into())); // extra clone
+    on_override_select(context.clone())                    // unconditional clone
+}
+```
+
+## Optimizations applied
+
+| # | Location | Change |
+|---|----------|--------|
+| 1 | `client.rs` / `provider.rs` | Added `CacConfig::get_dimensions()` that clones only the `dimensions` map under the read lock. The provider now fetches dimensions **only when experimentation is enabled** (they are unused otherwise). |
+| 2 | `core/config.rs` (`eval_config`, `eval_config_with_reasoning`) | Added a fast path that resolves directly against the **borrowed** `contexts`/`overrides` when there is no prefix filter. Only the rare prefix-filter path builds an owned `Config`. |
+| 3 | `core/config.rs` (`get_overrides`) | Clone a matched `Context` only when a callback actually consumes it; merge override maps by reference instead of cloning them into a temporary `Value::Object`. |
+
+All changes preserve existing behavior and semantics; the full
+`superposition_core` test suite (85 tests) passes.
+
+## Benchmark
+
+A criterion benchmark was added at
+`crates/superposition_core/benches/resolve.rs`. It reproduces the reported
+workload — **468,006 contexts, 18 dimensions, 3 default configs, and 100 query
+contexts sampled from actual context conditions** — and compares the optimized
+path against a faithful reproduction of the pre-optimization clone behavior.
+
+Run it with:
+
+```bash
+# Full production-scale run (default: 468,006 contexts)
+cargo bench -p superposition_core --bench resolve
+
+# Quicker local run with a smaller dataset
+BENCH_CONTEXTS=60000 cargo bench -p superposition_core --bench resolve
+```
+
+The dataset is generated deterministically (a small built-in xorshift PRNG), so
+runs are reproducible without any external `rand` dependency.
+
+### Results (median per-resolve)
+
+| Scale | Pre-optimization (cloned) | Optimized (borrowed) | Speedup |
+|-------|---------------------------|----------------------|---------|
+| 60,000 contexts | 138 ms | 2.69 ms | ~51× |
+| 468,006 contexts | 1.37 s | **22.98 ms** | **~60×** |
+
+> Note: the benchmark's synthetic per-context payload is heavier than the
+> production data, so the absolute pre-optimization figure runs higher than the
+> reported 444ms. The meaningful takeaways are the **ratio** (~60×) and the
+> **~23ms optimized floor**. In the reported environment, the ~444ms average is
+> expected to drop to well under ~50ms.
+
+## Remaining opportunity
+
+After removing the clones, the remaining ~23ms is dominated by the inherent
+linear scan of all 468k contexts calling `apply()` on each. The next lever is an
+**index** — bucketing contexts by a high-cardinality dimension so a query only
+tests candidate contexts rather than the full set. This is a larger
+architectural change and is left as a follow-up.

--- a/crates/superposition_core/Cargo.toml
+++ b/crates/superposition_core/Cargo.toml
@@ -27,7 +27,12 @@ toml = { workspace = true, features = ["preserve_order"] }
 uniffi = { workspace = true }
 
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
 uniffi = { workspace = true }
+
+[[bench]]
+name = "resolve"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/superposition_core/benches/resolve.rs
+++ b/crates/superposition_core/benches/resolve.rs
@@ -1,0 +1,234 @@
+//! Resolution benchmark for the config evaluation hot path.
+//!
+//! This benchmark reproduces the shape of the workload reported from
+//! production-scale data (hundreds of thousands of context override rules,
+//! a handful of default configs, ~18 dimensions) and measures a single
+//! "resolve all config" call — the same operation the OpenFeature provider
+//! performs on every flag evaluation via `superposition_core::eval_config`.
+//!
+//! Two variants are compared:
+//!   * `optimized_borrowed`     — the current implementation, which resolves
+//!     directly against the borrowed context/override set.
+//!   * `pre_optimization_cloned` — reproduces the pre-optimization overhead,
+//!     where every resolve deep-cloned the entire context set (once to read
+//!     the dimensions, once more to build a throwaway `Config`).
+//!
+//! Run with:
+//!     cargo bench -p superposition_core --bench resolve
+//!
+//! The dataset size defaults to the production figure (468,006 contexts) and
+//! can be overridden for quicker local runs:
+//!     BENCH_CONTEXTS=50000 cargo bench -p superposition_core --bench resolve
+
+use std::cell::Cell;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use serde_json::{json, Map, Value};
+use superposition_core::{eval_config, Config, MergeStrategy};
+use superposition_types::{
+    Cac, Condition, Context, DimensionInfo, OverrideWithKeys, Overrides,
+};
+
+/// Number of dimensions in the synthetic dataset (mirrors the reported data).
+const NUM_DIMENSIONS: usize = 18;
+/// Default number of contexts / override rules (reported production figure).
+const DEFAULT_NUM_CONTEXTS: usize = 468_006;
+/// Number of sampled query contexts to resolve against.
+const NUM_QUERIES: usize = 100;
+/// Per-dimension value cardinality; controls how many contexts a query matches.
+const DIMENSION_CARDINALITY: usize = 12;
+/// The (small) set of default config keys.
+const DEFAULT_CONFIG_KEYS: [&str; 3] = ["config.alpha", "config.beta", "config.gamma"];
+
+/// Tiny deterministic xorshift64 PRNG so the dataset is fully reproducible
+/// without pulling in an external `rand` dependency.
+struct Rng(u64);
+
+impl Rng {
+    fn new(seed: u64) -> Self {
+        Rng(seed)
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        let mut x = self.0;
+        x ^= x << 13;
+        x ^= x >> 7;
+        x ^= x << 17;
+        self.0 = x;
+        x
+    }
+
+    fn below(&mut self, n: usize) -> usize {
+        (self.next_u64() % n as u64) as usize
+    }
+}
+
+struct Dataset {
+    default_config: Map<String, Value>,
+    contexts: Vec<Context>,
+    overrides: HashMap<String, Overrides>,
+    dimensions: HashMap<String, DimensionInfo>,
+    queries: Vec<Map<String, Value>>,
+}
+
+fn build_dataset(num_contexts: usize) -> Dataset {
+    let mut rng = Rng::new(0x9E37_79B9_7F4A_7C15);
+
+    let default_config: Map<String, Value> = DEFAULT_CONFIG_KEYS
+        .iter()
+        .map(|k| (k.to_string(), json!("default")))
+        .collect();
+
+    let mut contexts = Vec::with_capacity(num_contexts);
+    let mut overrides = HashMap::with_capacity(num_contexts);
+
+    for i in 0..num_contexts {
+        // Each context conditions on 1..=3 dimensions with concrete values.
+        let num_dims = 1 + rng.below(3);
+        let start = rng.below(NUM_DIMENSIONS);
+        let mut cond = Map::new();
+        for j in 0..num_dims {
+            let dim = (start + j) % NUM_DIMENSIONS;
+            let val = rng.below(DIMENSION_CARDINALITY);
+            cond.insert(format!("d{dim}"), json!(format!("v{val}")));
+        }
+        let condition = Cac::<Condition>::try_from(cond)
+            .expect("non-empty condition")
+            .into_inner();
+
+        let override_key = format!("o{i}");
+        let target = DEFAULT_CONFIG_KEYS[i % DEFAULT_CONFIG_KEYS.len()];
+        let mut override_map = Map::new();
+        override_map.insert(target.to_string(), json!(format!("override_{i}")));
+        let override_value = Cac::<Overrides>::try_from(override_map)
+            .expect("non-empty override")
+            .into_inner();
+        overrides.insert(override_key.clone(), override_value);
+
+        contexts.push(Context {
+            id: format!("ctx_{i}"),
+            condition,
+            priority: (i % 100) as i32,
+            weight: 1,
+            override_with_keys: OverrideWithKeys::new(override_key),
+        });
+    }
+
+    // Sample query contexts directly from real context conditions, matching
+    // the "100 actual context conditions sampled from data" methodology.
+    let mut queries = Vec::with_capacity(NUM_QUERIES);
+    for _ in 0..NUM_QUERIES {
+        let idx = rng.below(num_contexts);
+        let query: Map<String, Value> = contexts[idx]
+            .condition
+            .iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect();
+        queries.push(query);
+    }
+
+    Dataset {
+        default_config,
+        contexts,
+        overrides,
+        // Empty dimensions => local-cohort evaluation short-circuits, isolating
+        // the context-matching + override-merge cost we care about.
+        dimensions: HashMap::new(),
+        queries,
+    }
+}
+
+/// Current implementation: resolve directly against the borrowed data.
+fn resolve_optimized(ds: &Dataset, query: &Map<String, Value>) -> Map<String, Value> {
+    eval_config(
+        ds.default_config.clone(),
+        &ds.contexts,
+        &ds.overrides,
+        &ds.dimensions,
+        query,
+        MergeStrategy::MERGE,
+        None,
+    )
+    .expect("resolve")
+}
+
+/// Pre-optimization behavior: every resolve deep-cloned the full context set
+/// twice — once while extracting dimensions, once while building a throwaway
+/// `Config` for (unused) prefix filtering.
+fn resolve_pre_optimization(
+    ds: &Dataset,
+    query: &Map<String, Value>,
+) -> Map<String, Value> {
+    // (1) Old `get_dimensions_info`: cloned the whole Config just to read
+    //     `.dimensions`.
+    let full = Config {
+        contexts: ds.contexts.clone(),
+        overrides: ds.overrides.clone(),
+        default_configs: ds.default_config.clone().into(),
+        dimensions: ds.dimensions.clone(),
+    };
+    let _dimensions = full.dimensions.clone();
+
+    // (2) Old `eval_config`: cloned contexts + overrides into a temporary
+    //     Config before resolving.
+    let contexts = ds.contexts.clone();
+    let overrides = ds.overrides.clone();
+    eval_config(
+        ds.default_config.clone(),
+        &contexts,
+        &overrides,
+        &ds.dimensions,
+        query,
+        MergeStrategy::MERGE,
+        None,
+    )
+    .expect("resolve")
+}
+
+fn bench_resolve(c: &mut Criterion) {
+    let num_contexts = std::env::var("BENCH_CONTEXTS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_NUM_CONTEXTS);
+
+    let start = Instant::now();
+    let ds = build_dataset(num_contexts);
+    eprintln!(
+        "Built dataset: {} contexts, {} dimensions, {} queries in {:.2?}",
+        num_contexts,
+        NUM_DIMENSIONS,
+        ds.queries.len(),
+        start.elapsed()
+    );
+
+    let mut group = c.benchmark_group("resolve_all_config");
+    // One iteration == one full resolve of one query context.
+    group.sample_size(10);
+    group.warm_up_time(Duration::from_secs(1));
+    group.measurement_time(Duration::from_secs(15));
+
+    group.bench_function("optimized_borrowed", |b| {
+        let counter = Cell::new(0usize);
+        b.iter(|| {
+            let q = &ds.queries[counter.get() % ds.queries.len()];
+            counter.set(counter.get() + 1);
+            black_box(resolve_optimized(&ds, q))
+        })
+    });
+
+    group.bench_function("pre_optimization_cloned", |b| {
+        let counter = Cell::new(0usize);
+        b.iter(|| {
+            let q = &ds.queries[counter.get() % ds.queries.len()];
+            counter.set(counter.get() + 1);
+            black_box(resolve_pre_optimization(&ds, q))
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_resolve);
+criterion_main!(benches);

--- a/crates/superposition_core/benches/resolve.rs
+++ b/crates/superposition_core/benches/resolve.rs
@@ -2,9 +2,10 @@
 //!
 //! This benchmark reproduces the shape of the workload reported from
 //! production-scale data (hundreds of thousands of context override rules,
-//! a handful of default configs, ~18 dimensions) and measures a single
-//! "resolve all config" call — the same operation the OpenFeature provider
-//! performs on every flag evaluation via `superposition_core::eval_config`.
+//! a handful of default configs, ~18 regular dimensions, and derived local
+//! cohorts) and measures a single "resolve all config" call — the same
+//! operation the OpenFeature provider performs on every flag evaluation via
+//! `superposition_core::eval_config`.
 //!
 //! Two variants are compared:
 //!   * `optimized_borrowed`     — the current implementation, which resolves
@@ -24,14 +25,15 @@ use std::cell::Cell;
 use std::collections::HashMap;
 use std::time::{Duration, Instant};
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use serde_json::{json, Map, Value};
-use superposition_core::{eval_config, Config, MergeStrategy};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use serde_json::{Map, Value, json};
+use superposition_core::{Config, MergeStrategy, eval_config};
 use superposition_types::{
-    Cac, Condition, Context, DimensionInfo, OverrideWithKeys, Overrides,
+    Cac, Condition, Context, DimensionInfo, ExtendedMap, OverrideWithKeys, Overrides,
+    database::models::cac::{DependencyGraph, DimensionType},
 };
 
-/// Number of dimensions in the synthetic dataset (mirrors the reported data).
+/// Number of regular dimensions in the synthetic dataset (mirrors the reported data).
 const NUM_DIMENSIONS: usize = 18;
 /// Default number of contexts / override rules (reported production figure).
 const DEFAULT_NUM_CONTEXTS: usize = 468_006;
@@ -65,6 +67,101 @@ impl Rng {
     }
 }
 
+fn root_dimension(dim: usize) -> String {
+    format!("d{dim}")
+}
+
+fn cohort_dimension(dim: usize) -> String {
+    format!("lc{dim}")
+}
+
+fn root_value(val: usize) -> String {
+    format!("v{val}")
+}
+
+fn cohort_value(val: usize) -> String {
+    format!("c{val}")
+}
+
+fn build_dimensions() -> HashMap<String, DimensionInfo> {
+    let mut dimensions = HashMap::with_capacity(NUM_DIMENSIONS * 2);
+
+    for dim in 0..NUM_DIMENSIONS {
+        let root = root_dimension(dim);
+        let cohort = cohort_dimension(dim);
+
+        dimensions.insert(
+            root.clone(),
+            DimensionInfo {
+                schema: ExtendedMap::from(Map::new()),
+                position: dim as i32,
+                dimension_type: DimensionType::Regular {},
+                dependency_graph: DependencyGraph(HashMap::from([
+                    (root.clone(), vec![cohort.clone()]),
+                    (cohort.clone(), Vec::new()),
+                ])),
+                value_compute_function_name: None,
+                description: String::new(),
+            },
+        );
+
+        let mut definitions = Map::new();
+        let mut enum_values = Vec::with_capacity(DIMENSION_CARDINALITY + 1);
+        for val in 0..DIMENSION_CARDINALITY {
+            let cohort_val = cohort_value(val);
+            enum_values.push(Value::String(cohort_val.clone()));
+            definitions.insert(
+                cohort_val,
+                json!({
+                    "==": [
+                        { "var": root },
+                        root_value(val)
+                    ]
+                }),
+            );
+        }
+        enum_values.push(Value::String("otherwise".to_string()));
+
+        let mut schema = Map::new();
+        schema.insert("type".to_string(), json!("string"));
+        schema.insert("enum".to_string(), Value::Array(enum_values));
+        schema.insert("definitions".to_string(), Value::Object(definitions));
+
+        dimensions.insert(
+            cohort.clone(),
+            DimensionInfo {
+                schema: ExtendedMap::from(schema),
+                position: (NUM_DIMENSIONS + dim) as i32,
+                dimension_type: DimensionType::LocalCohort(root),
+                dependency_graph: DependencyGraph(HashMap::from([(cohort, Vec::new())])),
+                value_compute_function_name: None,
+                description: String::new(),
+            },
+        );
+    }
+
+    dimensions
+}
+
+fn query_from_condition(condition: &Condition) -> Map<String, Value> {
+    condition
+        .iter()
+        .map(|(key, value)| {
+            if let Some(dim) = key.strip_prefix("lc") {
+                let root_key = format!("d{dim}");
+                let root_val = value
+                    .as_str()
+                    .and_then(|v| v.strip_prefix('c'))
+                    .map(|v| Value::String(format!("v{v}")))
+                    .unwrap_or_else(|| value.clone());
+                (root_key, root_val)
+            } else {
+                (key.clone(), value.clone())
+            }
+        })
+        .collect()
+}
+
 struct Dataset {
     default_config: Map<String, Value>,
     contexts: Vec<Context>,
@@ -92,7 +189,12 @@ fn build_dataset(num_contexts: usize) -> Dataset {
         for j in 0..num_dims {
             let dim = (start + j) % NUM_DIMENSIONS;
             let val = rng.below(DIMENSION_CARDINALITY);
-            cond.insert(format!("d{dim}"), json!(format!("v{val}")));
+            let (key, value) = if (i + j) % 3 == 0 {
+                (cohort_dimension(dim), cohort_value(val))
+            } else {
+                (root_dimension(dim), root_value(val))
+            };
+            cond.insert(key, json!(value));
         }
         let condition = Cac::<Condition>::try_from(cond)
             .expect("non-empty condition")
@@ -121,21 +223,14 @@ fn build_dataset(num_contexts: usize) -> Dataset {
     let mut queries = Vec::with_capacity(NUM_QUERIES);
     for _ in 0..NUM_QUERIES {
         let idx = rng.below(num_contexts);
-        let query: Map<String, Value> = contexts[idx]
-            .condition
-            .iter()
-            .map(|(k, v)| (k.clone(), v.clone()))
-            .collect();
-        queries.push(query);
+        queries.push(query_from_condition(&contexts[idx].condition));
     }
 
     Dataset {
         default_config,
         contexts,
         overrides,
-        // Empty dimensions => local-cohort evaluation short-circuits, isolating
-        // the context-matching + override-merge cost we care about.
-        dimensions: HashMap::new(),
+        dimensions: build_dimensions(),
         queries,
     }
 }
@@ -196,8 +291,9 @@ fn bench_resolve(c: &mut Criterion) {
     let start = Instant::now();
     let ds = build_dataset(num_contexts);
     eprintln!(
-        "Built dataset: {} contexts, {} dimensions, {} queries in {:.2?}",
+        "Built dataset: {} contexts, {} regular dimensions, {} local cohorts, {} queries in {:.2?}",
         num_contexts,
+        NUM_DIMENSIONS,
         NUM_DIMENSIONS,
         ds.queries.len(),
         start.elapsed()

--- a/crates/superposition_core/src/config.rs
+++ b/crates/superposition_core/src/config.rs
@@ -143,13 +143,6 @@ fn get_overrides(
     mut on_override_select: Option<&mut dyn FnMut(Context)>,
 ) -> Result<Map<String, Value>, String> {
     let mut required_overrides = Map::new();
-    // Only pay for a `Context` clone when a caller actually consumes it; the
-    // borrow keeps the common (callback-less) resolution path allocation-free.
-    let mut on_override_select = |context: &Context| {
-        if let Some(ref mut func) = on_override_select {
-            func(context.clone())
-        }
-    };
 
     for context in contexts {
         if !superposition_types::apply(&context.condition, query_data) {
@@ -178,7 +171,11 @@ fn get_overrides(
                 }
             }
         }
-        on_override_select(context);
+        // Only pay for a `Context` clone when a caller actually consumes it; the
+        // borrow keeps the common (callback-less) resolution path allocation-free.
+        if let Some(ref mut func) = on_override_select {
+            func(context.clone());
+        }
     }
 
     Ok(required_overrides)

--- a/crates/superposition_core/src/config.rs
+++ b/crates/superposition_core/src/config.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, HashSet};
 
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value};
 pub use superposition_types::api::config::MergeStrategy;
 use superposition_types::{
     logic::evaluate_local_cohorts, Config, Context, DimensionInfo, Overrides,
@@ -15,20 +15,41 @@ pub fn eval_config(
     merge_strategy: MergeStrategy,
     filter_prefixes: Option<Vec<String>>,
 ) -> Result<Map<String, Value>, String> {
-    // Create Config struct to use existing filtering logic
-    let mut config = Config {
+    // Local cohort evaluation only reads `dimensions`, which prefix filtering
+    // leaves untouched, so it is safe to compute once regardless of the path.
+    let modified_query_data = evaluate_local_cohorts(dimensions, query_data);
+
+    let filter_prefixes = filter_prefixes.filter(|p| !p.is_empty());
+
+    // Fast path: no prefix filtering. Resolve directly against the borrowed
+    // contexts/overrides instead of deep-cloning the entire context set (which
+    // can be hundreds of thousands of entries) into a temporary `Config`.
+    let Some(prefixes) = filter_prefixes else {
+        let overrides_map = get_overrides(
+            &modified_query_data,
+            contexts,
+            overrides,
+            &merge_strategy,
+            None,
+        )?;
+
+        let mut result_config = default_config;
+        merge_overrides_on_default_config(
+            &mut result_config,
+            overrides_map,
+            &merge_strategy,
+        );
+        return Ok(result_config);
+    };
+
+    // Slow path: prefix filtering needs an owned, filtered `Config`.
+    let config = Config {
         default_configs: default_config.into(),
         contexts: contexts.to_vec(),
         overrides: overrides.clone(),
         dimensions: dimensions.clone(),
-    };
-
-    // Apply prefix filtering if keys are provided (using existing superposition_types logic)
-    if let Some(prefixes) = filter_prefixes.filter(|p| !p.is_empty()) {
-        config = config.filter_by_prefix(&HashSet::from_iter(prefixes.iter().cloned()));
     }
-
-    let modified_query_data = evaluate_local_cohorts(&config.dimensions, query_data);
+    .filter_by_prefix(&HashSet::from_iter(prefixes));
 
     let overrides_map: Map<String, Value> = get_overrides(
         &modified_query_data,
@@ -54,18 +75,35 @@ pub fn eval_config_with_reasoning(
     merge_strategy: MergeStrategy,
     filter_prefixes: Option<Vec<String>>, // Optional prefix filtering
 ) -> Result<Map<String, Value>, String> {
-    let mut config = Config {
+    let modified_query_data = evaluate_local_cohorts(dimensions, query_data);
+
+    let filter_prefixes = filter_prefixes.filter(|p| !p.is_empty());
+
+    let Some(prefixes) = filter_prefixes else {
+        let overrides_map = get_overrides(
+            &modified_query_data,
+            contexts,
+            overrides,
+            &merge_strategy,
+            None,
+        )?;
+
+        let mut result_config = default_config;
+        merge_overrides_on_default_config(
+            &mut result_config,
+            overrides_map,
+            &merge_strategy,
+        );
+        return Ok(result_config);
+    };
+
+    let config = Config {
         default_configs: default_config.into(),
         contexts: contexts.to_vec(),
         overrides: overrides.clone(),
         dimensions: dimensions.clone(),
-    };
-
-    if let Some(prefixes) = filter_prefixes.filter(|p| !p.is_empty()) {
-        config = config.filter_by_prefix(&HashSet::from_iter(prefixes.iter().cloned()));
     }
-
-    let modified_query_data = evaluate_local_cohorts(&config.dimensions, query_data);
+    .filter_by_prefix(&HashSet::from_iter(prefixes));
 
     let overrides_map = get_overrides(
         &modified_query_data,
@@ -97,27 +135,6 @@ pub fn merge(doc: &mut Value, patch: &Value) {
     }
 }
 
-fn replace_top_level(
-    doc: &mut Map<String, Value>,
-    patch: &Value,
-    mut on_override: impl FnMut(),
-    override_key: &String,
-) {
-    match patch.as_object() {
-        Some(patch_map) => {
-            for (key, value) in patch_map {
-                doc.insert(key.clone(), value.clone());
-            }
-            on_override();
-        }
-        None => {
-            log::error!(
-                "Config: found non-object override key: {override_key} in overrides"
-            );
-        }
-    }
-}
-
 fn get_overrides(
     query_data: &Map<String, Value>,
     contexts: &[Context],
@@ -125,42 +142,46 @@ fn get_overrides(
     merge_strategy: &MergeStrategy,
     mut on_override_select: Option<&mut dyn FnMut(Context)>,
 ) -> Result<Map<String, Value>, String> {
-    let mut required_overrides: Value = json!({});
-    let mut on_override_select = |context: Context| {
+    let mut required_overrides = Map::new();
+    // Only pay for a `Context` clone when a caller actually consumes it; the
+    // borrow keeps the common (callback-less) resolution path allocation-free.
+    let mut on_override_select = |context: &Context| {
         if let Some(ref mut func) = on_override_select {
-            func(context)
+            func(context.clone())
         }
     };
 
     for context in contexts {
-        let valid_context = superposition_types::apply(&context.condition, query_data);
+        if !superposition_types::apply(&context.condition, query_data) {
+            continue;
+        }
 
-        if valid_context {
-            let override_key = context.override_with_keys.get_key();
-            if let Some(overriden_value) = overrides.get(override_key) {
-                match merge_strategy {
-                    MergeStrategy::REPLACE => replace_top_level(
-                        required_overrides.as_object_mut().unwrap(),
-                        &Value::Object(overriden_value.clone().into()),
-                        || on_override_select(context.clone()),
-                        override_key,
-                    ),
-                    MergeStrategy::MERGE => {
-                        merge(
-                            &mut required_overrides,
-                            &Value::Object(overriden_value.clone().into()),
-                        );
-                        on_override_select(context.clone())
-                    }
+        let override_key = context.override_with_keys.get_key();
+        let Some(overriden_value) = overrides.get(override_key) else {
+            continue;
+        };
+
+        match merge_strategy {
+            MergeStrategy::REPLACE => {
+                for (key, value) in overriden_value.iter() {
+                    required_overrides.insert(key.clone(), value.clone());
+                }
+            }
+            MergeStrategy::MERGE => {
+                for (key, value) in overriden_value.iter() {
+                    merge(
+                        required_overrides
+                            .entry(key.as_str())
+                            .or_insert(Value::Null),
+                        value,
+                    );
                 }
             }
         }
+        on_override_select(context);
     }
 
-    match required_overrides {
-        Value::Object(map) => Ok(map),
-        _ => Err("Failed to create overrides map".to_string()),
-    }
+    Ok(required_overrides)
 }
 
 fn merge_overrides_on_default_config(

--- a/crates/superposition_core/src/lib.rs
+++ b/crates/superposition_core/src/lib.rs
@@ -1,4 +1,7 @@
 #![deny(unused_crate_dependencies)]
+#[cfg(test)]
+use criterion as _;
+
 uniffi::setup_scaffolding!("superposition_client");
 pub mod config;
 pub mod experiment;

--- a/crates/superposition_provider/src/client.rs
+++ b/crates/superposition_provider/src/client.rs
@@ -228,6 +228,20 @@ impl CacConfig {
         cached_config.clone()
     }
 
+    /// Clone only the dimension metadata out of the cached config.
+    ///
+    /// Callers that just need dimensions (e.g. experiment variant resolution)
+    /// must not go through `get_cached_config`, which deep-clones the entire
+    /// context/override set — potentially hundreds of thousands of entries —
+    /// on every resolve.
+    pub async fn get_dimensions(&self) -> HashMap<String, DimensionInfo> {
+        let cached_config = self.cached_config.read().await;
+        cached_config
+            .as_ref()
+            .map(|config| config.dimensions.clone())
+            .unwrap_or_default()
+    }
+
     /// Evaluate configuration for given context and return resolved values
     pub async fn evaluate_config(
         &self,

--- a/crates/superposition_provider/src/client.rs
+++ b/crates/superposition_provider/src/client.rs
@@ -234,7 +234,7 @@ impl CacConfig {
     /// must not go through `get_cached_config`, which deep-clones the entire
     /// context/override set — potentially hundreds of thousands of entries —
     /// on every resolve.
-    pub async fn get_dimensions(&self) -> HashMap<String, DimensionInfo> {
+    pub(crate) async fn get_dimensions(&self) -> HashMap<String, DimensionInfo> {
         let cached_config = self.cached_config.read().await;
         cached_config
             .as_ref()

--- a/crates/superposition_provider/src/provider.rs
+++ b/crates/superposition_provider/src/provider.rs
@@ -69,11 +69,7 @@ impl SuperpositionProvider {
 
     async fn get_dimensions_info(&self) -> HashMap<String, DimensionInfo> {
         match &self.cac_config {
-            Some(cac_config) => cac_config
-                .get_cached_config()
-                .await
-                .map(|c| c.dimensions.clone())
-                .unwrap_or_default(),
+            Some(cac_config) => cac_config.get_dimensions().await,
             None => HashMap::new(),
         }
     }
@@ -124,8 +120,10 @@ impl SuperpositionProvider {
         let (mut context, targeting_key) =
             conversions::evaluation_context_to_query(evaluation_context.clone());
 
-        let dimensions_info = self.get_dimensions_info().await;
+        // Dimensions are only needed to resolve experiment variants, so avoid
+        // fetching (and cloning) them entirely when experimentation is off.
         let variant_ids = if let Some(exp_config) = &self.exp_config {
+            let dimensions_info = self.get_dimensions_info().await;
             exp_config
                 .get_applicable_variants(&dimensions_info, &context, targeting_key)
                 .await?

--- a/docs/misc/PERF_ANALYSIS_RESOLUTION.md
+++ b/docs/misc/PERF_ANALYSIS_RESOLUTION.md
@@ -136,9 +136,15 @@ All changes preserve existing behavior and semantics; the full
 
 A criterion benchmark was added at
 `crates/superposition_core/benches/resolve.rs`. It reproduces the reported
-workload — **468,006 contexts, 18 dimensions, 3 default configs, and 100 query
-contexts sampled from actual context conditions** — and compares the optimized
-path against a faithful reproduction of the pre-optimization clone behavior.
+workload shape — **468,006 contexts, 18 regular dimensions, 18 derived local
+cohort dimensions, 3 default configs, and 100 query contexts sampled from
+actual context conditions** — and compares the optimized path against a
+faithful reproduction of the pre-optimization clone behavior.
+
+The benchmark intentionally includes local-cohort evaluation: a subset of
+generated context rules targets derived `lcN` cohort dimensions, while sampled
+queries provide the underlying `dN` dimension values. Each measured resolve
+therefore evaluates local cohorts before scanning the full context set.
 
 Run it with:
 
@@ -151,25 +157,28 @@ BENCH_CONTEXTS=60000 cargo bench -p superposition_core --bench resolve
 ```
 
 The dataset is generated deterministically (a small built-in xorshift PRNG), so
-runs are reproducible without any external `rand` dependency.
+runs are reproducible without any external `rand` dependency. This remains a
+core-library benchmark; provider/SDK overhead, network overhead, cold-start
+fetch/cache initialization, and true end-to-end p99 measurements should be
+covered by follow-up benchmarks.
 
-### Results (median per-resolve)
+### Results (per-resolve, local run)
 
 | Scale | Pre-optimization (cloned) | Optimized (borrowed) | Speedup |
 |-------|---------------------------|----------------------|---------|
-| 60,000 contexts | 138 ms | 2.69 ms | ~51× |
-| 468,006 contexts | 1.37 s | **22.98 ms** | **~60×** |
+| 468,006 contexts + local cohorts | ~1.56 s | **~63 ms** | **~25×** |
 
-> Note: the benchmark's synthetic per-context payload is heavier than the
-> production data, so the absolute pre-optimization figure runs higher than the
-> reported 444ms. The meaningful takeaways are the **ratio** (~60×) and the
-> **~23ms optimized floor**. In the reported environment, the ~444ms average is
-> expected to drop to well under ~50ms.
+> Note: these are machine-dependent Criterion estimates from a synthetic
+> workload. The meaningful takeaway is that removing full-config clones is a
+> large core hot-path win even when local-cohort evaluation is included. It is
+> not a claim about end-to-end provider p99 latency.
 
 ## Remaining opportunity
 
-After removing the clones, the remaining ~23ms is dominated by the inherent
-linear scan of all 468k contexts calling `apply()` on each. The next lever is an
-**index** — bucketing contexts by a high-cardinality dimension so a query only
-tests candidate contexts rather than the full set. This is a larger
-architectural change and is left as a follow-up.
+After removing the clones, the remaining time is dominated by local-cohort
+evaluation plus the inherent linear scan of all 468k contexts calling `apply()`
+on each. The next levers are an **evaluation cache** for repeated
+config/context/version lookups and an **index** — bucketing contexts by a
+high-cardinality dimension so a query only tests candidate contexts rather than
+the full set. These are larger behavioral/architectural changes and are left as
+follow-ups.


### PR DESCRIPTION
## Problem

Warm config resolution was spending a large amount of time cloning data instead of evaluating it. In the provider/core resolve path, the cached `Config`, full `contexts` list, and `overrides` map could be cloned during every resolve, even when no prefix filtering was requested. This becomes expensive for large workspaces with tens or hundreds of thousands of context overrides.

## Solution

This PR removes clone-heavy work from the common warm resolve path.

- Added a borrowed fast path in `superposition_core::eval_config` and `eval_config_with_reasoning` when `filter_prefixes` is `None` or empty.
- Avoided constructing a temporary owned `Config` for the common non-prefix-filter path.
- Kept the existing owned `Config::filter_by_prefix` path for prefix-filtered resolves to preserve existing semantics.
- Changed override merging to merge by reference instead of cloning override maps into temporary `Value::Object`s.
- Cloned matched `Context` values only when a callback actually consumes them.
- Added `CacConfig::get_dimensions()` so the provider can clone only dimensions instead of the full cached config.
- Avoided fetching/cloning dimensions in provider evaluation when experimentation is disabled.
- Added a Criterion benchmark for the resolve hot path with:
  - 468,006 generated contexts
  - 18 regular dimensions
  - 18 derived local-cohort dimensions
  - 3 default configs
  - 100 sampled query contexts
- Added `PERF_ANALYSIS_RESOLUTION.md` documenting root cause, benchmark scope, results, and follow-up opportunities.

Local benchmark result on this machine:

```text
optimized_borrowed:      ~63 ms
pre_optimization_cloned: ~1.56 s
speedup:                 ~25x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Faster config resolution with less cloning and a direct fast path when no filtering is needed.
  * Reduced unnecessary work when experimentation is disabled.
  * Improved access to configuration metadata for lighter-weight reads.

* **Documentation**
  * Added performance analysis notes and benchmark results, including before/after comparisons and remaining optimization ideas.

* **Tests**
  * Added a benchmark to track resolution performance on production-like workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->