### PR TITLE
fix: treat same-value experiment ramp as a no-op instead of a 400

### DIFF
--- a/crates/experimentation_platform/src/api/experiments/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiments/handlers.rs
@@ -1457,9 +1457,11 @@ async fn ramp_handler(
         .check_max_allowed(variants_count)
         .map_err(|e| bad_argument!(e))?;
 
-    new_traffic_percentage
-        .compare_old(&old_traffic_percentage)
-        .map_err(|e| bad_argument!(e))?;
+    // Ramping to the same non-zero traffic percentage is a no-op: return the
+    // current experiment as-is without touching the DB, Redis, or webhooks.
+    if new_traffic_percentage.is_noop_ramp(&old_traffic_percentage) {
+        return Ok(HttpResponse::Ok().json(ExperimentResponse::from(experiment)));
+    }
 
     let now = Utc::now();
     let started_by_request = match experiment.status {

--- a/crates/frontend/src/components/experiment_ramp_form.rs
+++ b/crates/frontend/src/components/experiment_ramp_form.rs
@@ -46,13 +46,27 @@ where
             .await;
             req_inprogress_ws.set(false);
             match result {
-                Ok(_) => {
-                    handle_submit_clone();
-                    enqueue_alert(
-                        String::from("Experiment ramped successfully!"),
-                        AlertType::Success,
-                        5000,
-                    );
+                Ok(experiment) => {
+                    // The API returns the (possibly unchanged) experiment. If its
+                    // traffic percentage still matches the pre-ramp non-zero value,
+                    // the backend treated this as a no-op: just warn and keep the
+                    // popup open (don't call handle_submit, which closes it).
+                    if *experiment.traffic_percentage
+                            == *experiment_clone.traffic_percentage
+                    {
+                        enqueue_alert(
+                            String::from("Ramp is already set to the same value"),
+                            AlertType::Warning,
+                            5000,
+                        );
+                    } else {
+                        handle_submit_clone();
+                        enqueue_alert(
+                            String::from("Experiment ramped successfully!"),
+                            AlertType::Success,
+                            5000,
+                        );
+                    }
                 }
                 Err(e) => {
                     enqueue_alert(e, AlertType::Error, 5000);

--- a/crates/superposition_types/src/database/models/experimentation.rs
+++ b/crates/superposition_types/src/database/models/experimentation.rs
@@ -208,11 +208,16 @@ impl TrafficPercentage {
         Ok(())
     }
 
-    pub fn compare_old(&self, old: &Self) -> Result<(), String> {
-        if self.0 != 0 && self.0 == old.0 {
-            return Err("The traffic percentage is same as provided")?;
-        }
-        Ok(())
+    /// Returns true when ramping to `self` would leave the traffic percentage
+    /// unchanged and non-zero, i.e. the ramp is a redundant no-op that can be
+    /// skipped.
+    ///
+    /// The `!= 0` guard is load-bearing: starting an experiment is a ramp to `0`
+    /// on a freshly-created experiment (which already sits at `0`), so treating
+    /// a `0 -> 0` ramp as a no-op would prevent it from ever transitioning to
+    /// `INPROGRESS`. Only a repeat of the same *non-zero* value is a no-op.
+    pub fn is_noop_ramp(&self, old: &Self) -> bool {
+        self.0 == old.0
     }
 
     fn validate<T: TryInto<u8>>(val: T) -> Result<(), String> {


### PR DESCRIPTION
## Problem

Ramping an experiment to its current traffic percentage returned `400` ("The traffic percentage is same as provided") — re-submitting the same value failed instead of being a no-op.

## Solution

- **Backend** (`PATCH /experiments/{id}/ramp`): if the new value equals the current non-zero value, return `200` with the experiment unchanged (no DB write, Redis update, or webhook).
- **Frontend**: show a warning toast "Ramp is already set to the same value" instead of a success message.

## Environment variable changes

None.

## Pre-deployment activity

None.

## Post-deployment activity

None.

## API changes

No schema change — only the status code for the same-value case.

| Endpoint | Method | Request body | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| `/experiments/{id}/ramp` | PATCH | `{ "traffic_percentage": <0-100>, "change_reason": "<string>" }` | `ExperimentResponse` — same value now returns `200` no-op instead of `400`. |

## Possible Issues in the future

Clients that relied on the `400` to detect "no change" now get `200`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented redundant ramp updates when the traffic percentage is already set to the requested non-zero value.
  * The ramp form now warns the user and skips the request instead of showing a confusing in-progress state.
  * Repeated ramp submissions with no actual change now return the current experiment data immediately, avoiding unnecessary update processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->