### PR TITLE
fix(auth_n): try refresh oidc client on token exchange failure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,27 @@ AUTH_PROVIDER=DISABLED
 # OIDC_REDIRECT_HOST="http://localhost:8080"
 # OIDC_ORG_TOKEN_ENDPOINT_FORMAT="http://localhost:8081/realms/<organisation>/protocol/openid-connect/token"
 # OIDC_ORG_ISSUER_ENDPOINT_FORMAT="http://localhost:8081/realms/<organisation>"
+### Env(s) for optional API-token auth via RFC 7662 introspection (OIDC only)
+### Present all required vars to enable. See docs: Self-Hosting > Authentication.
+# OIDC_API_TOKEN_PREFIX=apikey                    # arbitrary, operator-chosen; marks a bearer token as an API key
+# OIDC_API_TOKEN_DELIMITER=_                       # optional separator; defaults to "_"
+### The flow needs the prefix plus at least ONE validation mechanism below:
+### static tokens and/or RFC 7662 introspection (static tokens are tried first).
+### (1) Static tokens: KMS-encrypted JSON array; each maps to a fixed principal
+###     (and, in SaaS, an "org"; omit "org" for a global-scoped token).
+# OIDC_API_STATIC_TOKENS='[{"token":"s3cr3t-ci","principal":"svc-ci","org":"acme"}]'
+### (2) RFC 7662 introspection caller auth: verbatim Authorization header
+###     (Bearer/Basic); secret, KMS-encrypted in non-dev.
+# OIDC_INTROSPECTION_AUTH_HEADER="Bearer introspect_secret"
+### Endpoint URLs below are OPTIONAL: when unset, the introspection endpoint is
+### discovered from provider metadata. The SaaS per-org format is the exception
+### (not discoverable) and is required for org-scoped API tokens.
+### Simple OIDC: single endpoint (optional; discovered otherwise)
+# OIDC_TOKEN_INTROSPECTION_URL="http://localhost:8081/realms/users/protocol/openid-connect/token/introspect"
+### SaaS OIDC: per-org format is REQUIRED (global-only is rejected at startup);
+### OIDC_TOKEN_INTROSPECTION_URL is an optional global (Login::Global) override.
+# OIDC_ORG_TOKEN_INTROSPECTION_URL_FORMAT="http://localhost:8081/realms/<organisation>/protocol/openid-connect/token/introspect"
+# OIDC_TOKEN_INTROSPECTION_URL="http://localhost:8081/realms/users/protocol/openid-connect/token/introspect"
 AUTH_Z_PROVIDER=DISABLED
 ### Env(s) for Casbin AuthZ
 # AUTH_Z_PROVIDER=CASBIN
@@ -59,24 +80,6 @@ REDIS_KEY_TTL=604800
 # Workspace lock TTL for batch operations in milliseconds (default: 1200000 = 20min)
 # WORKSPACE_LOCK_BATCH_TTL_MS=1200000
 
-################################################
-## Following values are to be set in KMS and not directly in ENV
-#
-# DB_PASSWORD
-# SUPERPOSITION_TOKEN
-# KRONOS_DISPATCH_TOKEN - scoped token for Kronos webhook callbacks (dispatch endpoint only)
-# OIDC_CLIENT_SECRET - if using OIDC as authn provider
-# CASBIN_DB_PASSWORD - if using CASBIN as authz provider
-# MASTER_ENCRYPTION_KEY - for using secrets
-# PREVIOUS_MASTER_ENCRYPTION_KEY - needed for rotating secrets
-#
-# also include the keys in KMS which have been mentioned in ENCRYPTED_KEYS
-#
-#
-## for local development, they already have a default value,
-## to override, you can set them directly in .env file
-#################################################
-
 ## used for internal admin operations like log level changes
 # INTERNAL_OPS_API_KEY = ""
 
@@ -93,3 +96,20 @@ KRONOS_DB_POOL_SIZE="1"
 
 # Needed for both service and library mode, but only in DEV/TEST. In production, this is stored in KMS.
 KRONOS_DISPATCH_TOKEN="dispatch-test"
+
+################################################
+## Following values are to be set in KMS and not directly in ENV
+#
+# DB_PASSWORD
+# SUPERPOSITION_TOKEN
+# KRONOS_DISPATCH_TOKEN - scoped token for Kronos webhook callbacks (dispatch endpoint only)
+# OIDC_CLIENT_SECRET - if using OIDC as authn provider
+# OIDC_INTROSPECTION_AUTH_HEADER - if using API-token (RFC 7662) introspection
+# OIDC_API_STATIC_TOKENS - if using API-token static tokens
+# CASBIN_DB_PASSWORD - if using CASBIN as authz provider
+# MASTER_ENCRYPTION_KEY - for using secrets
+# PREVIOUS_MASTER_ENCRYPTION_KEY - needed for rotating secrets
+#
+## for local development, they already have a default value,
+## to override, you can set them directly in .env file
+#################################################

--- a/crates/service_utils/src/db/utils.rs
+++ b/crates/service_utils/src/db/utils.rs
@@ -45,6 +45,53 @@ pub async fn get_oidc_client_secret(
     }
 }
 
+/// The verbatim `Authorization` header value Superposition presents to the RFC
+/// 7662 introspection endpoint (e.g. `Bearer <token>` or `Basic <base64>`).
+/// This is a secret and is KMS-decrypted like other secrets in non-dev
+/// environments. Returns `None` when the (optional) API-token flow is not
+/// configured.
+pub async fn get_introspection_auth_header(
+    kms_client: &Option<Client>,
+    app_env: &AppEnv,
+) -> Option<String> {
+    if std::env::var("OIDC_INTROSPECTION_AUTH_HEADER").is_err() {
+        return None;
+    }
+    match app_env {
+        AppEnv::DEV | AppEnv::TEST | AppEnv::SANDBOX => {
+            std::env::var("OIDC_INTROSPECTION_AUTH_HEADER").ok()
+        }
+        _ => Some(
+            kms::decrypt(
+                kms_client.clone().unwrap(),
+                "OIDC_INTROSPECTION_AUTH_HEADER",
+            )
+            .await,
+        ),
+    }
+}
+
+/// The JSON array of static API tokens (`OIDC_API_STATIC_TOKENS`), each entry
+/// `{token, principal[, email, org]}`. A secret, KMS-decrypted like other
+/// secrets in non-dev environments. Returns `None` when unset (static-token
+/// mechanism disabled).
+pub async fn get_static_api_tokens(
+    kms_client: &Option<Client>,
+    app_env: &AppEnv,
+) -> Option<String> {
+    if std::env::var("OIDC_API_STATIC_TOKENS").is_err() {
+        return None;
+    }
+    match app_env {
+        AppEnv::DEV | AppEnv::TEST | AppEnv::SANDBOX => {
+            std::env::var("OIDC_API_STATIC_TOKENS").ok()
+        }
+        _ => Some(
+            kms::decrypt(kms_client.clone().unwrap(), "OIDC_API_STATIC_TOKENS").await,
+        ),
+    }
+}
+
 pub async fn get_kronos_api_key(kms_client: &Option<Client>, app_env: &AppEnv) -> String {
     match app_env {
         AppEnv::DEV | AppEnv::TEST => {

--- a/crates/service_utils/src/middlewares/auth_n.rs
+++ b/crates/service_utils/src/middlewares/auth_n.rs
@@ -28,7 +28,9 @@ use oidc::{SaasOIDCAuthenticator, SimpleOIDCAuthenticator};
 use superposition_types::{DispatchUser, InternalUser, User};
 
 use crate::{
-    db::utils::get_oidc_client_secret,
+    db::utils::{
+        get_introspection_auth_header, get_oidc_client_secret, get_static_api_tokens,
+    },
     extensions::HttpRequestExt,
     helpers::get_from_env_unsafe,
     kronos_dispatch::DISPATCHER_USERNAME,
@@ -62,9 +64,22 @@ fn process_bearer_token<'a>(
     login_type: &Login,
     token: &str,
 ) -> Option<LocalBoxFuture<'a, Result<User, HttpResponse>>> {
+    // When the optional RFC 7662 API-token flow is configured and the token
+    // carries its prefix, strip the prefix and validate via introspection.
+    // Otherwise treat the token as a standard OIDC id-token.
+    if let Some(prefix) = auth_n_handler.0.api_token_prefix() {
+        if let Some(api_key) = token.strip_prefix(prefix.as_str()) {
+            return Some(
+                auth_n_handler
+                    .0
+                    .authenticate_with_api_token(login_type, api_key),
+            );
+        }
+    }
+
     let resp = auth_n_handler
         .0
-        .authenticate_with_bearer_token(&login_type, token);
+        .authenticate_with_bearer_token(login_type, token);
     Some(Box::pin(ready(resp)))
 }
 
@@ -99,7 +114,7 @@ fn process_basic_auth<'a>(
         })?;
 
     if is_dispatch_credential(&id, &secret, &state.kronos_dispatch_token) {
-        let user = process_dipatcher_token(&request);
+        let user = process_dipatcher_token(request);
         return Some(Box::pin(ready(Ok(user))));
     }
 
@@ -114,7 +129,7 @@ fn process_basic_auth<'a>(
     let user_resp = match BasicAuthGrant::resolve(grant_type, id, secret) {
         Some(grant) => auth_n_handler
             .0
-            .authenticate_with_basic_auth(&login_type, grant),
+            .authenticate_with_basic_auth(login_type, grant),
         None => Box::pin(ready(Err(
             ErrorBadRequest("Unsupported X-Grant-Type").into()
         ))),
@@ -199,7 +214,7 @@ where
                         &self.auth_n_handler,
                         &login_type,
                         token,
-                        &state,
+                        state,
                     ),
                     (_, _) => None,
                 }
@@ -250,6 +265,9 @@ impl AuthNHandler {
                 let base_url = get_from_env_unsafe("OIDC_REDIRECT_HOST").unwrap();
                 let cid = get_from_env_unsafe("OIDC_CLIENT_ID").unwrap();
                 let csecret = get_oidc_client_secret(kms_client, app_env).await;
+                let introspection_auth =
+                    get_introspection_auth_header(kms_client, app_env).await;
+                let static_tokens = get_static_api_tokens(kms_client, app_env).await;
                 Arc::new(
                     SimpleOIDCAuthenticator::new(
                         url,
@@ -257,6 +275,8 @@ impl AuthNHandler {
                         path_prefix,
                         cid,
                         csecret,
+                        introspection_auth,
+                        static_tokens,
                     )
                     .await
                     .unwrap(),
@@ -267,10 +287,21 @@ impl AuthNHandler {
                 let base_url = get_from_env_unsafe("OIDC_REDIRECT_HOST").unwrap();
                 let cid = get_from_env_unsafe("OIDC_CLIENT_ID").unwrap();
                 let csecret = get_oidc_client_secret(kms_client, app_env).await;
+                let introspection_auth =
+                    get_introspection_auth_header(kms_client, app_env).await;
+                let static_tokens = get_static_api_tokens(kms_client, app_env).await;
                 Arc::new(
-                    SaasOIDCAuthenticator::new(url, base_url, path_prefix, cid, csecret)
-                        .await
-                        .unwrap(),
+                    SaasOIDCAuthenticator::new(
+                        url,
+                        base_url,
+                        path_prefix,
+                        cid,
+                        csecret,
+                        introspection_auth,
+                        static_tokens,
+                    )
+                    .await
+                    .unwrap(),
                 )
             }
             _ => panic!("Missing/Unknown authenticator."),

--- a/crates/service_utils/src/middlewares/auth_n.rs
+++ b/crates/service_utils/src/middlewares/auth_n.rs
@@ -102,7 +102,10 @@ where
     fn call(&self, request: ServiceRequest) -> Self::Future {
         let state = request.app_data::<Data<AppState>>().unwrap();
 
-        let result = request
+        let login_type =
+            self.get_login_type(&request, &state.tenant_middleware_exclusion_list);
+
+        let auth_future = request
             .headers()
             .get(header::AUTHORIZATION)
             .and_then(|auth| auth.to_str().ok())
@@ -123,8 +126,30 @@ where
                                 request
                                     .extensions_mut()
                                     .insert::<InternalUser>(InternalUser);
-                                Ok(user)
+                                Box::pin(ready(Ok(user))) as LocalBoxFuture<'static, _>
                             })
+                    }
+                    (Some("Bearer"), Some(token)) => {
+                        let resp = self
+                            .auth_n_handler
+                            .0
+                            .authenticate_with_token(&login_type, token);
+                        Some(Box::pin(ready(resp)) as LocalBoxFuture<'static, _>)
+                    }
+                    (Some("Basic"), Some(credential))
+                        if request.path().ends_with("/dispatch/webhook")
+                            && is_dispatch_credential(
+                                credential,
+                                &state.kronos_dispatch_token,
+                            ) =>
+                    {
+                        request
+                            .extensions_mut()
+                            .insert::<DispatchUser>(DispatchUser);
+                        Some(Ok(User::new(
+                            format!("{DISPATCHER_USERNAME}@superposition.io"),
+                            DISPATCHER_USERNAME.to_string(),
+                        )))
                     }
                     (Some("Basic"), Some(credential))
                         if request.path().ends_with("/dispatch/webhook")
@@ -145,36 +170,21 @@ where
                 }
             })
             .unwrap_or_else(|| {
-                let login_type = self
-                    .get_login_type(&request, &state.tenant_middleware_exclusion_list);
-
-                Err(self
-                    .auth_n_handler
+                self.auth_n_handler
                     .0
-                    .authenticate(request.request(), &login_type))
+                    .authenticate(request.request(), &login_type)
             });
 
-        match result {
-            Ok(user) => {
-                request.extensions_mut().insert::<User>(user);
-                let fut = self.service.call(request);
-                Box::pin(async { fut.await.map(|sr| sr.map_into_left_body()) })
+        let srv = self.service.clone();
+        Box::pin(async move {
+            match auth_future.await {
+                Ok(user) => {
+                    request.extensions_mut().insert::<User>(user);
+                    srv.call(request).await.map(|sr| sr.map_into_left_body())
+                }
+                Err(resp) => Ok(request.into_response(resp.map_into_right_body())),
             }
-            Err(fut) => {
-                let srv = self.service.clone();
-                Box::pin(async move {
-                    match fut.await {
-                        Ok(user) => {
-                            request.extensions_mut().insert::<User>(user);
-                            srv.call(request).await.map(|sr| sr.map_into_left_body())
-                        }
-                        Err(resp) => {
-                            Ok(request.into_response(resp.map_into_right_body()))
-                        }
-                    }
-                })
-            }
-        }
+        })
     }
 }
 

--- a/crates/service_utils/src/middlewares/auth_n.rs
+++ b/crates/service_utils/src/middlewares/auth_n.rs
@@ -14,11 +14,12 @@ use actix_web::{
     Error, HttpMessage, HttpRequest, HttpResponse, Scope,
     body::{BoxBody, EitherBody},
     dev::{Service, ServiceRequest, ServiceResponse, Transform, forward_ready},
+    error::ErrorBadRequest,
     get,
     http::header,
     web::{self, Data, Path},
 };
-use authentication::{Authenticator, Login, SwitchOrgParams};
+use authentication::{Authenticator, BasicAuthGrant, Login, SwitchOrgParams};
 use aws_sdk_kms::Client;
 use base64::{Engine, engine::general_purpose};
 use futures_util::future::LocalBoxFuture;
@@ -133,7 +134,7 @@ where
                         let resp = self
                             .auth_n_handler
                             .0
-                            .authenticate_with_token(&login_type, token);
+                            .authenticate_with_bearer_token(&login_type, token);
                         Some(Box::pin(ready(resp)) as LocalBoxFuture<'static, _>)
                     }
                     (Some("Basic"), Some(credential))
@@ -165,6 +166,41 @@ where
                             format!("{DISPATCHER_USERNAME}@superposition.io"),
                             DISPATCHER_USERNAME.to_string(),
                         )))
+                    }
+                    (Some("Basic"), Some(token)) => {
+                        // `X-Grant-Type` selects how the Basic pair is validated:
+                        // absent => client_credentials (M2M), `password` => ROPC,
+                        // anything else is rejected with a 400.
+                        let grant_type = request
+                            .headers()
+                            .get("x-grant-type")
+                            .and_then(|v| v.to_str().ok());
+                        general_purpose::STANDARD
+                            .decode(token)
+                            .ok()
+                            .and_then(|decoded| String::from_utf8(decoded).ok())
+                            .and_then(|decoded| {
+                                let mut parts = decoded.splitn(2, ':');
+                                match (parts.next(), parts.next()) {
+                                    (Some(id), Some(secret)) => {
+                                        Some((id.to_string(), secret.to_string()))
+                                    }
+                                    _ => None,
+                                }
+                            })
+                            .map(|(id, secret)| {
+                                match BasicAuthGrant::resolve(grant_type, id, secret) {
+                                    Some(grant) => self
+                                        .auth_n_handler
+                                        .0
+                                        .authenticate_with_basic_auth(&login_type, grant),
+                                    None => Box::pin(ready(Err(ErrorBadRequest(
+                                        "Unsupported X-Grant-Type",
+                                    )
+                                    .into())))
+                                        as LocalBoxFuture<'static, _>,
+                                }
+                            })
                     }
                     (_, _) => None,
                 }

--- a/crates/service_utils/src/middlewares/auth_n.rs
+++ b/crates/service_utils/src/middlewares/auth_n.rs
@@ -113,7 +113,9 @@ fn process_basic_auth<'a>(
             }
         })?;
 
-    if is_dispatch_credential(&id, &secret, &state.kronos_dispatch_token) {
+    if request.path().ends_with("/dispatch/webhook")
+        && is_dispatch_credential(&id, &secret, &state.kronos_dispatch_token)
+    {
         let user = process_dipatcher_token(request);
         return Some(Box::pin(ready(Ok(user))));
     }

--- a/crates/service_utils/src/middlewares/auth_n.rs
+++ b/crates/service_utils/src/middlewares/auth_n.rs
@@ -37,17 +37,90 @@ use crate::{
 
 /// Verifies a `Basic` credential as the Kronos dispatch callback credential:
 /// `base64("kronos-dispatcher:<dispatch_token>")`.
-fn is_dispatch_credential(credential: &str, dispatch_token: &str) -> bool {
-    general_purpose::STANDARD
-        .decode(credential)
+fn is_dispatch_credential(id: &str, secret: &str, dispatch_token: &str) -> bool {
+    id == DISPATCHER_USERNAME && secret == dispatch_token
+}
+
+fn process_internal_token<'a>(
+    request: &ServiceRequest,
+) -> Option<LocalBoxFuture<'a, Result<User, HttpResponse>>> {
+    request
+        .headers()
+        .get("x-user")
+        .and_then(|auth| auth.to_str().ok())
+        .and_then(|user_str| serde_json::from_str::<User>(user_str).ok())
+        .map(|user| {
+            request
+                .extensions_mut()
+                .insert::<InternalUser>(InternalUser);
+            Box::pin(ready(Ok(user))) as LocalBoxFuture<'a, _>
+        })
+}
+
+fn process_bearer_token<'a>(
+    auth_n_handler: &AuthNHandler,
+    login_type: &Login,
+    token: &str,
+) -> Option<LocalBoxFuture<'a, Result<User, HttpResponse>>> {
+    let resp = auth_n_handler
+        .0
+        .authenticate_with_bearer_token(&login_type, token);
+    Some(Box::pin(ready(resp)))
+}
+
+fn process_dipatcher_token(request: &ServiceRequest) -> User {
+    request
+        .extensions_mut()
+        .insert::<DispatchUser>(DispatchUser);
+
+    User::new(
+        format!("{DISPATCHER_USERNAME}@superposition.io"),
+        DISPATCHER_USERNAME.to_string(),
+    )
+}
+
+fn process_basic_auth<'a>(
+    request: &ServiceRequest,
+    auth_n_handler: &AuthNHandler,
+    login_type: &Login,
+    token: &str,
+    state: &AppState,
+) -> Option<LocalBoxFuture<'a, Result<User, HttpResponse>>> {
+    let (id, secret) = general_purpose::STANDARD
+        .decode(token)
         .ok()
         .and_then(|decoded| String::from_utf8(decoded).ok())
         .and_then(|decoded| {
-            decoded.split_once(':').map(|(user, token)| {
-                user == DISPATCHER_USERNAME && token == dispatch_token
-            })
-        })
-        .unwrap_or(false)
+            let mut parts = decoded.splitn(2, ':');
+            match (parts.next(), parts.next()) {
+                (Some(id), Some(secret)) => Some((id.to_string(), secret.to_string())),
+                _ => None,
+            }
+        })?;
+
+    if is_dispatch_credential(&id, &secret, &state.kronos_dispatch_token) {
+        let user = process_dipatcher_token(&request);
+        return Some(Box::pin(ready(Ok(user))));
+    }
+
+    // `X-Grant-Type` selects how the Basic pair is validated:
+    // absent => client_credentials (M2M), `password` => ROPC,
+    // anything else is rejected with a 400.
+    let grant_type = request
+        .headers()
+        .get("x-grant-type")
+        .and_then(|v| v.to_str().ok());
+
+    let user_resp = match BasicAuthGrant::resolve(grant_type, id, secret) {
+        Some(grant) => auth_n_handler
+            .0
+            .authenticate_with_basic_auth(&login_type, grant),
+        None => Box::pin(ready(Err(
+            ErrorBadRequest("Unsupported X-Grant-Type").into()
+        ))),
+    };
+
+    Some(user_resp)
 }
 
 pub struct AuthNMiddleware<S> {
@@ -116,92 +189,18 @@ where
                     (Some("Internal"), Some(token))
                         if token == state.superposition_token =>
                     {
-                        request
-                            .headers()
-                            .get("x-user")
-                            .and_then(|auth| auth.to_str().ok())
-                            .and_then(|user_str| {
-                                serde_json::from_str::<User>(user_str).ok()
-                            })
-                            .map(|user| {
-                                request
-                                    .extensions_mut()
-                                    .insert::<InternalUser>(InternalUser);
-                                Box::pin(ready(Ok(user))) as LocalBoxFuture<'static, _>
-                            })
+                        process_internal_token(&request)
                     }
                     (Some("Bearer"), Some(token)) => {
-                        let resp = self
-                            .auth_n_handler
-                            .0
-                            .authenticate_with_bearer_token(&login_type, token);
-                        Some(Box::pin(ready(resp)) as LocalBoxFuture<'static, _>)
+                        process_bearer_token(&self.auth_n_handler, &login_type, token)
                     }
-                    (Some("Basic"), Some(credential))
-                        if request.path().ends_with("/dispatch/webhook")
-                            && is_dispatch_credential(
-                                credential,
-                                &state.kronos_dispatch_token,
-                            ) =>
-                    {
-                        request
-                            .extensions_mut()
-                            .insert::<DispatchUser>(DispatchUser);
-                        Some(Ok(User::new(
-                            format!("{DISPATCHER_USERNAME}@superposition.io"),
-                            DISPATCHER_USERNAME.to_string(),
-                        )))
-                    }
-                    (Some("Basic"), Some(credential))
-                        if request.path().ends_with("/dispatch/webhook")
-                            && is_dispatch_credential(
-                                credential,
-                                &state.kronos_dispatch_token,
-                            ) =>
-                    {
-                        request
-                            .extensions_mut()
-                            .insert::<DispatchUser>(DispatchUser);
-                        Some(Ok(User::new(
-                            format!("{DISPATCHER_USERNAME}@superposition.io"),
-                            DISPATCHER_USERNAME.to_string(),
-                        )))
-                    }
-                    (Some("Basic"), Some(token)) => {
-                        // `X-Grant-Type` selects how the Basic pair is validated:
-                        // absent => client_credentials (M2M), `password` => ROPC,
-                        // anything else is rejected with a 400.
-                        let grant_type = request
-                            .headers()
-                            .get("x-grant-type")
-                            .and_then(|v| v.to_str().ok());
-                        general_purpose::STANDARD
-                            .decode(token)
-                            .ok()
-                            .and_then(|decoded| String::from_utf8(decoded).ok())
-                            .and_then(|decoded| {
-                                let mut parts = decoded.splitn(2, ':');
-                                match (parts.next(), parts.next()) {
-                                    (Some(id), Some(secret)) => {
-                                        Some((id.to_string(), secret.to_string()))
-                                    }
-                                    _ => None,
-                                }
-                            })
-                            .map(|(id, secret)| {
-                                match BasicAuthGrant::resolve(grant_type, id, secret) {
-                                    Some(grant) => self
-                                        .auth_n_handler
-                                        .0
-                                        .authenticate_with_basic_auth(&login_type, grant),
-                                    None => Box::pin(ready(Err(ErrorBadRequest(
-                                        "Unsupported X-Grant-Type",
-                                    )
-                                    .into())))
-                                        as LocalBoxFuture<'static, _>,
-                                }
-                            })
-                    }
+                    (Some("Basic"), Some(token)) => process_basic_auth(
+                        &request,
+                        &self.auth_n_handler,
+                        &login_type,
+                        token,
+                        &state,
+                    ),
                     (_, _) => None,
                 }
             })

--- a/crates/service_utils/src/middlewares/auth_n/README.md
+++ b/crates/service_utils/src/middlewares/auth_n/README.md
@@ -1,0 +1,26 @@
+# `auth_n` — authentication middleware
+
+This module authenticates incoming requests. Superposition does **not** store
+users or do user management — every identity decision is delegated to an
+external OIDC provider or an external RFC 7662 token-introspection service, and
+verified per request.
+
+Full documentation — providers, credential schemes (`Internal`, `Bearer`
+OIDC id-token, `Basic` client-credentials/password with `X-Grant-Type`, and
+API-key introspection), caching, error semantics, the environment-variable
+reference, and the rationale behind each decision — lives in:
+
+**[docs/docs/self-hosting/authentication.md](../../../../../docs/docs/self-hosting/authentication.md)**
+(also published on the docs site under Self-Hosting → Authentication).
+
+Module layout:
+
+| File | Responsibility |
+| --- | --- |
+| `authentication.rs` | The `Authenticator` trait, `Login` scope, `BasicAuthGrant` |
+| `oidc/simple_authenticator.rs` | Single-realm OIDC provider |
+| `oidc/saas_authenticator.rs` | Per-organisation (SaaS) OIDC provider |
+| `oidc/api_token.rs` | API-token flow: static tokens + RFC 7662 introspection client |
+| `oidc/token_cache.rs` | In-memory cache for token-exchange / introspection results |
+| `oidc/utils.rs` | Shared OIDC client + grant-exchange helpers |
+| `no_auth.rs` | `DISABLED` provider |

--- a/crates/service_utils/src/middlewares/auth_n/authentication.rs
+++ b/crates/service_utils/src/middlewares/auth_n/authentication.rs
@@ -52,6 +52,12 @@ pub trait Authenticator: Sync + Send {
         login_type: &Login,
     ) -> LocalBoxFuture<'static, Result<User, HttpResponse>>;
 
+    fn authenticate_with_token(
+        &self,
+        login_type: &Login,
+        token: &str,
+    ) -> Result<User, HttpResponse>;
+
     fn get_organisations(&self, req: &HttpRequest) -> HttpResponse;
 
     fn generate_org_user<'a>(

--- a/crates/service_utils/src/middlewares/auth_n/authentication.rs
+++ b/crates/service_utils/src/middlewares/auth_n/authentication.rs
@@ -7,12 +7,51 @@ use actix_web::{
     web::Path,
 };
 use futures_util::future::LocalBoxFuture;
+use openidconnect::{
+    ClientId, ClientSecret, ResourceOwnerPassword, ResourceOwnerUsername,
+};
 use serde::Deserialize;
 use superposition_types::User;
 
 #[derive(Deserialize)]
 pub(super) struct SwitchOrgParams {
     pub(super) organisation_id: String,
+}
+
+/// The grant a `Basic` credential should be validated under. Selected by the
+/// `X-Grant-Type` header on the request (see [`BasicAuthGrant::resolve`]).
+pub enum BasicAuthGrant {
+    /// Resource Owner Password Credentials — the `Basic` pair is a user's
+    /// username/password, exchanged with the IdP for an id-token.
+    Password {
+        username: ResourceOwnerUsername,
+        password: ResourceOwnerPassword,
+    },
+    /// Client Credentials (machine-to-machine) — the `Basic` pair is a
+    /// client_id/client_secret validated against the IdP.
+    ClientCredentials {
+        client_id: ClientId,
+        client_secret: ClientSecret,
+    },
+}
+
+impl BasicAuthGrant {
+    /// Maps the `X-Grant-Type` header to a grant. Absent defaults to
+    /// `client_credentials`; `password` selects ROPC; anything else is
+    /// rejected (`None`) so the caller can fail closed with a 400.
+    pub fn resolve(grant_type: Option<&str>, id: String, secret: String) -> Option<Self> {
+        match grant_type {
+            None | Some("client_credentials") => Some(Self::ClientCredentials {
+                client_id: ClientId::new(id),
+                client_secret: ClientSecret::new(secret),
+            }),
+            Some("password") => Some(Self::Password {
+                username: ResourceOwnerUsername::new(id),
+                password: ResourceOwnerPassword::new(secret),
+            }),
+            Some(_) => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -52,11 +91,17 @@ pub trait Authenticator: Sync + Send {
         login_type: &Login,
     ) -> LocalBoxFuture<'static, Result<User, HttpResponse>>;
 
-    fn authenticate_with_token(
+    fn authenticate_with_bearer_token(
         &self,
         login_type: &Login,
         token: &str,
     ) -> Result<User, HttpResponse>;
+
+    fn authenticate_with_basic_auth(
+        &self,
+        login_type: &Login,
+        grant: BasicAuthGrant,
+    ) -> LocalBoxFuture<'static, Result<User, HttpResponse>>;
 
     fn get_organisations(&self, req: &HttpRequest) -> HttpResponse;
 

--- a/crates/service_utils/src/middlewares/auth_n/authentication.rs
+++ b/crates/service_utils/src/middlewares/auth_n/authentication.rs
@@ -3,6 +3,7 @@ use std::fmt::Display;
 use actix_web::{
     HttpRequest, HttpResponse, Scope,
     cookie::{Cookie, time::Duration},
+    error::ErrorNotImplemented,
     http::header,
     web::Path,
 };
@@ -96,6 +97,27 @@ pub trait Authenticator: Sync + Send {
         login_type: &Login,
         token: &str,
     ) -> Result<User, HttpResponse>;
+
+    /// The configured API-token prefix (`custom_prefix` + `delimiter`) when the
+    /// optional RFC 7662 introspection flow is enabled, else `None`. The
+    /// middleware uses this to route `Bearer <prefix>...` tokens to
+    /// [`Self::authenticate_with_api_token`] instead of OIDC id-token validation.
+    fn api_token_prefix(&self) -> Option<String> {
+        None
+    }
+
+    /// Validates an API token (the prefix already stripped) via RFC 7662 token
+    /// introspection. Only invoked when [`Self::api_token_prefix`] is `Some`;
+    /// the default is a safety net for providers that don't support the flow.
+    fn authenticate_with_api_token(
+        &self,
+        _login_type: &Login,
+        _api_key: &str,
+    ) -> LocalBoxFuture<'static, Result<User, HttpResponse>> {
+        Box::pin(async {
+            Err(ErrorNotImplemented("API token authentication is not supported").into())
+        })
+    }
 
     fn authenticate_with_basic_auth(
         &self,

--- a/crates/service_utils/src/middlewares/auth_n/no_auth.rs
+++ b/crates/service_utils/src/middlewares/auth_n/no_auth.rs
@@ -4,7 +4,7 @@ use superposition_types::User;
 
 use crate::middlewares::auth_n::helpers::fetch_org_ids_from_db;
 
-use super::authentication::{Authenticator, Login};
+use super::authentication::{Authenticator, BasicAuthGrant, Login};
 
 /// An Authenticator implementation that performs no authentication
 /// This is primarily for development and testing purposes
@@ -32,8 +32,20 @@ impl Authenticator for DisabledAuthenticator {
         Box::pin(async { Ok(User::default()) })
     }
 
-    fn authenticate_with_token(&self, _: &Login, _: &str) -> Result<User, HttpResponse> {
+    fn authenticate_with_bearer_token(
+        &self,
+        _: &Login,
+        _: &str,
+    ) -> Result<User, HttpResponse> {
         Ok(User::default())
+    }
+
+    fn authenticate_with_basic_auth(
+        &self,
+        _: &Login,
+        _: BasicAuthGrant,
+    ) -> LocalBoxFuture<'static, Result<User, HttpResponse>> {
+        Box::pin(async { Ok(User::default()) })
     }
 
     fn routes(&self) -> actix_web::Scope {

--- a/crates/service_utils/src/middlewares/auth_n/no_auth.rs
+++ b/crates/service_utils/src/middlewares/auth_n/no_auth.rs
@@ -32,6 +32,10 @@ impl Authenticator for DisabledAuthenticator {
         Box::pin(async { Ok(User::default()) })
     }
 
+    fn authenticate_with_token(&self, _: &Login, _: &str) -> Result<User, HttpResponse> {
+        Ok(User::default())
+    }
+
     fn routes(&self) -> actix_web::Scope {
         Scope::new("no_auth")
     }

--- a/crates/service_utils/src/middlewares/auth_n/oidc.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc.rs
@@ -14,7 +14,7 @@ use base64::{Engine, engine::general_purpose};
 use openidconnect::{
     self as oidcrs, AuthenticationFlow, ClaimsVerificationError, CsrfToken, Nonce,
     TokenResponse,
-    core::{CoreClient, CoreResponseType, CoreTokenResponse},
+    core::{CoreClient, CoreIdToken, CoreResponseType, CoreTokenResponse},
 };
 pub use saas_authenticator::SaasOIDCAuthenticator;
 pub use simple_authenticator::SimpleOIDCAuthenticator;
@@ -138,24 +138,21 @@ trait OIDCAuthenticator: Authenticator {
                 )
             })?;
 
+        let client = data.get_client();
+
         // Verify the freshly-minted ID token. If verification fails, the most
         // common cause is that the IdP has rotated its signing keys since we
         // last fetched the JWKS, so the cached keys can't validate the new
         // token's signature. Refresh the provider metadata once and retry
         // before giving up — this self-heals key rotation without a restart.
-        let mut response =
-            verify_id_token(&data.get_client(), &token_response, &p_cookie.nonce);
+        let mut response = verify_id_token(&client, &token_response, &p_cookie.nonce);
         if let Err(e) = &response {
             log::error!(
                 "OIDC: ID token verification failed; refreshing provider keys and retrying, error: {e:?}"
             );
             match data.refresh_client().await {
                 Ok(()) => {
-                    response = verify_id_token(
-                        &data.get_client(),
-                        &token_response,
-                        &p_cookie.nonce,
-                    );
+                    response = verify_id_token(&client, &token_response, &p_cookie.nonce);
                 }
                 Err(e) => {
                     log::error!("OIDC: failed to refresh provider metadata: {e}")
@@ -165,11 +162,7 @@ trait OIDCAuthenticator: Authenticator {
 
         match response {
             Ok(r) => {
-                let token = serde_json::to_string(&r).map_err(|e| {
-                    log::error!("Unable to stringify data: {e:?}");
-                    ErrorInternalServerError("Unable to stringify data".to_string())
-                })?;
-                let cookie = Cookie::build(login_type.to_string(), token)
+                let cookie = Cookie::build(login_type.to_string(), r.to_string())
                     .path(data.get_cookie_path())
                     .http_only(true)
                     .secure(true)
@@ -194,16 +187,16 @@ trait OIDCAuthenticator: Authenticator {
     }
 }
 
-fn verify_id_token(
-    client: &CoreClient,
-    token_response: &CoreTokenResponse,
-    nonce: &Nonce,
-) -> Result<CoreTokenResponse, ClaimsVerificationError> {
-    token_response
-        .id_token()
-        .ok_or_else(|| ClaimsVerificationError::Other("Id Token not found".to_string()))
-        .and_then(|t| t.claims(&client.id_token_verifier(), nonce))
-        .map(|_| token_response.clone())
+fn verify_id_token<'a>(
+    client: &'a CoreClient,
+    token_response: &'a CoreTokenResponse,
+    nonce: &'a Nonce,
+) -> Result<&'a CoreIdToken, ClaimsVerificationError> {
+    let id_token = token_response.id_token().ok_or_else(|| {
+        ClaimsVerificationError::Other("Id Token not found".to_string())
+    })?;
+    id_token.claims(&client.id_token_verifier(), nonce)?;
+    Ok(id_token)
 }
 
 fn sign_in_failed_response(retry_url: &str) -> HttpResponse {

--- a/crates/service_utils/src/middlewares/auth_n/oidc.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc.rs
@@ -12,8 +12,9 @@ use actix_web::{
 };
 use base64::{Engine, engine::general_purpose};
 use openidconnect::{
-    self as oidcrs, AuthenticationFlow, CsrfToken, Nonce, TokenResponse,
-    core::{CoreClient, CoreResponseType},
+    self as oidcrs, AuthenticationFlow, ClaimsVerificationError, CsrfToken, Nonce,
+    TokenResponse,
+    core::{CoreClient, CoreResponseType, CoreTokenResponse},
 };
 pub use saas_authenticator::SaasOIDCAuthenticator;
 pub use simple_authenticator::SimpleOIDCAuthenticator;
@@ -27,7 +28,14 @@ use crate::middlewares::auth_n::{
 /// Trait defining OIDC specific authenticator methods
 /// This is to be implemented by any OIDC based authenticator - SimpleOIDCAuthenticator, SaasOIDCAuthenticator etc.
 trait OIDCAuthenticator: Authenticator {
-    fn get_client(&self) -> &CoreClient;
+    fn get_client(&self) -> CoreClient;
+
+    /// Re-fetch the OpenID Provider metadata (including the JWKS signing keys)
+    /// from the issuer and swap in a freshly-built client. Called when ID token
+    /// verification fails, so a long-lived process recovers automatically once
+    /// the IdP rotates its signing keys (e.g. Google rotates JWKS every few
+    /// hours/days) instead of serving stale keys until the pod is restarted.
+    async fn refresh_client(&self) -> Result<(), String>;
 
     fn get_global_user(
         &self,
@@ -130,14 +138,30 @@ trait OIDCAuthenticator: Authenticator {
                 )
             })?;
 
-        let response = token_response
-            .id_token()
-            .ok_or_else(|| log::error!("No identity-token!"))
-            .and_then(|t| {
-                t.claims(&data.get_client().id_token_verifier(), &p_cookie.nonce)
-                    .map_err(|e| log::error!("Couldn't verify claims: {e:?}"))
-            })
-            .map(|_| token_response.clone());
+        // Verify the freshly-minted ID token. If verification fails, the most
+        // common cause is that the IdP has rotated its signing keys since we
+        // last fetched the JWKS, so the cached keys can't validate the new
+        // token's signature. Refresh the provider metadata once and retry
+        // before giving up — this self-heals key rotation without a restart.
+        let mut response =
+            verify_id_token(&data.get_client(), &token_response, &p_cookie.nonce);
+        if let Err(e) = &response {
+            log::error!(
+                "OIDC: ID token verification failed; refreshing provider keys and retrying, error: {e:?}"
+            );
+            match data.refresh_client().await {
+                Ok(()) => {
+                    response = verify_id_token(
+                        &data.get_client(),
+                        &token_response,
+                        &p_cookie.nonce,
+                    );
+                }
+                Err(e) => {
+                    log::error!("OIDC: failed to refresh provider metadata: {e}")
+                }
+            }
+        }
 
         match response {
             Ok(r) => {
@@ -156,10 +180,42 @@ trait OIDCAuthenticator: Authenticator {
                     .insert_header((header::LOCATION, params.state.redirect_uri.clone()))
                     .finish())
             }
-            Err(()) => Ok(data.new_redirect(
-                &login_type,
-                format!("{}/admin/organisations", data.get_path_prefix()),
-            )),
+            // Verification failed even after refreshing keys. Avoid retrying.
+            Err(e) => {
+                log::error!(
+                    "OIDC: ID token verification failed even after refreshing keys: {e:?}"
+                );
+                Ok(sign_in_failed_response(&format!(
+                    "{}/admin/organisations",
+                    data.get_path_prefix()
+                )))
+            }
         }
     }
+}
+
+fn verify_id_token(
+    client: &CoreClient,
+    token_response: &CoreTokenResponse,
+    nonce: &Nonce,
+) -> Result<CoreTokenResponse, ClaimsVerificationError> {
+    token_response
+        .id_token()
+        .ok_or_else(|| ClaimsVerificationError::Other("Id Token not found".to_string()))
+        .and_then(|t| t.claims(&client.id_token_verifier(), nonce))
+        .map(|_| token_response.clone())
+}
+
+fn sign_in_failed_response(retry_url: &str) -> HttpResponse {
+    let body = format!(
+        "<!DOCTYPE html><html><head><meta charset=\"utf-8\"><title>Sign-in failed</title></head>\
+         <body style=\"font-family:sans-serif;max-width:32rem;margin:4rem auto;text-align:center\">\
+         <h1>Sign-in failed</h1>\
+         <p>We couldn't complete your sign-in. This is usually temporary.</p>\
+         <p><a href=\"{retry_url}\">Try signing in again</a></p>\
+         </body></html>"
+    );
+    HttpResponse::Unauthorized()
+        .content_type("text/html; charset=utf-8")
+        .body(body)
 }

--- a/crates/service_utils/src/middlewares/auth_n/oidc.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc.rs
@@ -1,5 +1,6 @@
 mod saas_authenticator;
 mod simple_authenticator;
+mod token_cache;
 mod types;
 mod utils;
 

--- a/crates/service_utils/src/middlewares/auth_n/oidc.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc.rs
@@ -140,21 +140,25 @@ trait OIDCAuthenticator: Authenticator {
                 )
             })?;
 
-        let client = data.get_client();
-
         // Verify the freshly-minted ID token. If verification fails, the most
         // common cause is that the IdP has rotated its signing keys since we
         // last fetched the JWKS, so the cached keys can't validate the new
         // token's signature. Refresh the provider metadata once and retry
         // before giving up — this self-heals key rotation without a restart.
-        let mut response = verify_id_token(&client, &token_response, &p_cookie.nonce);
+        let mut response =
+            verify_id_token(&data.get_client(), &token_response, &p_cookie.nonce);
         if let Err(e) = &response {
             log::error!(
                 "OIDC: ID token verification failed; refreshing provider keys and retrying, error: {e:?}"
             );
             match data.refresh_client().await {
                 Ok(()) => {
-                    response = verify_id_token(&client, &token_response, &p_cookie.nonce);
+                    let refreshed_client = data.get_client();
+                    response = verify_id_token(
+                        &refreshed_client,
+                        &token_response,
+                        &p_cookie.nonce,
+                    );
                 }
                 Err(e) => {
                     log::error!("OIDC: failed to refresh provider metadata: {e}")
@@ -190,9 +194,9 @@ trait OIDCAuthenticator: Authenticator {
 }
 
 fn verify_id_token<'a>(
-    client: &'a CoreClient,
+    client: &CoreClient,
     token_response: &'a CoreTokenResponse,
-    nonce: &'a Nonce,
+    nonce: &Nonce,
 ) -> Result<&'a CoreIdToken, ClaimsVerificationError> {
     let id_token = token_response.id_token().ok_or_else(|| {
         ClaimsVerificationError::Other("Id Token not found".to_string())

--- a/crates/service_utils/src/middlewares/auth_n/oidc.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc.rs
@@ -1,3 +1,4 @@
+mod api_token;
 mod saas_authenticator;
 mod simple_authenticator;
 mod token_cache;

--- a/crates/service_utils/src/middlewares/auth_n/oidc/api_token.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/api_token.rs
@@ -1,0 +1,383 @@
+//! Optional **API-token authentication** for machine-to-machine access under an
+//! OIDC provider. A bearer token of the form `Bearer <prefix><delimiter><key>`
+//! is routed here (the prefix marks it as an API key) and validated by one of
+//! two mechanisms, tried in order:
+//!
+//! 1. **Static tokens** — a KMS-encrypted, operator-configured list of tokens,
+//!    each mapping to a fixed principal (and, in SaaS, a specific organisation).
+//!    Validated locally with a constant-time compare; no network call. Handy for
+//!    a small, fixed set of service accounts or for setups without an
+//!    introspection endpoint.
+//! 2. **RFC 7662 token introspection** — the `<key>` is forwarded, per RFC 7662,
+//!    to a configured/discovered introspection endpoint which answers whether the
+//!    token is active and returns its claims. Modelled on RFC 7662 so any
+//!    provider (Keycloak, Okta, Hydra, ... or a small custom service) can serve
+//!    it with little or no bespoke code.
+//!
+//! The whole flow is optional and only available under an OIDC provider: it
+//! activates only when a prefix plus at least one of the two mechanisms is
+//! configured (see [`ApiTokenConfig::from_env`]).
+
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use actix_web::error::{ErrorServiceUnavailable, ErrorUnauthorized};
+use once_cell::sync::Lazy;
+use serde::Deserialize;
+use superposition_types::User;
+
+use crate::helpers::{get_from_env_or_default, get_from_env_unsafe};
+
+/// Reused connection-pooling client for introspection calls.
+static HTTP_CLIENT: Lazy<reqwest::Client> = Lazy::new(reqwest::Client::new);
+
+/// Upper bound on how long an introspection result is cached, regardless of the
+/// token's `exp`. Introspection exists for near-real-time revocation, so we cap
+/// caching to keep revocation lag small even for long-lived tokens.
+const MAX_INTROSPECTION_CACHE_TTL: Duration = Duration::from_secs(300);
+
+/// Cache TTL for an introspection result: the time until the token's `exp`,
+/// capped at [`MAX_INTROSPECTION_CACHE_TTL`]. Returns `None` (no or already-past
+/// `exp`) so the cache applies its own short fallback.
+pub(super) fn cache_ttl(exp: Option<u64>) -> Option<Duration> {
+    let exp = exp?;
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+    let remaining = exp.checked_sub(now)?;
+    Some(Duration::from_secs(remaining).min(MAX_INTROSPECTION_CACHE_TTL))
+}
+
+/// Length-independent* byte comparison, to avoid leaking how many leading bytes
+/// of a static token matched via response timing. (*Length is not hidden; token
+/// values are high-entropy secrets so that leak is immaterial.)
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+/// One entry in the static-token list: a shared-secret token bound to a fixed
+/// identity (and, in SaaS, to an organisation). Deserialized from the JSON in
+/// `OIDC_API_STATIC_TOKENS`.
+#[derive(Deserialize)]
+struct StaticToken {
+    /// The secret value presented as the API key (after the prefix is stripped).
+    token: String,
+    /// Identity to authenticate as; used as the username and (absent `email`)
+    /// the email. Authorization (Casbin) keys off this.
+    principal: String,
+    /// Optional email for the principal; defaults to `principal`.
+    #[serde(default)]
+    email: Option<String>,
+    /// SaaS only: the organisation this token is valid for. `None` means the
+    /// token is valid for global-scoped requests. Ignored in Simple OIDC.
+    #[serde(default)]
+    org: Option<String>,
+}
+
+impl StaticToken {
+    fn to_user(&self) -> User {
+        let email = self.email.clone().unwrap_or_else(|| self.principal.clone());
+        User::new(email, self.principal.clone())
+    }
+
+    /// Whether this entry authenticates `api_key` for the request `scope`.
+    /// When `enforce_org` (SaaS), the org binding must match: an org-scoped
+    /// request needs `org == Some(scope)`, a global request needs `org == None`.
+    /// In Simple OIDC (`!enforce_org`) the org binding is ignored.
+    fn matches(&self, enforce_org: bool, scope: Option<&str>, api_key: &str) -> bool {
+        if enforce_org {
+            let scope_ok = match (scope, self.org.as_deref()) {
+                (Some(req), Some(tok)) => req == tok,
+                (None, None) => true,
+                _ => false,
+            };
+            if !scope_ok {
+                return false;
+            }
+        }
+        constant_time_eq(self.token.as_bytes(), api_key.as_bytes())
+    }
+}
+
+/// Introspection-endpoint settings, present only when RFC 7662 introspection is
+/// configured (`OIDC_INTROSPECTION_AUTH_HEADER` set). Absent for a static-only
+/// setup.
+struct IntrospectionSettings {
+    /// Verbatim `Authorization` header value Superposition presents to the
+    /// introspection endpoint (e.g. `Bearer <token>` or `Basic <base64>`) — the
+    /// endpoint is protected per RFC 7662 §2.1. A secret; KMS-decrypted upstream
+    /// and passed in.
+    auth_header: String,
+    /// SaaS per-org endpoint format with `<organisation>` (`None` for Simple).
+    /// This is *not* discoverable — per-org discovery would be a network call
+    /// per org — so org-scoped API tokens require it.
+    org_endpoint_format: Option<String>,
+    /// Explicit single/global introspection endpoint (both modes). Optional:
+    /// when absent, the endpoint discovered from provider metadata is used.
+    global_endpoint: Option<String>,
+}
+
+/// Static configuration for the API-token flow, loaded from env. Owns the prefix
+/// plus whichever validation mechanism(s) are configured.
+pub(super) struct ApiTokenConfig {
+    /// `custom_prefix` + `delimiter`, matched against (and stripped from) the
+    /// incoming bearer token to select this flow.
+    pub(super) prefix: String,
+    /// SaaS (per-org) mode: enforces static-token org binding and requires the
+    /// per-org introspection endpoint format.
+    is_saas: bool,
+    /// Static tokens, checked before introspection. May be empty.
+    static_tokens: Vec<StaticToken>,
+    /// Introspection settings; `None` for a static-only setup.
+    introspection: Option<IntrospectionSettings>,
+}
+
+impl ApiTokenConfig {
+    /// Loads config from env and the two upstream-decrypted secrets. Returns
+    /// `Ok(None)` (feature disabled) when the prefix is unset, or when the prefix
+    /// is set but neither validation mechanism is configured. Returns `Err` on a
+    /// malformed static-token list so the misconfiguration fails startup.
+    ///
+    /// - `auth_header`: the KMS-decrypted `OIDC_INTROSPECTION_AUTH_HEADER`;
+    ///   `Some` enables the introspection mechanism.
+    /// - `static_tokens_raw`: the KMS-decrypted `OIDC_API_STATIC_TOKENS` JSON;
+    ///   a non-empty list enables the static-token mechanism.
+    pub(super) fn from_env(
+        auth_header: Option<String>,
+        static_tokens_raw: Option<String>,
+        is_saas: bool,
+    ) -> Result<Option<Self>, String> {
+        // Without a prefix the flow can never be triggered from a bearer token.
+        let Some(prefix) = get_from_env_unsafe::<String>("OIDC_API_TOKEN_PREFIX")
+            .ok()
+            .filter(|p| !p.is_empty())
+        else {
+            return Ok(None);
+        };
+        let delimiter: String =
+            get_from_env_or_default("OIDC_API_TOKEN_DELIMITER", "_".into());
+
+        let static_tokens = match static_tokens_raw {
+            Some(raw) => parse_static_tokens(&raw)?,
+            None => Vec::new(),
+        };
+
+        let introspection = auth_header.map(|auth_header| {
+            let org_endpoint_format = is_saas
+                .then(|| {
+                    get_from_env_unsafe::<String>(
+                        "OIDC_ORG_TOKEN_INTROSPECTION_URL_FORMAT",
+                    )
+                    .ok()
+                })
+                .flatten();
+            let global_endpoint =
+                get_from_env_unsafe::<String>("OIDC_TOKEN_INTROSPECTION_URL").ok();
+            IntrospectionSettings {
+                auth_header,
+                org_endpoint_format,
+                global_endpoint,
+            }
+        });
+
+        // A prefix alone validates nothing; require at least one mechanism.
+        if introspection.is_none() && static_tokens.is_empty() {
+            log::warn!(
+                "OIDC_API_TOKEN_PREFIX is set but neither static tokens \
+                 (OIDC_API_STATIC_TOKENS) nor introspection \
+                 (OIDC_INTROSPECTION_AUTH_HEADER) are configured; API-token \
+                 authentication is disabled"
+            );
+            return Ok(None);
+        }
+
+        Ok(Some(Self {
+            prefix: format!("{prefix}{delimiter}"),
+            is_saas,
+            static_tokens,
+            introspection,
+        }))
+    }
+
+    /// Whether RFC 7662 introspection is configured (vs. static-only).
+    pub(super) fn introspection_enabled(&self) -> bool {
+        self.introspection.is_some()
+    }
+
+    /// Startup validation for the introspection mechanism (a static-only config
+    /// needs no endpoint, so this is a no-op then). Fails fast so a
+    /// misconfiguration surfaces at boot rather than on the first request.
+    ///
+    /// - SaaS: the per-org format is the base requirement — a global-only config
+    ///   contradicts the per-org isolation model and is rejected.
+    /// - Simple: a single endpoint must be resolvable, from an explicit URL or
+    ///   the `discovered` endpoint in provider metadata.
+    pub(super) fn ensure_serviceable(
+        &self,
+        discovered: Option<&str>,
+    ) -> Result<(), String> {
+        let Some(introspection) = &self.introspection else {
+            return Ok(());
+        };
+        if self.is_saas {
+            if introspection.org_endpoint_format.is_none() {
+                return Err("SaaS API-token introspection requires \
+                     OIDC_ORG_TOKEN_INTROSPECTION_URL_FORMAT (the per-organisation \
+                     introspection endpoint); a global-only configuration is not \
+                     valid for a per-org (SaaS) setup"
+                    .to_string());
+            }
+        } else if introspection.global_endpoint.is_none() && discovered.is_none() {
+            return Err(
+                "API-token introspection is enabled (OIDC_API_TOKEN_PREFIX + \
+                 OIDC_INTROSPECTION_AUTH_HEADER are set) but no introspection \
+                 endpoint is configured or discoverable — set \
+                 OIDC_TOKEN_INTROSPECTION_URL, or use an IdP that advertises \
+                 introspection_endpoint in its metadata"
+                    .to_string(),
+            );
+        }
+        Ok(())
+    }
+
+    /// Returns the principal for a static token matching `api_key` within
+    /// `scope`, or `None` if no static token matches. Checked before
+    /// introspection.
+    pub(super) fn match_static_token(
+        &self,
+        scope: Option<&str>,
+        api_key: &str,
+    ) -> Option<User> {
+        self.static_tokens
+            .iter()
+            .find(|t| t.matches(self.is_saas, scope, api_key))
+            .map(StaticToken::to_user)
+    }
+
+    /// Resolves the introspection endpoint for a request scope. Returns `None`
+    /// when introspection is disabled, or when nothing can serve the scope.
+    /// - `Some(org)` substitutes `<organisation>` in the per-org format (SaaS).
+    /// - `None` (global / Simple single realm): the explicit `global_endpoint`
+    ///   if set, otherwise the `discovered` endpoint from provider metadata.
+    pub(super) fn resolve_endpoint(
+        &self,
+        org_id: Option<&str>,
+        discovered: Option<String>,
+    ) -> Option<String> {
+        let introspection = self.introspection.as_ref()?;
+        match org_id {
+            Some(org_id) => introspection
+                .org_endpoint_format
+                .as_ref()
+                .map(|fmt| fmt.replace("<organisation>", org_id)),
+            None => introspection.global_endpoint.clone().or(discovered),
+        }
+    }
+
+    /// Introspects `api_key` against `endpoint`, returning the resolved
+    /// principal and the token's `exp` (seconds since the Unix epoch, if any).
+    pub(super) async fn introspect(
+        &self,
+        endpoint: &str,
+        api_key: &str,
+    ) -> Result<(User, Option<u64>), IntrospectError> {
+        let introspection = self.introspection.as_ref().ok_or_else(|| {
+            IntrospectError::Unreachable("introspection is not configured".to_string())
+        })?;
+
+        let response = HTTP_CLIENT
+            .post(endpoint)
+            .header(reqwest::header::AUTHORIZATION, &introspection.auth_header)
+            .form(&[("token", api_key)])
+            .send()
+            .await
+            .map_err(|e| IntrospectError::Unreachable(format!("request failed: {e}")))?;
+
+        if !response.status().is_success() {
+            return Err(IntrospectError::Unreachable(format!(
+                "introspection endpoint returned status {}",
+                response.status()
+            )));
+        }
+
+        let body: IntrospectionResponse = response.json().await.map_err(|e| {
+            IntrospectError::Unreachable(format!(
+                "could not parse introspection response: {e}"
+            ))
+        })?;
+
+        if !body.active {
+            return Err(IntrospectError::Inactive);
+        }
+
+        let exp = body.exp;
+        let user = body.into_user().ok_or(IntrospectError::Inactive)?;
+        Ok((user, exp))
+    }
+}
+
+/// Parses the `OIDC_API_STATIC_TOKENS` JSON array. An empty/blank value yields
+/// an empty list (mechanism off); invalid JSON is an error (fails startup).
+fn parse_static_tokens(raw: &str) -> Result<Vec<StaticToken>, String> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Ok(Vec::new());
+    }
+    serde_json::from_str::<Vec<StaticToken>>(raw).map_err(|e| {
+        format!(
+            "OIDC_API_STATIC_TOKENS must be a JSON array of \
+             {{\"token\", \"principal\"[, \"email\", \"org\"]}}: {e}"
+        )
+    })
+}
+
+/// The subset of the RFC 7662 introspection response we consume. All fields are
+/// standard; unknown fields are ignored.
+#[derive(Deserialize)]
+struct IntrospectionResponse {
+    /// The only REQUIRED field per RFC 7662 §2.2.
+    active: bool,
+    username: Option<String>,
+    sub: Option<String>,
+    email: Option<String>,
+    /// Expiry, seconds since the Unix epoch.
+    exp: Option<u64>,
+}
+
+impl IntrospectionResponse {
+    /// Maps standard introspection claims onto a Superposition [`User`].
+    /// Identity falls back across `username` -> `sub` -> `email`; returns `None`
+    /// when the active token carries no usable identity claim.
+    fn into_user(self) -> Option<User> {
+        let username = self.username.or(self.sub).or_else(|| self.email.clone())?;
+        let email = self.email.unwrap_or_else(|| username.clone());
+        Some(User::new(email, username))
+    }
+}
+
+/// Failure of an introspection call, mapped to distinct HTTP statuses so a
+/// caller can tell "your token is bad" (401) from "we couldn't check" (503).
+pub(super) enum IntrospectError {
+    /// `active:false`, or an active token with no usable identity claim.
+    Inactive,
+    /// The endpoint was unreachable, errored, or returned an unparseable body.
+    Unreachable(String),
+}
+
+impl From<IntrospectError> for actix_web::Error {
+    fn from(err: IntrospectError) -> Self {
+        match err {
+            IntrospectError::Inactive => {
+                ErrorUnauthorized("Invalid or inactive API token")
+            }
+            IntrospectError::Unreachable(detail) => {
+                log::error!("Token introspection failed: {detail}");
+                ErrorServiceUnavailable("Token introspection unavailable")
+            }
+        }
+    }
+}

--- a/crates/service_utils/src/middlewares/auth_n/oidc/api_token.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/api_token.rs
@@ -30,20 +30,11 @@ use crate::helpers::{get_from_env_or_default, get_from_env_unsafe};
 /// Reused connection-pooling client for introspection calls.
 static HTTP_CLIENT: Lazy<reqwest::Client> = Lazy::new(reqwest::Client::new);
 
-/// Upper bound on how long an introspection result is cached, regardless of the
-/// token's `exp`. Introspection exists for near-real-time revocation, so we cap
-/// caching to keep revocation lag small even for long-lived tokens.
-const MAX_INTROSPECTION_CACHE_TTL: Duration = Duration::from_secs(300);
-
-/// Cache TTL for an introspection result: the time until the token's `exp`,
-/// capped at [`MAX_INTROSPECTION_CACHE_TTL`]. Returns `None` (no or already-past
-/// `exp`) so the cache applies its own short fallback.
-pub(super) fn cache_ttl(exp: Option<u64>) -> Option<Duration> {
-    let exp = exp?;
-    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
-    let remaining = exp.checked_sub(now)?;
-    Some(Duration::from_secs(remaining).min(MAX_INTROSPECTION_CACHE_TTL))
-}
+/// Default upper bound (seconds) on how long an introspection result is cached,
+/// regardless of the token's `exp`. Introspection exists for near-real-time
+/// revocation, so we cap caching to keep revocation lag small even for
+/// long-lived tokens. Overridable via `OIDC_MAX_INTROSPECTION_CACHE_TTL_SECS`.
+const DEFAULT_MAX_INTROSPECTION_CACHE_TTL_SECS: u64 = 300;
 
 /// Length-independent* byte comparison, to avoid leaking how many leading bytes
 /// of a static token matched via response timing. (*Length is not hidden; token
@@ -119,6 +110,9 @@ struct IntrospectionSettings {
     /// Explicit single/global introspection endpoint (both modes). Optional:
     /// when absent, the endpoint discovered from provider metadata is used.
     global_endpoint: Option<String>,
+    /// Upper bound on how long an introspection result is cached, regardless of
+    /// the token's `exp`. Read from env at startup.
+    max_cache_ttl: Duration,
 }
 
 /// Static configuration for the API-token flow, loaded from env. Owns the prefix
@@ -167,6 +161,10 @@ impl ApiTokenConfig {
         };
 
         let introspection = auth_header.map(|auth_header| {
+            let max_cache_ttl = Duration::from_secs(get_from_env_or_default(
+                "OIDC_MAX_INTROSPECTION_CACHE_TTL_SECS",
+                DEFAULT_MAX_INTROSPECTION_CACHE_TTL_SECS,
+            ));
             let org_endpoint_format = is_saas
                 .then(|| {
                     get_from_env_unsafe::<String>(
@@ -181,6 +179,7 @@ impl ApiTokenConfig {
                 auth_header,
                 org_endpoint_format,
                 global_endpoint,
+                max_cache_ttl,
             }
         });
 
@@ -206,6 +205,18 @@ impl ApiTokenConfig {
     /// Whether RFC 7662 introspection is configured (vs. static-only).
     pub(super) fn introspection_enabled(&self) -> bool {
         self.introspection.is_some()
+    }
+
+    /// Cache TTL for an introspection result: the time until the token's `exp`,
+    /// capped at the configured `max_cache_ttl`. Returns `None` (no or
+    /// already-past `exp`, or introspection not configured) so the cache
+    /// applies its own short fallback.
+    pub(super) fn cache_ttl(&self, exp: Option<u64>) -> Option<Duration> {
+        let cap = self.introspection.as_ref()?.max_cache_ttl;
+        let exp = exp?;
+        let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+        let remaining = exp.checked_sub(now)?;
+        Some(Duration::from_secs(remaining).min(cap))
     }
 
     /// Startup validation for the introspection mechanism (a static-only config

--- a/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
@@ -25,8 +25,8 @@ use crate::{
         authentication::{Authenticator, BasicAuthGrant, Login},
         oidc::{
             OIDCAuthenticator,
-            api_token::{ApiTokenConfig, cache_ttl},
-            token_cache::{CachedGrant, TokenExchangeCache},
+            api_token::ApiTokenConfig,
+            token_cache::{CachedGrant, TokenCacheConfig, TokenExchangeCache},
             types::{GlobalUserClaims, GlobalUserIdToken, OrgUserClaims},
             utils::{
                 OidcProviderMetadata, build_client, discovered_introspection_endpoint,
@@ -114,7 +114,7 @@ impl SaasOIDCAuthenticator {
             path_prefix,
             issuer_endpoint_format,
             token_endpoint_format,
-            token_cache: TokenExchangeCache::new(),
+            token_cache: TokenExchangeCache::new(TokenCacheConfig::from_env()),
             api_token,
         })))
     }
@@ -454,7 +454,9 @@ impl Authenticator for SaasOIDCAuthenticator {
                 .introspect(&endpoint, &api_key)
                 .await
                 .map_err(actix_web::Error::from)?;
-            auth_n.token_cache.insert(key, user.clone(), cache_ttl(exp));
+            auth_n
+                .token_cache
+                .insert(key, user.clone(), config.cache_ttl(exp));
             Ok(user)
         })
     }

--- a/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
@@ -3,7 +3,9 @@ use std::sync::{Arc, RwLock};
 use actix_web::{
     HttpRequest, HttpResponse,
     cookie::{Cookie, time::Duration},
-    error::{ErrorBadRequest, ErrorInternalServerError, ErrorUnauthorized},
+    error::{
+        ErrorBadRequest, ErrorInternalServerError, ErrorNotImplemented, ErrorUnauthorized,
+    },
     http::header,
     web::{self, Data, Json, get, resource},
 };
@@ -12,7 +14,7 @@ use futures_util::future::LocalBoxFuture;
 use openidconnect::{
     self as oidcrs, ClientId, ClientSecret, IssuerUrl, RedirectUrl,
     ResourceOwnerPassword, ResourceOwnerUsername, Scope, TokenResponse, TokenUrl,
-    core::{CoreClient, CoreIdToken, CoreProviderMetadata},
+    core::{CoreClient, CoreIdToken},
 };
 use superposition_types::User;
 
@@ -23,10 +25,12 @@ use crate::{
         authentication::{Authenticator, BasicAuthGrant, Login},
         oidc::{
             OIDCAuthenticator,
+            api_token::{ApiTokenConfig, cache_ttl},
             token_cache::{CachedGrant, TokenExchangeCache},
             types::{GlobalUserClaims, GlobalUserIdToken, OrgUserClaims},
             utils::{
-                build_client, exchange_password_for_id_token, fetch_provider_metadata,
+                OidcProviderMetadata, build_client, discovered_introspection_endpoint,
+                exchange_password_for_id_token, fetch_provider_metadata,
                 presence_no_check, try_user_from, validate_client_credentials,
                 verify_presence,
             },
@@ -36,7 +40,7 @@ use crate::{
 
 pub struct AuthenticatorInner {
     client: RwLock<CoreClient>,
-    provider_metadata: RwLock<CoreProviderMetadata>,
+    provider_metadata: RwLock<OidcProviderMetadata>,
     issuer_url: IssuerUrl,
     client_id: ClientId,
     client_secret: ClientSecret,
@@ -46,6 +50,7 @@ pub struct AuthenticatorInner {
     issuer_endpoint_format: String,
     token_endpoint_format: String,
     token_cache: TokenExchangeCache,
+    api_token: Option<ApiTokenConfig>,
 }
 
 /// An OIDC Authenticator implementation for SaaS setups
@@ -66,6 +71,8 @@ impl SaasOIDCAuthenticator {
         path_prefix: String,
         client_id: String,
         client_secret: String,
+        introspection_auth_header: Option<String>,
+        static_tokens_raw: Option<String>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let issuer_endpoint_format =
             get_from_env_unsafe::<String>("OIDC_ORG_ISSUER_ENDPOINT_FORMAT").unwrap();
@@ -89,6 +96,13 @@ impl SaasOIDCAuthenticator {
             redirect_url.clone(),
         );
 
+        let api_token =
+            ApiTokenConfig::from_env(introspection_auth_header, static_tokens_raw, true)?;
+        if let Some(cfg) = &api_token {
+            let discovered = discovered_introspection_endpoint(&provider_metadata);
+            cfg.ensure_serviceable(discovered.as_deref())?;
+        }
+
         Ok(Self(Arc::new(AuthenticatorInner {
             client: RwLock::new(client),
             provider_metadata: RwLock::new(provider_metadata),
@@ -101,6 +115,7 @@ impl SaasOIDCAuthenticator {
             issuer_endpoint_format,
             token_endpoint_format,
             token_cache: TokenExchangeCache::new(),
+            api_token,
         })))
     }
 
@@ -153,7 +168,7 @@ impl SaasOIDCAuthenticator {
     ) -> Result<CoreClient, String> {
         let Login::Org(org_id) = login_type else {
             return Err(
-                "client_credentials requires an organisation-scoped request".to_string(),
+                "client_credentials requires an organisation-scoped request".to_string()
             );
         };
         let issuer_url = self
@@ -172,7 +187,12 @@ impl SaasOIDCAuthenticator {
             .clone()
             .set_issuer(issuer_url)
             .set_token_endpoint(Some(token_url));
-        Ok(build_client(provider, client_id, client_secret, redirect_url))
+        Ok(build_client(
+            provider,
+            client_id,
+            client_secret,
+            redirect_url,
+        ))
     }
 
     fn get_issuer_url(
@@ -372,6 +392,73 @@ impl Authenticator for SaasOIDCAuthenticator {
         }
     }
 
+    fn api_token_prefix(&self) -> Option<String> {
+        self.api_token.as_ref().map(|c| c.prefix.clone())
+    }
+
+    fn authenticate_with_api_token(
+        &self,
+        login_type: &Login,
+        api_key: &str,
+    ) -> LocalBoxFuture<'static, Result<User, HttpResponse>> {
+        if matches!(login_type, Login::None) {
+            return Box::pin(async { Ok(User::default()) });
+        }
+
+        let scope = match login_type {
+            Login::Org(org_id) => Some(org_id.clone()),
+            _ => None,
+        };
+        let auth_n = self.clone();
+        let api_key = api_key.to_string();
+        let key =
+            TokenExchangeCache::key(scope.clone(), CachedGrant::ApiToken, "", &api_key);
+        Box::pin(async move {
+            let Some(config) = auth_n.api_token.as_ref() else {
+                return Err(ErrorNotImplemented(
+                    "API token authentication is not configured",
+                )
+                .into());
+            };
+
+            if let Some(user) = config.match_static_token(scope.as_deref(), &api_key) {
+                return Ok(user);
+            }
+
+            if !config.introspection_enabled() {
+                return Err(ErrorUnauthorized("Invalid or inactive API token").into());
+            }
+
+            if let Some(user) = auth_n.token_cache.get(&key) {
+                return Ok(user);
+            }
+
+            // For a global request, fall back to the introspection endpoint
+            // advertised in the (cached) provider metadata.
+            let discovered = discovered_introspection_endpoint(
+                &auth_n
+                    .provider_metadata
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner()),
+            );
+            let Some(endpoint) = config.resolve_endpoint(scope.as_deref(), discovered)
+            else {
+                return Err(ErrorBadRequest(
+                    "API token authentication is not available for global requests \
+                     in this configuration",
+                )
+                .into());
+            };
+
+            let (user, exp) = config
+                .introspect(&endpoint, &api_key)
+                .await
+                .map_err(actix_web::Error::from)?;
+            auth_n.token_cache.insert(key, user.clone(), cache_ttl(exp));
+            Ok(user)
+        })
+    }
+
     fn authenticate_with_basic_auth(
         &self,
         login_type: &Login,
@@ -426,8 +513,8 @@ impl Authenticator for SaasOIDCAuthenticator {
                                 actix_web::Error::from(e)
                             })?;
 
-                    let user = auth_n
-                        .authenticate_with_bearer_token(&login_type, &id_token)?;
+                    let user =
+                        auth_n.authenticate_with_bearer_token(&login_type, &id_token)?;
                     auth_n.token_cache.insert(key, user.clone(), expires_in);
                     Ok(user)
                 })

--- a/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use actix_web::{
     HttpRequest, HttpResponse,
@@ -27,18 +27,22 @@ use crate::{
                 GlobalUserClaims, GlobalUserTokenResponse, OrgUserClaims,
                 OrgUserTokenResponse,
             },
-            utils::{presence_no_check, try_user_from, verify_presence},
+            utils::{
+                build_client, fetch_provider_metadata, presence_no_check, try_user_from,
+                verify_presence,
+            },
         },
     },
 };
 
-#[derive(Clone)]
 pub struct AuthenticatorInner {
-    client: CoreClient,
-    provider_metadata: CoreProviderMetadata,
-    client_id: String,
-    client_secret: String,
+    client: RwLock<CoreClient>,
+    provider_metadata: RwLock<CoreProviderMetadata>,
+    issuer_url: IssuerUrl,
+    client_id: ClientId,
+    client_secret: ClientSecret,
     base_url: String,
+    redirect_url: RedirectUrl,
     path_prefix: String,
     issuer_endpoint_format: String,
     token_endpoint_format: String,
@@ -71,30 +75,28 @@ impl SaasOIDCAuthenticator {
         let issuer_url = IssuerUrl::new(idp_url)
             .map_err(|e| format!("Unable to create issuer url: {}", e))
             .unwrap();
+        let redirect_url =
+            RedirectUrl::new(format!("{base_url}{path_prefix}/oidc/login"))?;
+        let client_id = ClientId::new(client_id);
+        let client_secret = ClientSecret::new(client_secret);
 
-        // Discover OpenID Provider metadata
-        let provider_metadata = CoreProviderMetadata::discover_async(
-            issuer_url,
-            oidcrs::reqwest::async_http_client,
-        )
-        .await?;
+        let provider_metadata = fetch_provider_metadata(issuer_url.clone()).await?;
 
-        // Create client
-        let client = CoreClient::from_provider_metadata(
+        let client = build_client(
             provider_metadata.clone(),
-            ClientId::new(client_id.clone()),
-            Some(ClientSecret::new(client_secret.clone())),
-        )
-        .set_redirect_uri(RedirectUrl::new(format!(
-            "{base_url}{path_prefix}/oidc/login"
-        ))?);
+            client_id.clone(),
+            client_secret.clone(),
+            redirect_url.clone(),
+        );
 
         Ok(Self(Arc::new(AuthenticatorInner {
-            client,
-            provider_metadata,
+            client: RwLock::new(client),
+            provider_metadata: RwLock::new(provider_metadata),
+            issuer_url,
             client_id,
             client_secret,
             base_url,
+            redirect_url,
             path_prefix,
             issuer_endpoint_format,
             token_endpoint_format,
@@ -123,16 +125,18 @@ impl SaasOIDCAuthenticator {
 
         let provider = self
             .provider_metadata
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
             .clone()
             .set_issuer(issuer_url)
             .set_token_endpoint(Some(token_url));
 
-        Ok(CoreClient::from_provider_metadata(
+        Ok(build_client(
             provider,
-            ClientId::new(self.client_id.clone()),
-            Some(ClientSecret::new(self.client_secret.clone())),
-        )
-        .set_redirect_uri(redirect_url))
+            self.client_id.clone(),
+            self.client_secret.clone(),
+            redirect_url,
+        ))
     }
 
     fn get_issuer_url(
@@ -153,11 +157,12 @@ impl SaasOIDCAuthenticator {
     }
 
     fn decode_global_token(&self, cookie: &str) -> Result<GlobalUserClaims, String> {
+        let client = self.get_client();
         let ctr = serde_json::from_str::<GlobalUserTokenResponse>(cookie)
             .map_err(|e| format!("Error while decoding token: {e}"))?;
         ctr.id_token()
             .ok_or(String::from("Id Token not found"))?
-            .claims(&self.client.id_token_verifier(), verify_presence)
+            .claims(&client.id_token_verifier(), verify_presence)
             .map_err(|e| format!("Error in claims verification: {e}"))
             .cloned()
     }
@@ -217,8 +222,34 @@ impl SaasOIDCAuthenticator {
 }
 
 impl OIDCAuthenticator for SaasOIDCAuthenticator {
-    fn get_client(&self) -> &CoreClient {
-        &self.client
+    fn get_client(&self) -> CoreClient {
+        self.client
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    async fn refresh_client(&self) -> Result<(), String> {
+        let provider_metadata = fetch_provider_metadata(self.issuer_url.clone())
+            .await
+            .map_err(|e| format!("Failed to refresh provider metadata: {e:?}"))?;
+
+        let client = build_client(
+            provider_metadata.clone(),
+            self.client_id.clone(),
+            self.client_secret.clone(),
+            self.redirect_url.clone(),
+        );
+
+        // Update the metadata first so org-specific clients derived from it also
+        // pick up the fresh keys, then swap in the rebuilt global client.
+        // Recover through poisoning: these locks only guard whole-value swaps.
+        *self
+            .provider_metadata
+            .write()
+            .unwrap_or_else(|e| e.into_inner()) = provider_metadata;
+        *self.client.write().unwrap_or_else(|e| e.into_inner()) = client;
+        Ok(())
     }
 
     fn get_global_user(

--- a/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
@@ -29,10 +29,10 @@ use crate::{
             token_cache::{CachedGrant, TokenCacheConfig, TokenExchangeCache},
             types::{GlobalUserClaims, GlobalUserIdToken, OrgUserClaims},
             utils::{
-                OidcProviderMetadata, build_client, discovered_introspection_endpoint,
-                exchange_password_for_id_token, fetch_provider_metadata,
-                presence_no_check, try_user_from, validate_client_credentials,
-                verify_presence,
+                BasicAuthError, OidcProviderMetadata, build_client,
+                discovered_introspection_endpoint, exchange_password_for_id_token,
+                fetch_provider_metadata, presence_no_check, try_user_from,
+                validate_client_credentials, verify_presence,
             },
         },
     },
@@ -273,6 +273,18 @@ impl SaasOIDCAuthenticator {
                 })
         }
     }
+
+    fn get_specific_client(&self, login_type: &Login) -> actix_web::Result<CoreClient> {
+        match login_type {
+            Login::Org(org_id) => self.get_org_client(org_id).map_err(|e| {
+                log::error!("Error in getting Org specific client: {e}");
+                ErrorInternalServerError(String::from(
+                    "Error in getting Org specific client",
+                ))
+            }),
+            _ => Ok(self.get_client()),
+        }
+    }
 }
 
 impl OIDCAuthenticator for SaasOIDCAuthenticator {
@@ -479,20 +491,9 @@ impl Authenticator for SaasOIDCAuthenticator {
 
         match grant {
             BasicAuthGrant::Password { username, password } => {
-                let client = match login_type {
-                    Login::Org(org_id) => match self.get_org_client(org_id) {
-                        Ok(client) => client,
-                        Err(e) => {
-                            log::error!("Error in getting Org specific client: {e}");
-                            return Box::pin(async {
-                                Err(ErrorInternalServerError(String::from(
-                                    "Error in getting Org specific client",
-                                ))
-                                .into())
-                            });
-                        }
-                    },
-                    _ => self.get_client(),
+                let client = match self.get_specific_client(login_type) {
+                    Ok(client) => client,
+                    Err(e) => return Box::pin(async { Err(e.into()) }),
                 };
                 let auth_n = self.clone();
                 let login_type = login_type.clone();
@@ -507,13 +508,37 @@ impl Authenticator for SaasOIDCAuthenticator {
                         return Ok(user);
                     }
 
-                    let (id_token, expires_in) =
-                        exchange_password_for_id_token(&client, &username, &password)
-                            .await
-                            .map_err(|e| {
-                                log::error!("Basic auth (password) failed: {e}");
-                                actix_web::Error::from(e)
+                    let (id_token, expires_in) = match exchange_password_for_id_token(
+                        &client, &username, &password,
+                    )
+                    .await
+                    {
+                        Err(BasicAuthError::TokenVerification(detail)) => {
+                            log::error!(
+                                "Basic auth (password): ID token verification failed; \
+                                 refreshing provider keys and retrying: {detail}"
+                            );
+                            auth_n.refresh_client().await.map_err(|e| {
+                                log::error!("Failed to refresh provider metadata: {e}");
+                                ErrorInternalServerError(String::from(
+                                    "Unable to authenticate user",
+                                ))
                             })?;
+                            let client = auth_n.get_specific_client(&login_type)?;
+                            exchange_password_for_id_token(&client, &username, &password)
+                                .await
+                                .map_err(|e| {
+                                    log::error!(
+                                        "Basic auth (password) failed after key refresh: {e}"
+                                    );
+                                    actix_web::Error::from(e)
+                                })?
+                        }
+                        result => result.map_err(|e| {
+                            log::error!("Basic auth (password) failed: {e}");
+                            actix_web::Error::from(e)
+                        })?,
+                    };
 
                     let user =
                         auth_n.authenticate_with_bearer_token(&login_type, &id_token)?;

--- a/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, RwLock};
 use actix_web::{
     HttpRequest, HttpResponse,
     cookie::{Cookie, time::Duration},
-    error::{ErrorBadRequest, ErrorInternalServerError},
+    error::{ErrorBadRequest, ErrorInternalServerError, ErrorUnauthorized},
     http::header,
     web::{self, Data, Json, get, resource},
 };
@@ -12,7 +12,7 @@ use futures_util::future::LocalBoxFuture;
 use openidconnect::{
     self as oidcrs, ClientId, ClientSecret, IssuerUrl, RedirectUrl,
     ResourceOwnerPassword, ResourceOwnerUsername, Scope, TokenResponse, TokenUrl,
-    core::{CoreClient, CoreProviderMetadata},
+    core::{CoreClient, CoreIdToken, CoreProviderMetadata},
 };
 use superposition_types::User;
 
@@ -23,10 +23,7 @@ use crate::{
         authentication::{Authenticator, Login},
         oidc::{
             OIDCAuthenticator,
-            types::{
-                GlobalUserClaims, GlobalUserTokenResponse, OrgUserClaims,
-                OrgUserTokenResponse,
-            },
+            types::{GlobalUserClaims, GlobalUserIdToken, OrgUserClaims},
             utils::{
                 build_client, fetch_provider_metadata, presence_no_check, try_user_from,
                 verify_presence,
@@ -158,11 +155,10 @@ impl SaasOIDCAuthenticator {
 
     fn decode_global_token(&self, cookie: &str) -> Result<GlobalUserClaims, String> {
         let client = self.get_client();
-        let ctr = serde_json::from_str::<GlobalUserTokenResponse>(cookie)
+        let ctr = cookie
+            .parse::<GlobalUserIdToken>()
             .map_err(|e| format!("Error while decoding token: {e}"))?;
-        ctr.id_token()
-            .ok_or(String::from("Id Token not found"))?
-            .claims(&client.id_token_verifier(), verify_presence)
+        ctr.claims(&client.id_token_verifier(), verify_presence)
             .map_err(|e| format!("Error in claims verification: {e}"))
             .cloned()
     }
@@ -177,11 +173,10 @@ impl SaasOIDCAuthenticator {
             .map_err(|e| format!("Error in getting Org specific client: {e}"))?;
         let id_token_verifier = client.id_token_verifier();
 
-        let ctr = serde_json::from_str::<OrgUserTokenResponse>(cookie)
+        let ctr = cookie
+            .parse::<CoreIdToken>()
             .map_err(|e| format!("Error while decoding token: {e}"))?;
-        ctr.id_token()
-            .ok_or(String::from("Id Token not found"))?
-            .claims(&id_token_verifier, presence_no_check)
+        ctr.claims(&id_token_verifier, presence_no_check)
             .map_err(|e| format!("Error in claims verification: {e}"))
             .cloned()
     }
@@ -307,6 +302,42 @@ impl Authenticator for SaasOIDCAuthenticator {
         }
     }
 
+    fn authenticate_with_token(
+        &self,
+        login_type: &Login,
+        token: &str,
+    ) -> Result<User, HttpResponse> {
+        match login_type {
+            Login::None => Ok(User::default()),
+            Login::Global => self
+                .decode_global_token(token)
+                .map_err(|e| {
+                    log::error!("Error in decoding user : {e}");
+                    ErrorUnauthorized(String::from("Unable to get user"))
+                })
+                .and_then(|claims| {
+                    try_user_from(&claims).map_err(|e| {
+                        log::error!("Unable to get user: {e}");
+                        ErrorUnauthorized(String::from("Unable to get user"))
+                    })
+                })
+                .map_err(Into::into),
+            Login::Org(org_id) => self
+                .decode_org_token(org_id, token)
+                .map_err(|e| {
+                    log::error!("Error in decoding org_user : {e}");
+                    ErrorUnauthorized(String::from("Unable to get org_user"))
+                })
+                .and_then(|claims| {
+                    try_user_from(&claims).map_err(|e| {
+                        log::error!("Unable to get org_user: {e}");
+                        ErrorUnauthorized(String::from("Unable to get org_user"))
+                    })
+                })
+                .map_err(Into::into),
+        }
+    }
+
     fn routes(&self) -> actix_web::Scope {
         web::scope("oidc")
             .app_data(Data::new(self.to_owned()))
@@ -396,23 +427,18 @@ impl Authenticator for SaasOIDCAuthenticator {
                     ))
                 })
                 .and_then(|tr| {
-                    tr.id_token()
-                        .ok_or_else(|| {
-                            log::error!("No identity-token!");
-                            None
-                        })?
+                    let id_token = tr.id_token().ok_or_else(|| {
+                        log::error!("No identity-token!");
+                        None
+                    })?;
+                    id_token
                         .claims(&client.id_token_verifier(), presence_no_check)
                         .map_err(|e| {
                             log::error!("Couldn't verify claims: {e:?}");
                             None
                         })?;
 
-                    serde_json::to_string(&tr).map_err(|e| {
-                        log::error!("Unable to stringify data: {e:?}");
-                        Some(ErrorInternalServerError(
-                            "Unable to stringify data".to_string(),
-                        ))
-                    })
+                    Ok(id_token.to_string())
                 })
                 .map_err(|e| e.map(Into::into).unwrap_or(redirect))
         })

--- a/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/saas_authenticator.rs
@@ -20,12 +20,14 @@ use crate::{
     extensions::HttpRequestExt,
     helpers::get_from_env_unsafe,
     middlewares::auth_n::{
-        authentication::{Authenticator, Login},
+        authentication::{Authenticator, BasicAuthGrant, Login},
         oidc::{
             OIDCAuthenticator,
+            token_cache::{CachedGrant, TokenExchangeCache},
             types::{GlobalUserClaims, GlobalUserIdToken, OrgUserClaims},
             utils::{
-                build_client, fetch_provider_metadata, presence_no_check, try_user_from,
+                build_client, exchange_password_for_id_token, fetch_provider_metadata,
+                presence_no_check, try_user_from, validate_client_credentials,
                 verify_presence,
             },
         },
@@ -43,6 +45,7 @@ pub struct AuthenticatorInner {
     path_prefix: String,
     issuer_endpoint_format: String,
     token_endpoint_format: String,
+    token_cache: TokenExchangeCache,
 }
 
 /// An OIDC Authenticator implementation for SaaS setups
@@ -97,6 +100,7 @@ impl SaasOIDCAuthenticator {
             path_prefix,
             issuer_endpoint_format,
             token_endpoint_format,
+            token_cache: TokenExchangeCache::new(),
         })))
     }
 
@@ -134,6 +138,41 @@ impl SaasOIDCAuthenticator {
             self.client_secret.clone(),
             redirect_url,
         ))
+    }
+
+    /// Builds an OIDC client configured with the *machine's* credentials (from
+    /// a `Basic` header) against the **org-specific** endpoints, so a
+    /// `client_credentials` exchange authenticates the machine. In a SaaS setup
+    /// service accounts are provisioned per organisation, so a
+    /// client_credentials request that isn't org-scoped is rejected.
+    fn machine_client(
+        &self,
+        login_type: &Login,
+        client_id: ClientId,
+        client_secret: ClientSecret,
+    ) -> Result<CoreClient, String> {
+        let Login::Org(org_id) = login_type else {
+            return Err(
+                "client_credentials requires an organisation-scoped request".to_string(),
+            );
+        };
+        let issuer_url = self
+            .get_issuer_url(org_id)
+            .map_err(|e| format!("Unable to create issuer url: {e}"))?;
+        let token_url = self
+            .get_token_url(org_id)
+            .map_err(|e| format!("Unable to create token url: {e}"))?;
+        let redirect_url =
+            RedirectUrl::new(format!("{}{}/", self.base_url, self.path_prefix))
+                .map_err(|e| format!("Unable to create redirect url: {e}"))?;
+        let provider = self
+            .provider_metadata
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+            .set_issuer(issuer_url)
+            .set_token_endpoint(Some(token_url));
+        Ok(build_client(provider, client_id, client_secret, redirect_url))
     }
 
     fn get_issuer_url(
@@ -302,7 +341,7 @@ impl Authenticator for SaasOIDCAuthenticator {
         }
     }
 
-    fn authenticate_with_token(
+    fn authenticate_with_bearer_token(
         &self,
         login_type: &Login,
         token: &str,
@@ -311,30 +350,134 @@ impl Authenticator for SaasOIDCAuthenticator {
             Login::None => Ok(User::default()),
             Login::Global => self
                 .decode_global_token(token)
-                .map_err(|e| {
-                    log::error!("Error in decoding user : {e}");
-                    ErrorUnauthorized(String::from("Unable to get user"))
-                })
+                .map_err(|e| format!("Error in decoding user : {e}"))
                 .and_then(|claims| {
-                    try_user_from(&claims).map_err(|e| {
-                        log::error!("Unable to get user: {e}");
-                        ErrorUnauthorized(String::from("Unable to get user"))
-                    })
+                    try_user_from(&claims).map_err(|e| format!("Unable to get user: {e}"))
                 })
-                .map_err(Into::into),
+                .map_err(|e| {
+                    log::error!("{e}");
+                    ErrorUnauthorized(String::from("Unable to get org_user")).into()
+                }),
             Login::Org(org_id) => self
                 .decode_org_token(org_id, token)
-                .map_err(|e| {
-                    log::error!("Error in decoding org_user : {e}");
-                    ErrorUnauthorized(String::from("Unable to get org_user"))
-                })
+                .map_err(|e| format!("Error in decoding org_user : {e}"))
                 .and_then(|claims| {
-                    try_user_from(&claims).map_err(|e| {
-                        log::error!("Unable to get org_user: {e}");
-                        ErrorUnauthorized(String::from("Unable to get org_user"))
-                    })
+                    try_user_from(&claims)
+                        .map_err(|e| format!("Unable to get org_user: {e}"))
                 })
-                .map_err(Into::into),
+                .map_err(|e| {
+                    log::error!("{e}");
+                    ErrorUnauthorized(String::from("Unable to get org_user")).into()
+                }),
+        }
+    }
+
+    fn authenticate_with_basic_auth(
+        &self,
+        login_type: &Login,
+        grant: BasicAuthGrant,
+    ) -> LocalBoxFuture<'static, Result<User, HttpResponse>> {
+        if matches!(login_type, Login::None) {
+            return Box::pin(async { Ok(User::default()) });
+        }
+
+        // Per-org realms in SaaS: scope the cache key by org so the same
+        // credentials can't be reused across org realms.
+        let scope = match login_type {
+            Login::Org(org_id) => Some(org_id.clone()),
+            _ => None,
+        };
+
+        match grant {
+            BasicAuthGrant::Password { username, password } => {
+                let client = match login_type {
+                    Login::Org(org_id) => match self.get_org_client(org_id) {
+                        Ok(client) => client,
+                        Err(e) => {
+                            log::error!("Error in getting Org specific client: {e}");
+                            return Box::pin(async {
+                                Err(ErrorInternalServerError(String::from(
+                                    "Error in getting Org specific client",
+                                ))
+                                .into())
+                            });
+                        }
+                    },
+                    _ => self.get_client(),
+                };
+                let auth_n = self.clone();
+                let login_type = login_type.clone();
+                let key = TokenExchangeCache::key(
+                    scope,
+                    CachedGrant::Password,
+                    username.as_str(),
+                    password.secret(),
+                );
+                Box::pin(async move {
+                    if let Some(user) = auth_n.token_cache.get(&key) {
+                        return Ok(user);
+                    }
+
+                    let (id_token, expires_in) =
+                        exchange_password_for_id_token(&client, &username, &password)
+                            .await
+                            .map_err(|e| {
+                                log::error!("Basic auth (password) failed: {e}");
+                                actix_web::Error::from(e)
+                            })?;
+
+                    let user = auth_n
+                        .authenticate_with_bearer_token(&login_type, &id_token)?;
+                    auth_n.token_cache.insert(key, user.clone(), expires_in);
+                    Ok(user)
+                })
+            }
+            BasicAuthGrant::ClientCredentials {
+                client_id,
+                client_secret,
+            } => {
+                let auth_n = self.clone();
+                let key = TokenExchangeCache::key(
+                    scope,
+                    CachedGrant::ClientCredentials,
+                    client_id.as_str(),
+                    client_secret.secret(),
+                );
+                let client = match self.machine_client(
+                    login_type,
+                    client_id.clone(),
+                    client_secret,
+                ) {
+                    Ok(client) => client,
+                    Err(e) => {
+                        log::error!("Error building machine client: {e}");
+                        return Box::pin(async {
+                            Err(ErrorInternalServerError(String::from(
+                                "Error building machine client",
+                            ))
+                            .into())
+                        });
+                    }
+                };
+                Box::pin(async move {
+                    if let Some(user) = auth_n.token_cache.get(&key) {
+                        return Ok(user);
+                    }
+
+                    let expires_in =
+                        validate_client_credentials(&client).await.map_err(|e| {
+                            log::error!("Basic auth (client_credentials) failed: {e}");
+                            actix_web::Error::from(e)
+                        })?;
+
+                    // No user identity in a client_credentials grant; derive a
+                    // stable, namespaced service principal from the client_id.
+                    let principal = format!("service-account-{}", client_id.as_str());
+                    let user = User::new(principal.clone(), principal);
+                    auth_n.token_cache.insert(key, user.clone(), expires_in);
+                    Ok(user)
+                })
+            }
         }
     }
 
@@ -417,7 +560,7 @@ impl Authenticator for SaasOIDCAuthenticator {
         Box::pin(async move {
             client
                 .exchange_password(&user, &pass)
-                .add_scope(Scope::new(String::from("openid")))
+                .add_scope(Scope::new("openid".to_string()))
                 .request_async(oidcrs::reqwest::async_http_client)
                 .await
                 .map_err(|e| {

--- a/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
@@ -23,9 +23,10 @@ use crate::middlewares::auth_n::{
         api_token::ApiTokenConfig,
         token_cache::{CachedGrant, TokenCacheConfig, TokenExchangeCache},
         utils::{
-            OidcProviderMetadata, build_client, discovered_introspection_endpoint,
-            exchange_password_for_id_token, fetch_provider_metadata, try_user_from,
-            validate_client_credentials, verify_presence,
+            BasicAuthError, OidcProviderMetadata, build_client,
+            discovered_introspection_endpoint, exchange_password_for_id_token,
+            fetch_provider_metadata, try_user_from, validate_client_credentials,
+            verify_presence,
         },
     },
 };
@@ -319,13 +320,40 @@ impl Authenticator for SimpleOIDCAuthenticator {
                         return Ok(user);
                     }
 
-                    let (id_token, expires_in) =
-                        exchange_password_for_id_token(&client, &username, &password)
+                    let (id_token, expires_in) = match exchange_password_for_id_token(
+                        &client, &username, &password,
+                    )
+                    .await
+                    {
+                        Err(BasicAuthError::TokenVerification(detail)) => {
+                            log::error!(
+                                "Basic auth (password): ID token verification failed; \
+                                 refreshing provider keys and retrying: {detail}"
+                            );
+                            auth_n.refresh_client().await.map_err(|e| {
+                                log::error!("Failed to refresh provider metadata: {e}");
+                                ErrorInternalServerError(String::from(
+                                    "Unable to authenticate user",
+                                ))
+                            })?;
+                            exchange_password_for_id_token(
+                                &auth_n.get_client(),
+                                &username,
+                                &password,
+                            )
                             .await
                             .map_err(|e| {
-                                log::error!("Basic auth (password) failed: {e}");
+                                log::error!(
+                                    "Basic auth (password) failed after key refresh: {e}"
+                                );
                                 actix_web::Error::from(e)
-                            })?;
+                            })?
+                        }
+                        result => result.map_err(|e| {
+                            log::error!("Basic auth (password) failed: {e}");
+                            actix_web::Error::from(e)
+                        })?,
+                    };
 
                     let user = auth_n.get_user_from_id_token(&id_token).map_err(|e| {
                         log::error!("Error in decoding user : {e}");

--- a/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
@@ -20,8 +20,8 @@ use crate::middlewares::auth_n::{
     helpers::fetch_org_ids_from_db,
     oidc::{
         OIDCAuthenticator,
-        api_token::{ApiTokenConfig, cache_ttl},
-        token_cache::{CachedGrant, TokenExchangeCache},
+        api_token::ApiTokenConfig,
+        token_cache::{CachedGrant, TokenCacheConfig, TokenExchangeCache},
         utils::{
             OidcProviderMetadata, build_client, discovered_introspection_endpoint,
             exchange_password_for_id_token, fetch_provider_metadata, try_user_from,
@@ -95,7 +95,7 @@ impl SimpleOIDCAuthenticator {
             client_secret,
             redirect_url,
             path_prefix,
-            token_cache: TokenExchangeCache::new(),
+            token_cache: TokenExchangeCache::new(TokenCacheConfig::from_env()),
             api_token,
         })))
     }
@@ -287,7 +287,9 @@ impl Authenticator for SimpleOIDCAuthenticator {
                 .introspect(&endpoint, &api_key)
                 .await
                 .map_err(actix_web::Error::from)?;
-            auth_n.token_cache.insert(key, user.clone(), cache_ttl(exp));
+            auth_n
+                .token_cache
+                .insert(key, user.clone(), config.cache_ttl(exp));
             Ok(user)
         })
     }

--- a/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
@@ -9,26 +9,32 @@ use derive_more::{Deref, DerefMut};
 use futures_util::future::LocalBoxFuture;
 use openidconnect::{
     ClientId, ClientSecret, IssuerUrl, RedirectUrl,
-    core::{CoreClient, CoreIdToken, CoreIdTokenClaims},
+    core::{CoreClient, CoreIdToken, CoreIdTokenClaims, CoreProviderMetadata},
 };
 use superposition_types::User;
 
 use crate::middlewares::auth_n::{
-    authentication::{Authenticator, Login},
+    authentication::{Authenticator, BasicAuthGrant, Login},
     helpers::fetch_org_ids_from_db,
     oidc::{
         OIDCAuthenticator,
-        utils::{build_client, fetch_provider_metadata, try_user_from, verify_presence},
+        token_cache::{CachedGrant, TokenExchangeCache},
+        utils::{
+            build_client, exchange_password_for_id_token, fetch_provider_metadata,
+            try_user_from, validate_client_credentials, verify_presence,
+        },
     },
 };
 
 pub struct AuthenticatorInner {
     client: RwLock<CoreClient>,
+    provider_metadata: RwLock<CoreProviderMetadata>,
     issuer_url: IssuerUrl,
     client_id: ClientId,
     client_secret: ClientSecret,
     redirect_url: RedirectUrl,
     path_prefix: String,
+    token_cache: TokenExchangeCache,
 }
 
 /// A simple OIDC Authenticator implementation that uses a single
@@ -58,7 +64,7 @@ impl SimpleOIDCAuthenticator {
         let provider_metadata = fetch_provider_metadata(issuer_url.clone()).await?;
 
         let client = build_client(
-            provider_metadata,
+            provider_metadata.clone(),
             client_id.clone(),
             client_secret.clone(),
             redirect_url.clone(),
@@ -66,11 +72,13 @@ impl SimpleOIDCAuthenticator {
 
         Ok(Self(Arc::new(AuthenticatorInner {
             client: RwLock::new(client),
+            provider_metadata: RwLock::new(provider_metadata),
             issuer_url,
             client_id,
             client_secret,
             redirect_url,
             path_prefix,
+            token_cache: TokenExchangeCache::new(),
         })))
     }
 
@@ -82,6 +90,35 @@ impl SimpleOIDCAuthenticator {
         ctr.claims(&client.id_token_verifier(), verify_presence)
             .map_err(|e| format!("Error in claims verification: {e}"))
             .cloned()
+    }
+
+    fn get_user_from_id_token(&self, token: &str) -> Result<User, String> {
+        self.decode_global_token(token)
+            .map_err(|e| format!("Error in decoding user: {e}"))
+            .and_then(|claims| {
+                try_user_from(&claims).map_err(|e| format!("Unable to get user: {e}"))
+            })
+    }
+
+    /// Builds an OIDC client configured with the *machine's* credentials (from
+    /// a `Basic` header) so a `client_credentials` exchange authenticates the
+    /// machine rather than this service's own OIDC client.
+    fn machine_client(
+        &self,
+        client_id: ClientId,
+        client_secret: ClientSecret,
+    ) -> CoreClient {
+        let provider_metadata = self
+            .provider_metadata
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        build_client(
+            provider_metadata,
+            client_id,
+            client_secret,
+            self.redirect_url.clone(),
+        )
     }
 }
 
@@ -98,12 +135,16 @@ impl OIDCAuthenticator for SimpleOIDCAuthenticator {
             .await
             .map_err(|e| format!("Failed to refresh provider metadata: {e:?}"))?;
         let client = build_client(
-            provider_metadata,
+            provider_metadata.clone(),
             self.client_id.clone(),
             self.client_secret.clone(),
             self.redirect_url.clone(),
         );
 
+        *self
+            .provider_metadata
+            .write()
+            .unwrap_or_else(|e| e.into_inner()) = provider_metadata;
         *self.client.write().unwrap_or_else(|e| e.into_inner()) = client;
         Ok(())
     }
@@ -157,26 +198,94 @@ impl Authenticator for SimpleOIDCAuthenticator {
         }
     }
 
-    fn authenticate_with_token(
+    fn authenticate_with_bearer_token(
         &self,
         login_type: &Login,
         token: &str,
     ) -> Result<User, HttpResponse> {
         match login_type {
             Login::None => Ok(User::default()),
-            _ => self
-                .decode_global_token(token)
-                .map_err(|e| {
-                    log::error!("Error in decoding user : {e}");
-                    ErrorUnauthorized(String::from("Unable to get user"))
+            _ => self.get_user_from_id_token(token).map_err(|e| {
+                log::error!("Error in decoding user : {e}");
+                ErrorUnauthorized(String::from("Unable to get user")).into()
+            }),
+        }
+    }
+
+    fn authenticate_with_basic_auth(
+        &self,
+        login_type: &Login,
+        grant: BasicAuthGrant,
+    ) -> LocalBoxFuture<'static, Result<User, HttpResponse>> {
+        if matches!(login_type, Login::None) {
+            return Box::pin(async { Ok(User::default()) });
+        }
+
+        let auth_n = self.clone();
+        match grant {
+            BasicAuthGrant::Password { username, password } => {
+                let key = TokenExchangeCache::key(
+                    None,
+                    CachedGrant::Password,
+                    username.as_str(),
+                    password.secret(),
+                );
+                let client = self.get_client();
+
+                Box::pin(async move {
+                    if let Some(user) = auth_n.token_cache.get(&key) {
+                        return Ok(user);
+                    }
+
+                    let (id_token, expires_in) =
+                        exchange_password_for_id_token(&client, &username, &password)
+                            .await
+                            .map_err(|e| {
+                                log::error!("Basic auth (password) failed: {e}");
+                                actix_web::Error::from(e)
+                            })?;
+
+                    let user = auth_n.get_user_from_id_token(&id_token).map_err(|e| {
+                        log::error!("Error in decoding user : {e}");
+                        actix_web::Error::from(ErrorInternalServerError(String::from(
+                            "Unable to get user",
+                        )))
+                    })?;
+                    auth_n.token_cache.insert(key, user.clone(), expires_in);
+                    Ok(user)
                 })
-                .and_then(|claims| {
-                    try_user_from(&claims).map_err(|e| {
-                        log::error!("Unable to get user: {e}");
-                        ErrorUnauthorized(String::from("Unable to get user"))
-                    })
+            }
+            BasicAuthGrant::ClientCredentials {
+                client_id,
+                client_secret,
+            } => {
+                let key = TokenExchangeCache::key(
+                    None,
+                    CachedGrant::ClientCredentials,
+                    client_id.as_str(),
+                    client_secret.secret(),
+                );
+                let client = self.machine_client(client_id.clone(), client_secret);
+
+                Box::pin(async move {
+                    if let Some(user) = auth_n.token_cache.get(&key) {
+                        return Ok(user);
+                    }
+
+                    let expires_in =
+                        validate_client_credentials(&client).await.map_err(|e| {
+                            log::error!("Basic auth (client_credentials) failed: {e}");
+                            actix_web::Error::from(e)
+                        })?;
+
+                    // No user identity in a client_credentials grant; derive a
+                    // stable, namespaced service principal from the client_id.
+                    let principal = format!("service-account-{}", client_id.as_str());
+                    let user = User::new(principal.clone(), principal);
+                    auth_n.token_cache.insert(key, user.clone(), expires_in);
+                    Ok(user)
                 })
-                .map_err(Into::into),
+            }
         }
     }
 

--- a/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
@@ -2,14 +2,16 @@ use std::sync::{Arc, RwLock};
 
 use actix_web::{
     HttpRequest, HttpResponse,
-    error::{ErrorBadRequest, ErrorInternalServerError, ErrorUnauthorized},
+    error::{
+        ErrorBadRequest, ErrorInternalServerError, ErrorNotImplemented, ErrorUnauthorized,
+    },
     web::{self, Data, get, resource},
 };
 use derive_more::{Deref, DerefMut};
 use futures_util::future::LocalBoxFuture;
 use openidconnect::{
     ClientId, ClientSecret, IssuerUrl, RedirectUrl,
-    core::{CoreClient, CoreIdToken, CoreIdTokenClaims, CoreProviderMetadata},
+    core::{CoreClient, CoreIdToken, CoreIdTokenClaims},
 };
 use superposition_types::User;
 
@@ -18,23 +20,26 @@ use crate::middlewares::auth_n::{
     helpers::fetch_org_ids_from_db,
     oidc::{
         OIDCAuthenticator,
+        api_token::{ApiTokenConfig, cache_ttl},
         token_cache::{CachedGrant, TokenExchangeCache},
         utils::{
-            build_client, exchange_password_for_id_token, fetch_provider_metadata,
-            try_user_from, validate_client_credentials, verify_presence,
+            OidcProviderMetadata, build_client, discovered_introspection_endpoint,
+            exchange_password_for_id_token, fetch_provider_metadata, try_user_from,
+            validate_client_credentials, verify_presence,
         },
     },
 };
 
 pub struct AuthenticatorInner {
     client: RwLock<CoreClient>,
-    provider_metadata: RwLock<CoreProviderMetadata>,
+    provider_metadata: RwLock<OidcProviderMetadata>,
     issuer_url: IssuerUrl,
     client_id: ClientId,
     client_secret: ClientSecret,
     redirect_url: RedirectUrl,
     path_prefix: String,
     token_cache: TokenExchangeCache,
+    api_token: Option<ApiTokenConfig>,
 }
 
 /// A simple OIDC Authenticator implementation that uses a single
@@ -52,6 +57,8 @@ impl SimpleOIDCAuthenticator {
         path_prefix: String,
         client_id: String,
         client_secret: String,
+        introspection_auth_header: Option<String>,
+        static_tokens_raw: Option<String>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let issuer_url = IssuerUrl::new(idp_url)
             .map_err(|e| format!("Unable to create issuer url: {}", e))
@@ -70,6 +77,16 @@ impl SimpleOIDCAuthenticator {
             redirect_url.clone(),
         );
 
+        let api_token = ApiTokenConfig::from_env(
+            introspection_auth_header,
+            static_tokens_raw,
+            false,
+        )?;
+        if let Some(cfg) = &api_token {
+            let discovered = discovered_introspection_endpoint(&provider_metadata);
+            cfg.ensure_serviceable(discovered.as_deref())?;
+        }
+
         Ok(Self(Arc::new(AuthenticatorInner {
             client: RwLock::new(client),
             provider_metadata: RwLock::new(provider_metadata),
@@ -79,6 +96,7 @@ impl SimpleOIDCAuthenticator {
             redirect_url,
             path_prefix,
             token_cache: TokenExchangeCache::new(),
+            api_token,
         })))
     }
 
@@ -212,6 +230,68 @@ impl Authenticator for SimpleOIDCAuthenticator {
         }
     }
 
+    fn api_token_prefix(&self) -> Option<String> {
+        self.api_token.as_ref().map(|c| c.prefix.clone())
+    }
+
+    fn authenticate_with_api_token(
+        &self,
+        login_type: &Login,
+        api_key: &str,
+    ) -> LocalBoxFuture<'static, Result<User, HttpResponse>> {
+        if matches!(login_type, Login::None) {
+            return Box::pin(async { Ok(User::default()) });
+        }
+
+        let auth_n = self.clone();
+        let api_key = api_key.to_string();
+        // Simple is single-realm, so the introspected principal is
+        // org-independent: scope the cache key by `None`.
+        let key = TokenExchangeCache::key(None, CachedGrant::ApiToken, "", &api_key);
+        Box::pin(async move {
+            let Some(config) = auth_n.api_token.as_ref() else {
+                return Err(ErrorNotImplemented(
+                    "API token authentication is not configured",
+                )
+                .into());
+            };
+
+            if let Some(user) = config.match_static_token(None, &api_key) {
+                return Ok(user);
+            }
+
+            if !config.introspection_enabled() {
+                return Err(ErrorUnauthorized("Invalid or inactive API token").into());
+            }
+
+            if let Some(user) = auth_n.token_cache.get(&key) {
+                return Ok(user);
+            }
+
+            // Single-realm: resolve the one endpoint from explicit config, else
+            // the endpoint discovered in the (cached) provider metadata.
+            let discovered = discovered_introspection_endpoint(
+                &auth_n
+                    .provider_metadata
+                    .read()
+                    .unwrap_or_else(|e| e.into_inner()),
+            );
+            let Some(endpoint) = config.resolve_endpoint(None, discovered) else {
+                return Err(ErrorInternalServerError(
+                    "API token introspection endpoint is not configured and none \
+                     was advertised in provider metadata",
+                )
+                .into());
+            };
+            let (user, exp) = config
+                .introspect(&endpoint, &api_key)
+                .await
+                .map_err(actix_web::Error::from)?;
+            auth_n.token_cache.insert(key, user.clone(), cache_ttl(exp));
+            Ok(user)
+        })
+    }
+
     fn authenticate_with_basic_auth(
         &self,
         login_type: &Login,
@@ -247,9 +327,7 @@ impl Authenticator for SimpleOIDCAuthenticator {
 
                     let user = auth_n.get_user_from_id_token(&id_token).map_err(|e| {
                         log::error!("Error in decoding user : {e}");
-                        actix_web::Error::from(ErrorInternalServerError(String::from(
-                            "Unable to get user",
-                        )))
+                        ErrorInternalServerError(String::from("Unable to get user"))
                     })?;
                     auth_n.token_cache.insert(key, user.clone(), expires_in);
                     Ok(user)

--- a/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
@@ -2,14 +2,14 @@ use std::sync::{Arc, RwLock};
 
 use actix_web::{
     HttpRequest, HttpResponse,
-    error::{ErrorBadRequest, ErrorInternalServerError},
+    error::{ErrorBadRequest, ErrorInternalServerError, ErrorUnauthorized},
     web::{self, Data, get, resource},
 };
 use derive_more::{Deref, DerefMut};
 use futures_util::future::LocalBoxFuture;
 use openidconnect::{
-    ClientId, ClientSecret, IssuerUrl, RedirectUrl, TokenResponse,
-    core::{CoreClient, CoreIdTokenClaims, CoreTokenResponse},
+    ClientId, ClientSecret, IssuerUrl, RedirectUrl,
+    core::{CoreClient, CoreIdToken, CoreIdTokenClaims},
 };
 use superposition_types::User;
 
@@ -76,11 +76,10 @@ impl SimpleOIDCAuthenticator {
 
     fn decode_global_token(&self, cookie: &str) -> Result<CoreIdTokenClaims, String> {
         let client = self.get_client();
-        let ctr = serde_json::from_str::<CoreTokenResponse>(cookie)
+        let ctr = cookie
+            .parse::<CoreIdToken>()
             .map_err(|e| format!("Error while decoding token: {e}"))?;
-        ctr.id_token()
-            .ok_or(String::from("Id Token not found"))?
-            .claims(&client.id_token_verifier(), verify_presence)
+        ctr.claims(&client.id_token_verifier(), verify_presence)
             .map_err(|e| format!("Error in claims verification: {e}"))
             .cloned()
     }
@@ -155,6 +154,29 @@ impl Authenticator for SimpleOIDCAuthenticator {
                 let resp = auth_n.get_global_user(request, request.path().to_string());
                 Box::pin(async { resp })
             }
+        }
+    }
+
+    fn authenticate_with_token(
+        &self,
+        login_type: &Login,
+        token: &str,
+    ) -> Result<User, HttpResponse> {
+        match login_type {
+            Login::None => Ok(User::default()),
+            _ => self
+                .decode_global_token(token)
+                .map_err(|e| {
+                    log::error!("Error in decoding user : {e}");
+                    ErrorUnauthorized(String::from("Unable to get user"))
+                })
+                .and_then(|claims| {
+                    try_user_from(&claims).map_err(|e| {
+                        log::error!("Unable to get user: {e}");
+                        ErrorUnauthorized(String::from("Unable to get user"))
+                    })
+                })
+                .map_err(Into::into),
         }
     }
 

--- a/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/simple_authenticator.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use actix_web::{
     HttpRequest, HttpResponse,
@@ -8,8 +8,8 @@ use actix_web::{
 use derive_more::{Deref, DerefMut};
 use futures_util::future::LocalBoxFuture;
 use openidconnect::{
-    self as oidcrs, ClientId, ClientSecret, IssuerUrl, RedirectUrl, TokenResponse,
-    core::{CoreClient, CoreIdTokenClaims, CoreProviderMetadata, CoreTokenResponse},
+    ClientId, ClientSecret, IssuerUrl, RedirectUrl, TokenResponse,
+    core::{CoreClient, CoreIdTokenClaims, CoreTokenResponse},
 };
 use superposition_types::User;
 
@@ -18,13 +18,16 @@ use crate::middlewares::auth_n::{
     helpers::fetch_org_ids_from_db,
     oidc::{
         OIDCAuthenticator,
-        utils::{try_user_from, verify_presence},
+        utils::{build_client, fetch_provider_metadata, try_user_from, verify_presence},
     },
 };
 
-#[derive(Clone)]
 pub struct AuthenticatorInner {
-    client: CoreClient,
+    client: RwLock<CoreClient>,
+    issuer_url: IssuerUrl,
+    client_id: ClientId,
+    client_secret: ClientSecret,
+    redirect_url: RedirectUrl,
     path_prefix: String,
 }
 
@@ -47,44 +50,63 @@ impl SimpleOIDCAuthenticator {
         let issuer_url = IssuerUrl::new(idp_url)
             .map_err(|e| format!("Unable to create issuer url: {}", e))
             .unwrap();
+        let redirect_url =
+            RedirectUrl::new(format!("{base_url}{path_prefix}/oidc/login"))?;
+        let client_id = ClientId::new(client_id);
+        let client_secret = ClientSecret::new(client_secret);
 
-        // Discover OpenID Provider metadata
-        let provider_metadata = CoreProviderMetadata::discover_async(
-            issuer_url,
-            oidcrs::reqwest::async_http_client,
-        )
-        .await?;
+        let provider_metadata = fetch_provider_metadata(issuer_url.clone()).await?;
 
-        // Create client
-        let client = CoreClient::from_provider_metadata(
-            provider_metadata.clone(),
-            ClientId::new(client_id.clone()),
-            Some(ClientSecret::new(client_secret.clone())),
-        )
-        .set_redirect_uri(RedirectUrl::new(format!(
-            "{base_url}{path_prefix}/oidc/login"
-        ))?);
+        let client = build_client(
+            provider_metadata,
+            client_id.clone(),
+            client_secret.clone(),
+            redirect_url.clone(),
+        );
 
         Ok(Self(Arc::new(AuthenticatorInner {
-            client,
+            client: RwLock::new(client),
+            issuer_url,
+            client_id,
+            client_secret,
+            redirect_url,
             path_prefix,
         })))
     }
 
     fn decode_global_token(&self, cookie: &str) -> Result<CoreIdTokenClaims, String> {
+        let client = self.get_client();
         let ctr = serde_json::from_str::<CoreTokenResponse>(cookie)
             .map_err(|e| format!("Error while decoding token: {e}"))?;
         ctr.id_token()
             .ok_or(String::from("Id Token not found"))?
-            .claims(&self.client.id_token_verifier(), verify_presence)
+            .claims(&client.id_token_verifier(), verify_presence)
             .map_err(|e| format!("Error in claims verification: {e}"))
             .cloned()
     }
 }
 
 impl OIDCAuthenticator for SimpleOIDCAuthenticator {
-    fn get_client(&self) -> &CoreClient {
-        &self.client
+    fn get_client(&self) -> CoreClient {
+        self.client
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone()
+    }
+
+    async fn refresh_client(&self) -> Result<(), String> {
+        let provider_metadata = fetch_provider_metadata(self.issuer_url.clone())
+            .await
+            .map_err(|e| format!("Failed to refresh provider metadata: {e:?}"))?;
+        let client = build_client(
+            provider_metadata,
+            self.client_id.clone(),
+            self.client_secret.clone(),
+            self.redirect_url.clone(),
+        );
+
+        *self.client.write().unwrap_or_else(|e| e.into_inner()) = client;
+        Ok(())
     }
 
     fn get_global_user(

--- a/crates/service_utils/src/middlewares/auth_n/oidc/token_cache.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/token_cache.rs
@@ -14,13 +14,44 @@ use std::{
 
 use superposition_types::User;
 
-/// Drop a cached principal this many seconds before the exchanged token's
-/// actual expiry, to stay ahead of clock skew and in-flight latency.
-const CACHE_REFRESH_SAFETY_MARGIN_SECS: Duration = Duration::from_secs(30);
+use crate::helpers::get_from_env_or_default;
 
-/// Fallback TTL when the IdP omits `expires_in` from the token response
-/// (`expires_in` is only RECOMMENDED by RFC 6749 §5.1, not required).
-const FALLBACK_TTL_SECS: Duration = Duration::from_secs(60);
+/// Default seconds to drop a cached principal before the token's actual expiry
+/// (overridable via `OIDC_CACHE_REFRESH_SAFETY_MARGIN_SECS`).
+const DEFAULT_CACHE_REFRESH_SAFETY_MARGIN_SECS: u64 = 30;
+
+/// Default fallback TTL in seconds when the IdP omits `expires_in`
+/// (overridable via `OIDC_FALLBACK_TTL_SECS`).
+const DEFAULT_FALLBACK_TTL_SECS: u64 = 60;
+
+/// Tunable TTLs for [`TokenExchangeCache`], loaded from env. Kept separate from
+/// the cache itself so the cache stays a pure data structure (constructible with
+/// explicit values in tests) and env-reading lives in one place.
+pub(super) struct TokenCacheConfig {
+    /// Drop a cached principal this many seconds before the exchanged token's
+    /// actual expiry, to stay ahead of clock skew and in-flight latency.
+    refresh_margin: Duration,
+    /// Fallback TTL when the IdP omits `expires_in` from the token response
+    /// (`expires_in` is only RECOMMENDED by RFC 6749 §5.1, not required).
+    fallback_ttl: Duration,
+}
+
+impl TokenCacheConfig {
+    /// Reads the TTL overrides from env at startup, so a malformed override
+    /// fails fast at boot rather than on the first cached request.
+    pub(super) fn from_env() -> Self {
+        Self {
+            refresh_margin: Duration::from_secs(get_from_env_or_default(
+                "OIDC_CACHE_REFRESH_SAFETY_MARGIN_SECS",
+                DEFAULT_CACHE_REFRESH_SAFETY_MARGIN_SECS,
+            )),
+            fallback_ttl: Duration::from_secs(get_from_env_or_default(
+                "OIDC_FALLBACK_TTL_SECS",
+                DEFAULT_FALLBACK_TTL_SECS,
+            )),
+        }
+    }
+}
 
 /// Which Basic grant produced an entry. Part of the key so a `username` can
 /// never collide with a `client_id`.
@@ -43,14 +74,19 @@ struct CacheEntry {
     expires_at: Instant,
 }
 
-#[derive(Default)]
 pub(super) struct TokenExchangeCache {
     entries: RwLock<HashMap<CacheKey, CacheEntry>>,
+    config: TokenCacheConfig,
 }
 
 impl TokenExchangeCache {
-    pub(super) fn new() -> Self {
-        Self::default()
+    /// Builds a cache with the given TTL config. Pure — the caller reads the
+    /// config (from env at startup, or explicit values in tests).
+    pub(super) fn new(config: TokenCacheConfig) -> Self {
+        Self {
+            entries: RwLock::new(HashMap::new()),
+            config,
+        }
     }
 
     /// Builds a cache key, hashing the secret so it is never stored in plaintext.
@@ -77,8 +113,8 @@ impl TokenExchangeCache {
     /// entries are pruned lazily on write so the map cannot grow unbounded.
     pub(super) fn insert(&self, key: CacheKey, user: User, expires_in: Option<Duration>) {
         let ttl = expires_in
-            .unwrap_or(FALLBACK_TTL_SECS)
-            .saturating_sub(CACHE_REFRESH_SAFETY_MARGIN_SECS);
+            .unwrap_or(self.config.fallback_ttl)
+            .saturating_sub(self.config.refresh_margin);
         let expires_at = Instant::now() + ttl;
 
         let mut entries = self.entries.write().unwrap_or_else(|e| e.into_inner());

--- a/crates/service_utils/src/middlewares/auth_n/oidc/token_cache.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/token_cache.rs
@@ -1,0 +1,94 @@
+//! In-memory cache for Basic-auth token exchanges (password + client_credentials).
+//!
+//! Basic auth is validated on every request, and each validation otherwise
+//! round-trips to the IdP's token endpoint. This cache short-circuits repeat
+//! requests bearing the same credentials with the previously-resolved
+//! principal, until shortly before the exchanged token would expire.
+
+use std::{
+    collections::{HashMap, hash_map::DefaultHasher},
+    hash::{Hash, Hasher},
+    sync::RwLock,
+    time::{Duration, Instant},
+};
+
+use superposition_types::User;
+
+/// Drop a cached principal this many seconds before the exchanged token's
+/// actual expiry, to stay ahead of clock skew and in-flight latency.
+const CACHE_REFRESH_SAFETY_MARGIN_SECS: Duration = Duration::from_secs(30);
+
+/// Fallback TTL when the IdP omits `expires_in` from the token response
+/// (`expires_in` is only RECOMMENDED by RFC 6749 §5.1, not required).
+const FALLBACK_TTL_SECS: Duration = Duration::from_secs(60);
+
+/// Which Basic grant produced an entry. Part of the key so a `username` can
+/// never collide with a `client_id`.
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub(super) enum CachedGrant {
+    Password,
+    ClientCredentials,
+}
+
+/// Cache key: `(scope, grant, principal_id, hash(secret))`.
+/// - `scope` is the org for SaaS (per-org realms) and `None` for the
+///   single-realm Simple authenticator.
+/// - hashing the secret keeps the key compact and makes rotation an automatic
+///   miss (a new secret hashes differently), and avoids holding plaintext.
+type CacheKey = (Option<String>, CachedGrant, String, u64);
+
+struct CacheEntry {
+    user: User,
+    expires_at: Instant,
+}
+
+#[derive(Default)]
+pub(super) struct TokenExchangeCache {
+    entries: RwLock<HashMap<CacheKey, CacheEntry>>,
+}
+
+impl TokenExchangeCache {
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Builds a cache key, hashing the secret so it is never stored in plaintext.
+    pub(super) fn key(
+        scope: Option<String>,
+        grant: CachedGrant,
+        principal_id: &str,
+        secret: &str,
+    ) -> CacheKey {
+        (scope, grant, principal_id.to_string(), hash_secret(secret))
+    }
+
+    /// Returns the cached principal if present and not yet expired.
+    pub(super) fn get(&self, key: &CacheKey) -> Option<User> {
+        let entries = self.entries.read().unwrap_or_else(|e| e.into_inner());
+        entries
+            .get(key)
+            .filter(|entry| Instant::now() < entry.expires_at)
+            .map(|entry| entry.user.clone())
+    }
+
+    /// Caches `user` with a TTL of the token's `expires_in` minus the safety
+    /// margin (or the fallback when the IdP omitted `expires_in`). Expired
+    /// entries are pruned lazily on write so the map cannot grow unbounded.
+    pub(super) fn insert(&self, key: CacheKey, user: User, expires_in: Option<Duration>) {
+        let ttl = expires_in
+            .unwrap_or_else(|| FALLBACK_TTL_SECS)
+            .saturating_sub(CACHE_REFRESH_SAFETY_MARGIN_SECS);
+        let expires_at = Instant::now() + ttl;
+
+        let mut entries = self.entries.write().unwrap_or_else(|e| e.into_inner());
+        let now = Instant::now();
+        entries.retain(|_, entry| entry.expires_at > now);
+        entries.insert(key, CacheEntry { user, expires_at });
+    }
+}
+
+fn hash_secret(secret: &str) -> u64 {
+    let mut hasher = DefaultHasher::new();
+    secret.hash(&mut hasher);
+    hasher.finish()
+}

--- a/crates/service_utils/src/middlewares/auth_n/oidc/token_cache.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/token_cache.rs
@@ -28,6 +28,7 @@ const FALLBACK_TTL_SECS: Duration = Duration::from_secs(60);
 pub(super) enum CachedGrant {
     Password,
     ClientCredentials,
+    ApiToken,
 }
 
 /// Cache key: `(scope, grant, principal_id, hash(secret))`.
@@ -76,7 +77,7 @@ impl TokenExchangeCache {
     /// entries are pruned lazily on write so the map cannot grow unbounded.
     pub(super) fn insert(&self, key: CacheKey, user: User, expires_in: Option<Duration>) {
         let ttl = expires_in
-            .unwrap_or_else(|| FALLBACK_TTL_SECS)
+            .unwrap_or(FALLBACK_TTL_SECS)
             .saturating_sub(CACHE_REFRESH_SAFETY_MARGIN_SECS);
         let expires_at = Instant::now() + ttl;
 

--- a/crates/service_utils/src/middlewares/auth_n/oidc/types.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/types.rs
@@ -1,12 +1,10 @@
 use actix_web::HttpRequest;
 use base64::{Engine, engine::general_purpose};
 use openidconnect::{
-    AdditionalClaims, AuthorizationCode, CsrfToken, EmptyExtraTokenFields, IdTokenClaims,
-    IdTokenFields, Nonce, StandardTokenResponse,
+    AdditionalClaims, AuthorizationCode, CsrfToken, IdToken, IdTokenClaims, Nonce,
     core::{
         CoreGenderClaim, CoreIdTokenClaims, CoreJsonWebKeyType,
-        CoreJweContentEncryptionAlgorithm, CoreJwsSigningAlgorithm, CoreTokenResponse,
-        CoreTokenType,
+        CoreJweContentEncryptionAlgorithm, CoreJwsSigningAlgorithm,
     },
 };
 use serde::{Deserialize, Deserializer, Serialize};
@@ -19,20 +17,15 @@ pub(super) struct GlobalUserExtraClaims {
 
 impl AdditionalClaims for GlobalUserExtraClaims {}
 
-pub(super) type GlobalUserCoreIdTokenFields = IdTokenFields<
+pub(super) type GlobalUserClaims = IdTokenClaims<GlobalUserExtraClaims, CoreGenderClaim>;
+pub(super) type GlobalUserIdToken = IdToken<
     GlobalUserExtraClaims,
-    EmptyExtraTokenFields,
     CoreGenderClaim,
     CoreJweContentEncryptionAlgorithm,
     CoreJwsSigningAlgorithm,
     CoreJsonWebKeyType,
 >;
 
-pub(super) type GlobalUserTokenResponse =
-    StandardTokenResponse<GlobalUserCoreIdTokenFields, CoreTokenType>;
-pub(super) type GlobalUserClaims = IdTokenClaims<GlobalUserExtraClaims, CoreGenderClaim>;
-
-pub(super) type OrgUserTokenResponse = CoreTokenResponse;
 pub(super) type OrgUserClaims = CoreIdTokenClaims;
 
 #[derive(Serialize)]

--- a/crates/service_utils/src/middlewares/auth_n/oidc/utils.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/utils.rs
@@ -74,8 +74,13 @@ pub(super) enum BasicAuthError {
     Unsupported,
     /// The supplied username/password was rejected by the identity provider.
     InvalidCredentials,
-    /// Any other failure: network error, misconfiguration, missing id-token,
-    /// or claims verification failure. Detail is for logs, not the client.
+    /// The exchanged ID token could not be verified. The most common cause is
+    /// stale JWKS: the IdP rotated its signing keys since the provider metadata
+    /// was last fetched. Callers can retry after refreshing the metadata. Detail
+    /// is for logs, not the client.
+    TokenVerification(String),
+    /// Any other failure: network error, misconfiguration, or missing id-token.
+    /// Detail is for logs, not the client.
     Internal(String),
 }
 
@@ -86,6 +91,7 @@ impl std::fmt::Display for BasicAuthError {
                 write!(f, "password grant not supported by identity provider")
             }
             Self::InvalidCredentials => write!(f, "invalid username or password"),
+            Self::TokenVerification(detail) => write!(f, "{detail}"),
             Self::Internal(detail) => write!(f, "{detail}"),
         }
     }
@@ -100,7 +106,7 @@ impl From<BasicAuthError> for actix_web::Error {
             BasicAuthError::InvalidCredentials => {
                 ErrorUnauthorized("Invalid username or password")
             }
-            BasicAuthError::Internal(_) => {
+            BasicAuthError::TokenVerification(_) | BasicAuthError::Internal(_) => {
                 ErrorInternalServerError("Failed to authenticate user")
             }
         }
@@ -201,7 +207,7 @@ pub(super) async fn exchange_password_for_id_token(
     id_token
         .claims(&client.id_token_verifier(), presence_no_check)
         .map_err(|e| {
-            BasicAuthError::Internal(format!("Couldn't verify claims: {e:?}"))
+            BasicAuthError::TokenVerification(format!("Couldn't verify claims: {e:?}"))
         })?;
 
     Ok((id_token.to_string(), expires_in))

--- a/crates/service_utils/src/middlewares/auth_n/oidc/utils.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/utils.rs
@@ -1,4 +1,8 @@
-use openidconnect::{AdditionalClaims, GenderClaim, IdTokenClaims, Nonce};
+use openidconnect::{
+    self as oidcrs, AdditionalClaims, ClientId, ClientSecret, GenderClaim, IdTokenClaims,
+    IssuerUrl, Nonce, RedirectUrl,
+    core::{CoreClient, CoreProviderMetadata},
+};
 use superposition_types::User;
 
 pub(super) fn verify_presence(n: Option<&Nonce>) -> Result<(), String> {
@@ -27,4 +31,26 @@ pub(super) fn try_user_from<A: AdditionalClaims, B: GenderClaim>(
         .ok_or(String::from("Username not found"))?;
 
     Ok(User::new(email, username))
+}
+
+pub(super) async fn fetch_provider_metadata(
+    issuer_url: IssuerUrl,
+) -> Result<CoreProviderMetadata, Box<dyn std::error::Error>> {
+    let provider_metadata = CoreProviderMetadata::discover_async(
+        issuer_url,
+        oidcrs::reqwest::async_http_client,
+    )
+    .await?;
+
+    Ok(provider_metadata)
+}
+
+pub(super) fn build_client(
+    provider_metadata: CoreProviderMetadata,
+    client_id: ClientId,
+    client_secret: ClientSecret,
+    redirect_url: RedirectUrl,
+) -> CoreClient {
+    CoreClient::from_provider_metadata(provider_metadata, client_id, Some(client_secret))
+        .set_redirect_uri(redirect_url)
 }

--- a/crates/service_utils/src/middlewares/auth_n/oidc/utils.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/utils.rs
@@ -1,9 +1,57 @@
+use std::time::Duration;
+
+use actix_web::error::{
+    ErrorInternalServerError, ErrorNotImplemented, ErrorUnauthorized,
+};
 use openidconnect::{
     self as oidcrs, AdditionalClaims, ClientId, ClientSecret, GenderClaim, IdTokenClaims,
-    IssuerUrl, Nonce, RedirectUrl,
-    core::{CoreClient, CoreProviderMetadata},
+    IssuerUrl, Nonce, OAuth2TokenResponse, RedirectUrl, RequestTokenError,
+    ResourceOwnerPassword, ResourceOwnerUsername, Scope, TokenResponse,
+    core::{CoreClient, CoreErrorResponseType, CoreProviderMetadata},
 };
 use superposition_types::User;
+
+/// Classifies a failure of the Basic-auth (ROPC / password grant) exchange so
+/// callers can surface an accurate HTTP status instead of a blanket 500.
+#[derive(Debug)]
+pub(super) enum BasicAuthError {
+    /// The identity provider does not support the password grant (e.g. Google
+    /// rejects it with `unsupported_grant_type`). Basic auth cannot work here.
+    Unsupported,
+    /// The supplied username/password was rejected by the identity provider.
+    InvalidCredentials,
+    /// Any other failure: network error, misconfiguration, missing id-token,
+    /// or claims verification failure. Detail is for logs, not the client.
+    Internal(String),
+}
+
+impl std::fmt::Display for BasicAuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unsupported => {
+                write!(f, "password grant not supported by identity provider")
+            }
+            Self::InvalidCredentials => write!(f, "invalid username or password"),
+            Self::Internal(detail) => write!(f, "{detail}"),
+        }
+    }
+}
+
+impl From<BasicAuthError> for actix_web::Error {
+    fn from(err: BasicAuthError) -> Self {
+        match err {
+            BasicAuthError::Unsupported => ErrorNotImplemented(
+                "Basic auth is not supported by the configured identity provider",
+            ),
+            BasicAuthError::InvalidCredentials => {
+                ErrorUnauthorized("Invalid username or password")
+            }
+            BasicAuthError::Internal(_) => {
+                ErrorInternalServerError("Failed to authenticate user")
+            }
+        }
+    }
+}
 
 pub(super) fn verify_presence(n: Option<&Nonce>) -> Result<(), String> {
     if n.is_some() {
@@ -53,4 +101,78 @@ pub(super) fn build_client(
 ) -> CoreClient {
     CoreClient::from_provider_metadata(provider_metadata, client_id, Some(client_secret))
         .set_redirect_uri(redirect_url)
+}
+
+/// Maps a standard OAuth token-endpoint error code onto a classified
+/// [`BasicAuthError`]. Shared by the password (ROPC) and client-credentials
+/// exchanges: `invalid_grant` (bad user creds) and `invalid_client` /
+/// `unauthorized_client` (bad/disallowed client creds) both read as
+/// "invalid credentials", while `unsupported_grant_type` means the IdP does
+/// not offer the grant at all.
+fn status_for_token_error_code(code: &CoreErrorResponseType) -> BasicAuthError {
+    match code {
+        CoreErrorResponseType::UnsupportedGrantType => BasicAuthError::Unsupported,
+        CoreErrorResponseType::InvalidGrant
+        | CoreErrorResponseType::InvalidClient
+        | CoreErrorResponseType::UnauthorizedClient => BasicAuthError::InvalidCredentials,
+        other => BasicAuthError::Internal(format!("token endpoint error: {other:?}")),
+    }
+}
+
+pub(super) async fn exchange_password_for_id_token(
+    client: &CoreClient,
+    username: &ResourceOwnerUsername,
+    password: &ResourceOwnerPassword,
+) -> Result<(String, Option<Duration>), BasicAuthError> {
+    let token_response = client
+        .exchange_password(username, password)
+        .add_scope(Scope::new("openid".to_string()))
+        .add_scope(Scope::new("email".to_string()))
+        .add_scope(Scope::new("profile".to_string()))
+        .request_async(oidcrs::reqwest::async_http_client)
+        .await
+        .map_err(|e| match &e {
+            RequestTokenError::ServerResponse(resp) => {
+                status_for_token_error_code(resp.error())
+            }
+            other => BasicAuthError::Internal(format!(
+                "Failed to exchange password for token: {other:?}"
+            )),
+        })?;
+
+    let expires_in = token_response.expires_in();
+    let id_token = token_response
+        .id_token()
+        .ok_or_else(|| BasicAuthError::Internal("No identity-token!".to_string()))?;
+    id_token
+        .claims(&client.id_token_verifier(), presence_no_check)
+        .map_err(|e| {
+            BasicAuthError::Internal(format!("Couldn't verify claims: {e:?}"))
+        })?;
+
+    Ok((id_token.to_string(), expires_in))
+}
+
+/// Validates a machine's client_id/client_secret against the IdP using the
+/// `client_credentials` grant. The `client` must already be configured with the
+/// machine's credentials (see each authenticator's `machine_client`). A
+/// successful exchange proves the credentials are valid; the returned token is
+/// not needed since the principal is derived from the client_id. Returns the
+/// token's `expires_in` (if provided) so the caller can bound its cache entry.
+pub(super) async fn validate_client_credentials(
+    client: &CoreClient,
+) -> Result<Option<Duration>, BasicAuthError> {
+    client
+        .exchange_client_credentials()
+        .request_async(oidcrs::reqwest::async_http_client)
+        .await
+        .map_err(|e| match &e {
+            RequestTokenError::ServerResponse(resp) => {
+                status_for_token_error_code(resp.error())
+            }
+            other => BasicAuthError::Internal(format!(
+                "Failed to exchange client credentials: {other:?}"
+            )),
+        })
+        .map(|t| t.expires_in())
 }

--- a/crates/service_utils/src/middlewares/auth_n/oidc/utils.rs
+++ b/crates/service_utils/src/middlewares/auth_n/oidc/utils.rs
@@ -4,12 +4,66 @@ use actix_web::error::{
     ErrorInternalServerError, ErrorNotImplemented, ErrorUnauthorized,
 };
 use openidconnect::{
-    self as oidcrs, AdditionalClaims, ClientId, ClientSecret, GenderClaim, IdTokenClaims,
-    IssuerUrl, Nonce, OAuth2TokenResponse, RedirectUrl, RequestTokenError,
-    ResourceOwnerPassword, ResourceOwnerUsername, Scope, TokenResponse,
-    core::{CoreClient, CoreErrorResponseType, CoreProviderMetadata},
+    self as oidcrs, AdditionalClaims, AdditionalProviderMetadata, ClientId, ClientSecret,
+    GenderClaim, IdTokenClaims, IntrospectionUrl, IssuerUrl, Nonce, OAuth2TokenResponse,
+    ProviderMetadata, RedirectUrl, RequestTokenError, ResourceOwnerPassword,
+    ResourceOwnerUsername, Scope, TokenResponse,
+    core::{
+        CoreAuthDisplay, CoreClaimName, CoreClaimType, CoreClient, CoreClientAuthMethod,
+        CoreErrorResponseType, CoreGrantType, CoreJsonWebKey, CoreJsonWebKeyType,
+        CoreJsonWebKeyUse, CoreJweContentEncryptionAlgorithm,
+        CoreJweKeyManagementAlgorithm, CoreJwsSigningAlgorithm, CoreResponseMode,
+        CoreResponseType, CoreSubjectIdentifierType,
+    },
 };
+use serde::{Deserialize, Serialize};
 use superposition_types::User;
+
+/// Additional provider-metadata beyond OIDC Core discovery: the RFC 7662
+/// introspection endpoint (defined by RFC 8414). It is OPTIONAL — a provider may
+/// support introspection without advertising it — hence `Option`.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub(super) struct IntrospectionMetadata {
+    #[serde(default)]
+    pub(super) introspection_endpoint: Option<IntrospectionUrl>,
+}
+
+impl AdditionalProviderMetadata for IntrospectionMetadata {}
+
+/// OIDC provider metadata carrying the introspection endpoint alongside the
+/// standard Core fields. Mirrors `CoreProviderMetadata` with our additional
+/// metadata swapped in for the empty default.
+pub(super) type OidcProviderMetadata = ProviderMetadata<
+    IntrospectionMetadata,
+    CoreAuthDisplay,
+    CoreClientAuthMethod,
+    CoreClaimName,
+    CoreClaimType,
+    CoreGrantType,
+    CoreJweContentEncryptionAlgorithm,
+    CoreJweKeyManagementAlgorithm,
+    CoreJwsSigningAlgorithm,
+    CoreJsonWebKeyType,
+    CoreJsonWebKeyUse,
+    CoreJsonWebKey,
+    CoreResponseMode,
+    CoreResponseType,
+    CoreSubjectIdentifierType,
+>;
+
+/// The introspection endpoint advertised in the provider's discovery metadata
+/// (RFC 8414 `introspection_endpoint`), as a plain string, if present. Keeps the
+/// `openidconnect` metadata-digging in one place so callers (and the
+/// introspection config) deal only in URLs.
+pub(super) fn discovered_introspection_endpoint(
+    metadata: &OidcProviderMetadata,
+) -> Option<String> {
+    metadata
+        .additional_metadata()
+        .introspection_endpoint
+        .as_ref()
+        .map(|url| url.url().as_str().to_string())
+}
 
 /// Classifies a failure of the Basic-auth (ROPC / password grant) exchange so
 /// callers can surface an accurate HTTP status instead of a blanket 500.
@@ -83,8 +137,8 @@ pub(super) fn try_user_from<A: AdditionalClaims, B: GenderClaim>(
 
 pub(super) async fn fetch_provider_metadata(
     issuer_url: IssuerUrl,
-) -> Result<CoreProviderMetadata, Box<dyn std::error::Error>> {
-    let provider_metadata = CoreProviderMetadata::discover_async(
+) -> Result<OidcProviderMetadata, Box<dyn std::error::Error>> {
+    let provider_metadata = OidcProviderMetadata::discover_async(
         issuer_url,
         oidcrs::reqwest::async_http_client,
     )
@@ -94,7 +148,7 @@ pub(super) async fn fetch_provider_metadata(
 }
 
 pub(super) fn build_client(
-    provider_metadata: CoreProviderMetadata,
+    provider_metadata: OidcProviderMetadata,
     client_id: ClientId,
     client_secret: ClientSecret,
     redirect_url: RedirectUrl,

--- a/docs/docs/self-hosting/authentication.md
+++ b/docs/docs/self-hosting/authentication.md
@@ -1,0 +1,437 @@
+---
+title: Authentication
+description: How Superposition authenticates requests — providers, schemes, configuration, and the rationale behind the design.
+---
+
+# Authentication
+
+This page documents Superposition's authentication (`auth_n`) subsystem end to
+end: the providers you can choose, the credential schemes accepted on each
+request, how to configure them, and — importantly — **why** the design is the
+way it is.
+
+> Authentication answers "who is making this request". It is distinct from
+> **authorization** (what they are allowed to do), which is handled separately
+> by the Casbin layer. See [Environment Variables → Authorization](./environment-variables.md#authorization).
+
+## Design philosophy: Superposition does not store users
+
+A deliberate stance shapes this whole subsystem: **Superposition does not store
+users and does not do any user management.** It never owns a password table, a
+user directory, or a session store. Every identity decision is delegated to an
+external identity provider (IdP) or an external token service, and Superposition
+only ever *verifies* what it is handed on each request.
+
+This keeps Superposition stateless with respect to identity and lets you bring
+your own IdP (Keycloak, Okta, Auth0, Google, …) and your own API-key/token
+management system. The trade-offs made throughout the design flow from this
+stance.
+
+## Providers
+
+The provider is selected by the `AUTH_PROVIDER` environment variable, whose
+value is a `+`-separated string of `PROVIDER[+ARG...]`.
+
+| `AUTH_PROVIDER` | Meaning |
+| --- | --- |
+| `DISABLED` | No authentication. Every request is treated as a default user. **Development / private evaluation only.** |
+| `OIDC+<issuer_url>` | Single-realm OIDC. One IdP issuer authenticates everyone; organisations are a Superposition concept, not separate realms. |
+| `OIDC_SAAS+<issuer_url>` | Per-organisation OIDC. Each org has its own realm/endpoints; the first issuer also acts as the global identity provider. |
+
+```bash
+# Disabled (dev only)
+AUTH_PROVIDER=DISABLED
+
+# Single-realm OIDC
+AUTH_PROVIDER=OIDC+https://issuer.example.com/realms/users
+
+# Per-org (SaaS) OIDC
+AUTH_PROVIDER=OIDC_SAAS+https://issuer.example.com/realms/users
+```
+
+The key difference between `OIDC` and `OIDC_SAAS`:
+
+- **`OIDC` (Simple)** validates every credential against the **single**
+  configured realm. Organisations exist in Superposition's own data, but they
+  all share one IdP realm.
+- **`OIDC_SAAS`** resolves a **per-organisation** realm/endpoint (via
+  `<organisation>` placeholder formats) so each tenant's credentials are
+  validated against that tenant's own realm. This is what gives SaaS deployments
+  tenant isolation at the identity layer.
+
+## Credential schemes
+
+The middleware inspects the `Authorization` header and dispatches by scheme.
+All schemes resolve to a single `User` that the rest of the request pipeline
+consumes.
+
+| Scheme on `Authorization` | Used by | Validated how |
+| --- | --- | --- |
+| `Internal <token>` + `x-user` header | Trusted internal services | Shared secret equals `SUPERPOSITION_TOKEN`; identity taken from `x-user` |
+| `Bearer <id_token>` | Interactive users / frontends | OIDC id-token: signature (JWKS), `iss`, `aud`, `exp` |
+| `Bearer <prefix><delim><api_key>` | Machine-to-machine (API keys) | **Static tokens** (operator-configured list), then **RFC 7662 token introspection** against an external endpoint |
+| `Basic base64(id:secret)` (+ `X-Grant-Type`) | Machine-to-machine / non-interactive | OAuth `client_credentials` (default) or `password`/ROPC against the IdP |
+
+Positive classification is used throughout: each token type is identified by an
+explicit marker (scheme, or a configured prefix), never by "it wasn't any of the
+others". A token that matches nothing is rejected, not guessed.
+
+### `Bearer` — OIDC id-token
+
+The standard path. The frontend obtains an id-token from the IdP via the
+interactive authorization-code login flow and presents it as
+`Authorization: Bearer <id_token>`. Superposition validates it against the IdP's
+JWKS (`iss`, `aud`, `exp`, signature) and derives the `User` from the token's
+`email` / `preferred_username` claims.
+
+### `Basic` — client credentials & password grants
+
+`Basic` carries a `base64(id:secret)` pair. **What the pair means is chosen by
+the `X-Grant-Type` header** — Basic is only the transport; the grant is stated
+explicitly, never inferred:
+
+| `X-Grant-Type` | Grant | `id:secret` is | Result |
+| --- | --- | --- | --- |
+| *(absent)* or `client_credentials` | OAuth Client Credentials | `client_id:client_secret` | Machine principal |
+| `password` | Resource Owner Password Credentials (ROPC) | `username:password` | The user |
+| *anything else* | — | — | **400 Bad Request** |
+
+**Client credentials (`client_credentials`)** — the default. Superposition
+performs an OAuth `client_credentials` exchange against the IdP using the
+provided machine credentials. A successful exchange proves the credentials are
+valid; the resulting principal is a synthetic, namespaced service account:
+`service-account-<client_id>` (matching Keycloak's own convention). This is the
+recommended machine-to-machine mechanism when your IdP issues client
+credentials.
+
+- In **`OIDC_SAAS`**, client-credentials requests are **org-scoped**: the
+  machine's credentials are validated against the **organisation's own realm**
+  token endpoint, and a request that is not org-scoped is rejected. This is the
+  isolation boundary — a machine registered in org A's realm cannot authenticate
+  against org B.
+
+**Password (`password`)** — ROPC. Superposition exchanges the user's
+username/password with the IdP for an id-token. Note that ROPC is **deprecated**
+and **not supported by all IdPs**: Keycloak supports it; Google does not.
+Against an IdP that rejects the grant you will receive **501 Not Implemented**
+(see [Error semantics](#error-semantics)).
+
+### `Bearer <prefix>` — API tokens (static tokens & RFC 7662 introspection)
+
+This is the mechanism for **API-key style** access. A configured `<prefix>`
+(and optional `<delimiter>`) marks a bearer token as an API key rather than an
+OIDC id-token; Superposition strips the prefix and validates the remaining
+`<api_key>` by one of **two mechanisms**, tried in order:
+
+1. **Static tokens** — an operator-configured list of tokens, each bound to a
+   fixed principal. Validated locally, no network call.
+2. **RFC 7662 token introspection** — the key is forwarded to an external system
+   that owns it, which answers "is this token active, and who is it?".
+
+When both are configured, a presented key is checked against the **static tokens
+first**, then introspected. At least one mechanism must be configured for the
+flow to be enabled.
+
+**This flow is optional.** It is available only under an OIDC provider and only
+when its environment variables are configured. If unconfigured, prefixed tokens
+are simply treated as ordinary bearer tokens (and will fail id-token validation).
+
+#### Static tokens
+
+For a small, fixed set of machine credentials — or a deployment with no
+introspection endpoint — you can configure the tokens directly. This still fits
+the "Superposition does not store users" stance: the tokens live in your secret
+manager (KMS), not in a Superposition-managed user store, and each simply names
+the principal it authenticates as.
+
+`OIDC_API_STATIC_TOKENS` is a **KMS-encrypted** (like `OIDC_CLIENT_SECRET`) JSON
+array; each entry maps a token to an identity:
+
+```json
+[
+  { "token": "<high-entropy-secret>", "principal": "svc-ci", "email": "ci@example.com" },
+  { "token": "<another-secret>", "principal": "svc-billing", "org": "acme" }
+]
+```
+
+- `token` (required) — the secret presented as `<api_key>`. Compared in
+  **constant time**; use high-entropy values.
+- `principal` (required) — the identity to authenticate as (used as the
+  username, and the email when `email` is omitted). Authorization (Casbin) keys
+  off this.
+- `email` (optional) — defaults to `principal`.
+- `org` (optional, **SaaS only**) — binds the token to one organisation: it
+  authenticates only `Login::Org(<org>)` requests. Omit `org` to make the token
+  **global-scoped** (`Login::Global`). In single-realm OIDC, `org` is ignored.
+
+Because static tokens are matched locally, a match returns immediately with **no
+introspection round-trip and no caching** needed. A key that matches no static
+token falls through to introspection (if configured), otherwise the request is
+rejected (`401`).
+
+#### RFC 7662 introspection
+
+This path is built entirely around
+**[RFC 7662 OAuth 2.0 Token Introspection](https://datatracker.ietf.org/doc/html/rfc7662)**:
+rather than managing API keys itself, Superposition forwards the key to an
+**external** system that owns it, and asks — per RFC 7662 — "is this token
+active, and who is it?".
+
+How it works:
+
+1. A caller sends `Authorization: Bearer <prefix><delimiter><api_key>`, where
+   `<prefix>` and `<delimiter>` are configured (`OIDC_API_TOKEN_PREFIX`,
+   `OIDC_API_TOKEN_DELIMITER`). The prefix distinguishes an API key from a
+   normal JWT id-token (which begins with `eyJ`).
+2. Superposition strips the prefix and `POST`s the key to the introspection
+   endpoint (configured via env, or discovered from provider metadata) as
+   `application/x-www-form-urlencoded` `token=<api_key>`, authenticating itself
+   with the `OIDC_INTROSPECTION_AUTH_HEADER`.
+3. The endpoint returns a standard RFC 7662 JSON response. If `active` is
+   `false` the request is rejected; otherwise the `User` is derived from the
+   standard `username` / `sub` / `email` claims.
+
+The endpoint is protected (RFC 7662 §2.1), so Superposition authenticates itself
+to it. **`OIDC_INTROSPECTION_AUTH_HEADER` is the verbatim `Authorization` header
+value** Superposition sends — e.g. `Bearer <token>` for a custom service, or
+`Basic <base64(client_id:client_secret)>` for a provider's native endpoint (such
+as Keycloak, which requires client authentication). It is a secret and is
+KMS-decrypted in non-dev environments, exactly like `OIDC_CLIENT_SECRET`.
+
+The response is 100% standard RFC 7662 — **no Superposition-specific claims are
+required.** In many cases you do not even need to build an endpoint: Keycloak,
+Okta, Hydra, Auth0 and others already expose an introspection endpoint you can
+point at.
+
+> **Introspection endpoint URL.** RFC 7662 does not define a fixed path — the
+> endpoint is provider-specific and advertised as `introspection_endpoint` in
+> the provider's `.well-known/openid-configuration`. For Keycloak it is
+> `.../realms/{realm}/protocol/openid-connect/token/introspect`. Configure the
+> exact URL from your provider's discovery document.
+
+**Global-scope API tokens (SaaS).** By default SaaS API tokens are org-scoped
+(above). API tokens under a **global** (`Login::Global`) request — mirroring how
+the SaaS provider keeps a global client alongside its per-org clients — are
+supported by resolving the global introspection endpoint in this order:
+
+1. `OIDC_TOKEN_INTROSPECTION_URL` if set (explicit override), else
+2. the `introspection_endpoint` **discovered** from the global provider's
+   metadata (which Superposition already fetches), else
+3. rejected.
+
+So in the common case you need **no** extra env — the global endpoint is
+discovered automatically. Note that `introspection_endpoint` is *optional* in
+provider metadata (RFC 8414): an IdP can support introspection without
+advertising it, in which case set `OIDC_TOKEN_INTROSPECTION_URL` explicitly.
+
+**Tenant isolation (SaaS).** For `OIDC_SAAS`, the introspection endpoint is a
+per-organisation URL format
+(`OIDC_ORG_TOKEN_INTROSPECTION_URL_FORMAT`, with `<organisation>`). API-token
+requests must be org-scoped, and the token is validated against **that org's
+introspection endpoint**. A token minted for another org's realm comes back
+`active: false`.
+
+> **Design note — why no org claim.** We deliberately do **not** require a
+> custom org claim in the introspection response, to keep the contract pure
+> RFC 7662. Isolation therefore rests on the endpoint genuinely being per-org.
+> If an operator configures a **single shared** introspection endpoint for all
+> orgs in a SaaS deployment, there is **no tenant isolation on API keys** — that
+> is a configuration responsibility, made in exchange for a standard,
+> zero-custom-claim contract.
+
+A minimal reference implementation of an introspection endpoint is provided —
+see [Reference introspection service](#reference-introspection-service).
+
+### `Internal` — application-internal only
+
+:::danger Not for external use
+The `Internal` scheme is **exclusively for Superposition's own internal
+service-to-service calls**. It is **not** an authentication method for users or
+integrations, and must never be documented to, or handed to, any caller.
+
+`Authorization: Internal <token>` (where `<token>` equals `SUPERPOSITION_TOKEN`)
+with an `x-user` header lets the caller **assert any identity it wants** — the
+`User` is taken verbatim from `x-user` with no verification. `SUPERPOSITION_TOKEN`
+is a single, deployment-global secret. Anyone who obtains it can impersonate any
+user in any organisation — i.e. **full access**. Treat it like a root credential:
+never expose the scheme through a gateway, never log it, and rotate it if
+leaked.
+:::
+
+## Caching
+
+Every `Basic` and API-token request would otherwise round-trip to the IdP or
+introspection endpoint on **each** call. An in-memory cache short-circuits
+repeat requests bearing the same credentials:
+
+- **Key**: `(org_scope, grant_kind, principal_id, hash(secret))`. The secret is
+  stored only as a hash, never in plaintext — which also makes **credential
+  rotation an automatic cache miss** (a new secret hashes differently).
+- **Value**: the resolved `User` plus an expiry.
+- **TTL**: derived from the token's `expires_in` / `exp`, minus a 30s safety
+  margin (60s fallback when the IdP omits expiry). Introspection results are
+  additionally **capped at 5 minutes** so revocation lag stays small.
+- Expired entries are pruned lazily on write, so the cache cannot grow unbounded.
+
+**Revocation trade-off:** because results are cached, a revoked credential can
+remain accepted until its cache entry expires (bounded by the TTL / the 5-minute
+introspection cap). This is the standard cost of caching introspection; the cap
+keeps it small.
+
+## Error semantics
+
+Failures are mapped to distinct HTTP statuses so callers can tell "your
+credential is bad" from "we couldn't verify it":
+
+| Situation | Status |
+| --- | --- |
+| Valid credential | `200` (request proceeds) |
+| Bad username/password or client credentials (`invalid_grant` / `invalid_client`) | `401 Unauthorized` |
+| API token `active: false`, or active but no identity claim | `401 Unauthorized` |
+| IdP does not support the requested grant (e.g. ROPC on Google → `unsupported_grant_type`) | `501 Not Implemented` |
+| Unknown `X-Grant-Type` value | `400 Bad Request` |
+| Introspection endpoint unreachable / errored / unparseable | `503 Service Unavailable` |
+
+For diagnosis, the raw IdP/introspection error (error code + description) is
+logged server-side even though the client-facing message is intentionally
+coarse.
+
+## Environment variables
+
+### Core OIDC
+
+| Variable | Applies to | Notes |
+| --- | --- | --- |
+| `AUTH_PROVIDER` | all | `DISABLED` \| `OIDC+<issuer>` \| `OIDC_SAAS+<issuer>` |
+| `OIDC_CLIENT_ID` | OIDC | Superposition's own client id at the IdP |
+| `OIDC_CLIENT_SECRET` | OIDC | Client secret (plaintext or KMS ciphertext) |
+| `OIDC_REDIRECT_HOST` | OIDC | Base URL for the interactive login redirect |
+| `OIDC_ORG_ISSUER_ENDPOINT_FORMAT` | SaaS | Per-org issuer, with `<organisation>` |
+| `OIDC_ORG_TOKEN_ENDPOINT_FORMAT` | SaaS | Per-org token endpoint, with `<organisation>` |
+
+### API-token authentication (optional)
+
+**Required to enable the flow:** `OIDC_API_TOKEN_PREFIX` plus **at least one**
+validation mechanism — static tokens (`OIDC_API_STATIC_TOKENS`) and/or RFC 7662
+introspection (`OIDC_INTROSPECTION_AUTH_HEADER`). A prefix set with neither
+mechanism logs a warning and stays disabled. When both are set, a key is matched
+against static tokens first, then introspected.
+
+For **introspection under SaaS**, the per-org
+`OIDC_ORG_TOKEN_INTROSPECTION_URL_FORMAT` is also required (the per-org endpoint
+can't be discovered, and a per-org setup is the whole point of SaaS). The
+single/global endpoint URL is otherwise optional — when unset it is taken from
+the `introspection_endpoint` discovered in your provider's metadata.
+
+**Startup validation** (fail-fast — the misconfiguration surfaces at boot, not
+on the first request). A malformed `OIDC_API_STATIC_TOKENS` JSON fails startup.
+When **introspection** is enabled:
+
+- **Simple**: fails to start if no endpoint can be resolved — neither
+  `OIDC_TOKEN_INTROSPECTION_URL` nor a discovered `introspection_endpoint`.
+- **SaaS**: fails to start if `OIDC_ORG_TOKEN_INTROSPECTION_URL_FORMAT` is
+  missing. A **global-only** SaaS configuration is rejected — it contradicts the
+  per-org isolation model.
+
+(A **static-only** setup needs no introspection endpoint, so these endpoint
+checks don't apply.)
+
+| Variable | Applies to | Notes |
+| --- | --- | --- |
+| `OIDC_API_TOKEN_PREFIX` | OIDC / SaaS | Arbitrary, operator-chosen prefix that marks a bearer token as an API key (e.g. `apikey`). Only needs to be distinguishable from a JWT. **Required** to enable the flow. |
+| `OIDC_API_TOKEN_DELIMITER` | OIDC / SaaS | Optional separator between prefix and key (e.g. `_`). Defaults to `_`. |
+| `OIDC_API_STATIC_TOKENS` | OIDC / SaaS | KMS-encrypted (like `OIDC_CLIENT_SECRET`) JSON array of `{token, principal[, email, org]}`. Enables the static-token mechanism. In SaaS, `org` binds a token to an organisation; omit for global scope. |
+| `OIDC_INTROSPECTION_AUTH_HEADER` | OIDC / SaaS | Verbatim `Authorization` header Superposition sends to the endpoint (`Bearer <token>` or `Basic <base64>`). Secret — KMS-decrypted in non-dev, like `OIDC_CLIENT_SECRET`. Enables the introspection mechanism. |
+| `OIDC_TOKEN_INTROSPECTION_URL` | OIDC (Simple) / SaaS (global) | Explicit single (Simple) / global (SaaS `Login::Global`) endpoint. **Optional** — falls back to the discovered `introspection_endpoint`. Set it only when the IdP doesn't advertise one, or to override. |
+| `OIDC_ORG_TOKEN_INTROSPECTION_URL_FORMAT` | SaaS | Per-org endpoint, with `<organisation>`. Not discoverable. **Required** when introspection is enabled under SaaS (a global-only SaaS introspection config is rejected at startup). |
+
+The endpoint URL is provider-specific (`introspection_endpoint` in the
+provider's discovery document); for Keycloak it is
+`.../realms/{realm}/protocol/openid-connect/token/introspect`.
+
+Example (single-realm OIDC with API tokens enabled):
+
+```bash
+AUTH_PROVIDER=OIDC+https://issuer.example.com/realms/users
+OIDC_CLIENT_ID=superposition
+OIDC_CLIENT_SECRET='<client-secret-or-kms-ciphertext>'
+OIDC_REDIRECT_HOST=https://superposition.example.com
+
+# Optional API-token flow. Prefix + at least one mechanism (static and/or introspection).
+OIDC_API_TOKEN_PREFIX=apikey
+OIDC_API_TOKEN_DELIMITER=_
+OIDC_INTROSPECTION_AUTH_HEADER='Bearer <token>'   # or 'Basic <base64(id:secret)>'; KMS ciphertext in non-dev
+# Optional: omit to use the endpoint discovered from provider metadata.
+OIDC_TOKEN_INTROSPECTION_URL=https://tokens.example.com/introspect
+```
+
+Example (single-realm OIDC, **static tokens only** — no introspection endpoint):
+
+```bash
+AUTH_PROVIDER=OIDC+https://issuer.example.com/realms/users
+OIDC_CLIENT_ID=superposition
+OIDC_CLIENT_SECRET='<client-secret-or-kms-ciphertext>'
+OIDC_REDIRECT_HOST=https://superposition.example.com
+
+OIDC_API_TOKEN_PREFIX=apikey
+OIDC_API_TOKEN_DELIMITER=_
+# KMS ciphertext in non-dev; each token maps to a fixed principal.
+OIDC_API_STATIC_TOKENS='[{"token":"<key>","principal":"svc-ci","email":"ci@example.com"}]'
+```
+
+Example (SaaS with per-org API-token introspection):
+
+```bash
+AUTH_PROVIDER=OIDC_SAAS+https://issuer.example.com/realms/users
+OIDC_CLIENT_ID=superposition
+OIDC_CLIENT_SECRET='<client-secret-or-kms-ciphertext>'
+OIDC_REDIRECT_HOST=https://superposition.example.com
+OIDC_ORG_TOKEN_ENDPOINT_FORMAT='https://issuer.example.com/realms/<organisation>/protocol/openid-connect/token'
+OIDC_ORG_ISSUER_ENDPOINT_FORMAT='https://issuer.example.com/realms/<organisation>'
+
+OIDC_API_TOKEN_PREFIX=apikey
+OIDC_API_TOKEN_DELIMITER=_
+OIDC_INTROSPECTION_AUTH_HEADER='Bearer <token>'   # or 'Basic <base64(id:secret)>'; KMS ciphertext in non-dev
+OIDC_ORG_TOKEN_INTROSPECTION_URL_FORMAT='https://issuer.example.com/realms/<organisation>/protocol/openid-connect/token/introspect'
+# Global (Login::Global) endpoint is auto-discovered from provider metadata;
+# set OIDC_TOKEN_INTROSPECTION_URL only to override it.
+```
+
+## Design decisions & rationale
+
+- **No user storage.** Superposition delegates all identity to an IdP or an
+  external token service, staying stateless. Every other decision follows from
+  this.
+- **RFC 7662 for API tokens.** Choosing a standard (rather than a bespoke
+  contract) means external teams can often reuse an existing introspection
+  endpoint with zero custom code, and the response needs no Superposition-specific
+  claims.
+- **Static tokens as a no-infra alternative.** Not every deployment wants to
+  stand up (or point at) an introspection endpoint for a handful of machine
+  credentials. A KMS-encrypted list keeps the secrets in your secret manager
+  rather than a Superposition user store, is matched in constant time, and
+  — being checked before introspection — lets a fixed "master" key coexist with
+  dynamically introspected ones.
+- **Explicit grant selection (`X-Grant-Type`).** A `Basic` pair is ambiguous
+  between a user's password and a client's credentials. Rather than inferring
+  intent from the credential, the grant is stated in a header and unknown values
+  fail closed — auth intent is never guessed.
+- **Client credentials over ROPC for machines.** ROPC is deprecated and
+  IdP-dependent (Google rejects it). Client credentials is the correct M2M grant
+  and works wherever the IdP issues client credentials.
+- **Org-scoped validation in SaaS.** Machine credentials and API tokens are
+  validated against the organisation's own realm/endpoint, so a credential for
+  one tenant cannot authenticate against another.
+- **Positive classification.** Every token type is identified by an explicit
+  marker; anything unrecognised is rejected, not routed to a default validator.
+- **Caching keyed by hashed secrets.** Repeat requests avoid IdP round-trips,
+  rotation is an automatic miss, and plaintext secrets are never held in memory —
+  at the cost of a bounded revocation lag.
+
+## Reference introspection service
+
+A minimal reference implementation of an RFC 7662 introspection endpoint is
+provided under [`examples/token-introspection`](https://github.com/juspay/superposition/tree/main/examples/token-introspection)
+in the repository. It shows the exact request/response contract Superposition
+expects and can be used as a starting point for your own token-management
+service. It is illustrative only and not production-hardened.

--- a/docs/docs/self-hosting/environment-variables.md
+++ b/docs/docs/self-hosting/environment-variables.md
@@ -62,8 +62,9 @@ Superposition currently has two practical deployment modes:
 
 - `APP_ENV=PROD`: the app initializes AWS KMS and expects encrypted, base64 KMS
   ciphertext values for sensitive settings such as `DB_PASSWORD`,
-  `SUPERPOSITION_TOKEN`, `OIDC_CLIENT_SECRET`, `CASBIN_DB_PASSWORD`, and
-  `MASTER_ENCRYPTION_KEY`.
+  `SUPERPOSITION_TOKEN`, `OIDC_CLIENT_SECRET`, `OIDC_INTROSPECTION_AUTH_HEADER`
+  and `OIDC_API_STATIC_TOKENS` (when API-token auth is enabled),
+  `CASBIN_DB_PASSWORD`, and `MASTER_ENCRYPTION_KEY`.
 - `APP_ENV=DEV`: the app reads those values directly from environment variables.
   This is useful for local and non-AWS self-hosted deployments. If you use this
   mode outside local development, inject secrets from your platform secret
@@ -114,6 +115,40 @@ OIDC_REDIRECT_HOST=https://superposition.example.com
 OIDC_ORG_TOKEN_ENDPOINT_FORMAT='https://issuer.example.com/realms/<organisation>/protocol/openid-connect/token'
 OIDC_ORG_ISSUER_ENDPOINT_FORMAT='https://issuer.example.com/realms/<organisation>'
 ```
+
+Optional API-token authentication (OIDC only) is enabled with a prefix plus at
+least one validation mechanism: **static tokens** and/or **RFC 7662 token
+introspection**. When both are configured, a presented key is matched against
+static tokens first, then introspected.
+
+```bash
+OIDC_API_TOKEN_PREFIX=apikey                      # arbitrary, operator-chosen; marks a bearer token as an API key
+OIDC_API_TOKEN_DELIMITER=_                         # optional; separates prefix and key (defaults to "_")
+
+# Mechanism 1 — static tokens. KMS-encrypted (like OIDC_CLIENT_SECRET) JSON array;
+# each entry maps a token to a fixed principal. In SaaS, "org" binds a token to an
+# organisation; omit "org" for a global-scoped token. "email" is optional.
+OIDC_API_STATIC_TOKENS='[{"token":"<key>","principal":"svc-ci","org":"acme"}]'
+
+# Mechanism 2 — RFC 7662 introspection. Verbatim Authorization header sent to the
+# endpoint (Bearer or Basic). Secret — KMS-encrypted in non-dev.
+OIDC_INTROSPECTION_AUTH_HEADER='Bearer <token>'   # or 'Basic <base64(id:secret)>'
+
+# Introspection endpoint URLs are OPTIONAL — when unset, the endpoint is
+# discovered from provider metadata. Simple: single endpoint (optional).
+OIDC_TOKEN_INTROSPECTION_URL='https://issuer.example.com/realms/users/protocol/openid-connect/token/introspect'
+
+# SaaS OIDC: the per-org format is REQUIRED when introspection is enabled (a
+# global-only SaaS introspection config is rejected at startup); the global
+# (Login::Global) endpoint is discovered unless OIDC_TOKEN_INTROSPECTION_URL
+# overrides it.
+OIDC_ORG_TOKEN_INTROSPECTION_URL_FORMAT='https://issuer.example.com/realms/<organisation>/protocol/openid-connect/token/introspect'
+```
+
+For the complete authentication picture — all credential schemes (including
+`Basic` machine-to-machine access and API-key introspection), how they behave,
+caching, and error semantics — see the dedicated
+[Authentication](./authentication.md) page.
 
 ## Authorization
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -42,6 +42,10 @@ const sidebars: SidebarsConfig = {
                 },
                 {
                     type: "doc",
+                    id: "self-hosting/authentication",
+                },
+                {
+                    type: "doc",
                     id: "self-hosting/production",
                 },
                 {

--- a/examples/token-introspection/README.md
+++ b/examples/token-introspection/README.md
@@ -1,0 +1,83 @@
+# Reference token introspection service
+
+A minimal, **illustrative** [RFC 7662](https://datatracker.ietf.org/doc/html/rfc7662)
+OAuth 2.0 Token Introspection endpoint for Superposition's optional API-token
+authentication flow.
+
+Superposition takes the stance that it does **not** store users or manage
+tokens. For API-key access it forwards the key to an external introspection
+endpoint (this one) and builds a principal from the standard response. See the
+[Authentication docs](../../docs/docs/self-hosting/authentication.md) for the
+full flow.
+
+> This is a reference only — an in-memory key store, no persistence, no real
+> crypto. Use it to understand the contract, not in production.
+
+## Run
+
+```bash
+npm install
+INTROSPECTION_AUTH_TOKEN=my-caller-secret npm start
+# listening on :4000/introspect
+```
+
+## The contract
+
+**Request** (sent by Superposition):
+
+```http
+POST /introspect
+Authorization: <OIDC_INTROSPECTION_AUTH_HEADER, verbatim — this example expects "Bearer <token>">
+Content-Type: application/x-www-form-urlencoded
+
+token=<api_key>
+```
+
+**Response** — active token:
+
+```json
+{ "active": true, "sub": "svc-billing", "username": "svc-billing", "email": "svc-billing@example.com", "exp": 1893456000 }
+```
+
+**Response** — unknown / revoked / expired token:
+
+```json
+{ "active": false }
+```
+
+Superposition derives identity from `username` → `sub` → `email`, and uses `exp`
+to bound its cache. Any additional standard claims are ignored.
+
+## Try it
+
+```bash
+# Valid key
+curl -s -X POST http://localhost:4000/introspect \
+  -H "Authorization: Bearer my-caller-secret" \
+  -d token=live-abc123
+
+# Revoked key -> { "active": false }
+curl -s -X POST http://localhost:4000/introspect \
+  -H "Authorization: Bearer my-caller-secret" \
+  -d token=live-revoked
+```
+
+## Point Superposition at it
+
+```bash
+AUTH_PROVIDER=OIDC+https://issuer.example.com/realms/users
+# ... other OIDC vars ...
+OIDC_API_TOKEN_PREFIX=apikey
+OIDC_API_TOKEN_DELIMITER=_
+OIDC_INTROSPECTION_AUTH_HEADER='Bearer my-caller-secret'
+OIDC_TOKEN_INTROSPECTION_URL=http://localhost:4000/introspect
+```
+
+The prefix is arbitrary and operator-chosen — it only needs to be
+distinguishable from a JWT. A caller then authenticates with:
+
+```http
+Authorization: Bearer apikey_live-abc123
+```
+
+(`apikey` + `_` + the api key `live-abc123`.)

--- a/examples/token-introspection/package.json
+++ b/examples/token-introspection/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "superposition-token-introspection-example",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Reference RFC 7662 token introspection endpoint for Superposition API-token auth",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2"
+  }
+}

--- a/examples/token-introspection/server.js
+++ b/examples/token-introspection/server.js
@@ -1,0 +1,87 @@
+// Reference RFC 7662 (OAuth 2.0 Token Introspection) endpoint for Superposition's
+// optional API-token authentication flow.
+//
+// Superposition delegates API-key validation to an external service (it does not
+// store users or manage tokens itself). When a request arrives as
+// `Authorization: Bearer <prefix><delimiter><api_key>`, Superposition strips the
+// prefix and POSTs the key to this endpoint per RFC 7662, then builds a principal
+// from the standard response claims.
+//
+// This is an ILLUSTRATIVE reference only — an in-memory key store, no real
+// crypto, no persistence. It exists to show the exact request/response contract.
+//
+//   npm install && npm start
+//
+// Then, from Superposition's config:
+//   OIDC_TOKEN_INTROSPECTION_URL=http://localhost:4000/introspect
+//   OIDC_INTROSPECTION_AUTH_HEADER="Bearer <INTROSPECTION_AUTH_TOKEN below>"
+//   OIDC_API_TOKEN_PREFIX=apikey   (arbitrary, operator-chosen)
+//   OIDC_API_TOKEN_DELIMITER=_
+//
+// OIDC_INTROSPECTION_AUTH_HEADER is sent to this endpoint verbatim as the
+// Authorization header. This example expects the `Bearer <token>` form.
+
+const express = require("express");
+
+const app = express();
+// RFC 7662 requests are application/x-www-form-urlencoded.
+app.use(express.urlencoded({ extended: false }));
+
+// The bearer token Superposition presents (the value inside
+// OIDC_INTROSPECTION_AUTH_HEADER="Bearer <this>").
+// The introspection endpoint MUST be protected (RFC 7662 §2.1).
+const INTROSPECTION_AUTH_TOKEN =
+  process.env.INTROSPECTION_AUTH_TOKEN || "change-me-caller-secret";
+
+// A stand-in "token store". In a real service this is your API-key database.
+// Each entry maps an api_key -> the identity + expiry to report.
+const now = () => Math.floor(Date.now() / 1000);
+const TOKENS = {
+  // A valid, active key.
+  "live-abc123": {
+    active: true,
+    sub: "svc-billing",
+    username: "svc-billing",
+    email: "svc-billing@example.com",
+    exp: now() + 3600, // seconds since the Unix epoch
+  },
+  // A revoked key — reported as inactive.
+  "live-revoked": { active: false },
+};
+
+// Verify the caller (Superposition) is authorized to introspect.
+function callerAuthorized(req) {
+  const auth = req.get("authorization") || "";
+  const [scheme, value] = auth.split(" ");
+  return scheme === "Bearer" && value === INTROSPECTION_AUTH_TOKEN;
+}
+
+app.post("/introspect", (req, res) => {
+  if (!callerAuthorized(req)) {
+    // The CALLER is unauthorized (not the token being introspected).
+    return res.status(401).json({ error: "invalid_client" });
+  }
+
+  const token = req.body.token;
+  const entry = token && TOKENS[token];
+
+  // RFC 7662: an unknown/expired/revoked token is simply `{ "active": false }`.
+  if (!entry || !entry.active || (entry.exp && entry.exp < now())) {
+    return res.json({ active: false });
+  }
+
+  // Active: return the standard claims. Superposition reads username/sub/email
+  // for identity and exp to bound its cache.
+  return res.json({
+    active: true,
+    sub: entry.sub,
+    username: entry.username,
+    email: entry.email,
+    exp: entry.exp,
+  });
+});
+
+const port = process.env.PORT || 4000;
+app.listen(port, () => {
+  console.log(`introspection endpoint listening on :${port}/introspect`);
+});


### PR DESCRIPTION
## Change log
1. Try to refresh on every token exchange with OIDC IdP in case the exchange fails and use the refreshed info to re-try token exchange - refresh happens only during the call.

Note: The refresh would keep happening on every fail token exchange if a successful refresh was not achieved. token exchange re-try is only done once, re-try failure will lead to a terminal state in the user login experience avoiding the infinite redirects.

2. Reduce `auth cookie` to only contain only `id_token`
3. Add support of using `id_token` as `Bearer token` value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added direct token-based authentication support across enabled and disabled modes.
  * Improved OIDC sign-in by refreshing provider metadata and reusing refreshed client configuration.
* **Bug Fixes**
  * Prevents login failures caused by stale signing keys by retrying ID token verification once after refresh.
  * Returns a clear “Sign-in failed” unauthorized response when verification still fails.
* **Refactor**
  * Streamlined authentication middleware flow for consistent handling of login type and responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->