### PR TITLE
docs: add Vendure custom fields blog

### DIFF
--- a/docs/blog/2026-07-07-context-aware-vendure-custom-fields.md
+++ b/docs/blog/2026-07-07-context-aware-vendure-custom-fields.md
@@ -1,0 +1,150 @@
+---
+slug: context-aware-vendure-custom-fields
+title: Context-aware Vendure custom fields with Superposition
+description: How Superposition adds channel aware resolved values to Vendure custom fields.
+tags: [superposition, vendure, commerce, configuration]
+---
+
+import AnimationSlide from '@site/src/components/AnimationSlide';
+import { VendureOwnershipFlow } from '@site/src/components/animations';
+
+Commerce data is rarely as global as it first appears.
+
+An online store often needs extra product information: a price band, a fulfilment promise, a merchandising label, or a marketplace-specific badge.
+In Vendure, custom fields are a natural place to store this data because they let teams extend products and product variants directly.
+
+But some values are "default" values.
+
+The effective value can change by channel, currency, market, customer group, product, variant, or a rollout state.
+That is where things usually start to get messy: more custom fields, more conditional code, more duplicated entities, more operational risk.
+
+The [Superposition Vendure plugin](https://github.com/juspay/vendure-plugin-superposition) takes a cleaner approach:
+
+```text
+Vendure owns the stored fallback.
+Superposition owns the context-aware effective value
+```
+
+<AnimationSlide width="100%" height={420} mode="auto" loop={false}>
+    <VendureOwnershipFlow />
+</AnimationSlide>
+
+Vendure remains the system of record for the catalog. Superposition adds a runtime configuration layer that can resolve the right value for the current business context.
+
+<!-- truncate -->
+
+## Why Superposition fits this problem
+
+Superposition starts from a simple idea: configuration should be resolved in context. Instead of spreading rules across environment variables, hardcoded conditionals , or one-off feature flags, it lets teams define typed defaults and resolve the right value for each context in a cascading way.
+
+The important part is that the catalog does not need to become more complex just because the business rules become more specific. Vendure keeps the base product data understandable, and Superposition resolves the effective value at read time.
+
+## A concrete example
+
+Suppose a merchant wants to store a `bulkPrice` for each product variant. In Vendure, this can be added as a custom field on `ProductVariant`.
+
+```ts
+SuperpositionPlugin.init({
+    entities: {
+        ProductVariant: [{ name: 'bulkPrice', type: 'int', nullable: true }],
+    },
+});
+```
+
+Vendure stores the fallback value:
+
+```text
+ProductVariant.customFields.bulkPrice = 800
+```
+
+That value is still useful. It is the base price that applies when no more specific rule is present.
+
+Now suppose the same merchant wants a different bulk price for the B2B channel in INR. That value does not need to become another Vendure custom field. It can be stored as a contextual override in Superposition:
+
+```text
+channel = b2b
+currency = INR
+entity = product_variant
+entity_id = 1
+bulkPrice = 1200
+```
+
+At read time, the plugin builds a context from the request and the entity being resolved. If the context matches the override, Superposition returns `1200`. If it does not, the value falls back to the Vendure custom field value, `800`.
+
+The storefront can ask for both values:
+
+```graphql
+query {
+    productVariant(id: "1") {
+        id
+        customFields {
+            bulkPrice
+        }
+        resolvedBulkPrice
+    }
+}
+```
+
+The distinction is intentional. `customFields.bulkPrice` is the value stored in Vendure. `resolvedBulkPrice` is the value resolved for the current context.
+
+For the default context, the resolved value is `800`. For the B2B INR context, the resolved value is `1200`.
+
+## Why not replace the custom field?
+
+The plugin does not overwrite Vendure's nested `customFields.bulkPrice` field. That field remains the persisted fallback value. This is important because merchants and developers already expect Vendure custom fields to represent data stored in Vendure.
+
+Instead, the plugin exposes a separate resolved field:
+
+```text
+customFields.bulkPrice = stored fallback
+resolvedBulkPrice = context-aware value
+```
+
+This keeps ownership clear. Vendure remains responsible for the base catalog value, while Superposition is responsible for resolving the effective value for a request.
+
+## How it works
+
+The integration follows the same shape as the example.
+
+First, the plugin registers the configured custom fields with Vendure. That lets Vendure keep storing the fallback value on the entity, using the normal custom-field mechanism.
+
+Second, the plugin adds resolved fields to the GraphQL API. For a custom field named `bulkPrice`, the API can expose a field such as `resolvedBulkPrice`.
+
+Third, when a resolved field is requested, the plugin builds a Superposition context from the current request and entity. That context can include values such as the active channel, currency, entity type, and entity id.
+
+```text
+channel = current channel
+currency = current currency
+entity = product_variant
+entity_id = current variant id
+```
+
+Superposition then evaluates that context against the configured overrides and returns the effective value. If no override applies, the plugin returns the Vendure fallback value.
+
+## What this gives teams
+
+The most immediate benefit is that teams avoid turning every contextual rule into a new catalog field. A merchant does not need separate fields like `b2bBulkPrice`, `inrBulkPrice`, or `enterpriseBulkPrice`. The catalog can keep one field, `bulkPrice`, while Superposition decides which value applies for the current request.
+
+It also keeps operational changes out of application code. A price band, label, or availability note can change for a market or channel without adding another conditional branch to the storefront or redeploying the Vendure application.
+
+And because Superposition treats these values as typed configuration, teams get a cleaner place to manage overrides, review changes, and reason about why a request received a particular value.
+
+## Dashboard behavior
+
+The Dashboard extension shows a read-only Superposition values panel on product and product-variant detail pages. The goal is to make the relationship visible: the merchant can see the value stored in Vendure and the value resolved by Superposition for the current context.
+
+It does not replace Vendure's built-in custom-field editor. Editing the fallback value in Vendure and editing a contextual override in Superposition are different operations, so the plugin keeps those responsibilities separate.
+
+## A clean extension point
+
+This leaves room for richer workflows without changing the meaning of the existing fields. For example, an override editor can be added later to create or update Superposition values from the Dashboard. That editor would still be separate from Vendure's built-in custom-field form, because it would be editing a contextual override rather than the stored fallback.
+
+The core idea stays the same: Vendure owns the catalog value, and Superposition resolves the effective value for the context.
+
+## Closing thoughts
+
+The plugin is intentionally small in concept. It does not replace Vendure's catalog model, and it does not ask teams to move product data out of Vendure. It adds a context-aware layer around the places where commerce data naturally varies.
+
+That makes custom fields more useful in real-world commerce setups, where the right value often depends on channel, currency, market, customer segment, or rollout state.
+
+You can find the plugin and usage examples in the [juspay/vendure-plugin-superposition](https://github.com/juspay/vendure-plugin-superposition) repository.

--- a/docs/src/components/animations/VendureOwnershipFlow/index.tsx
+++ b/docs/src/components/animations/VendureOwnershipFlow/index.tsx
@@ -1,0 +1,249 @@
+import React, { useCallback, useEffect, useRef } from "react";
+import { animate, stagger } from "animejs";
+import { useAnimationSlide } from "@site/src/hooks/useAnimationSlide";
+import styles from "./styles.module.css";
+
+function DatabaseIcon() {
+    return (
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+            <ellipse cx="12" cy="5" rx="7" ry="3" />
+            <path d="M5 5v10c0 1.7 3.1 3 7 3s7-1.3 7-3V5" />
+            <path d="M5 10c0 1.7 3.1 3 7 3s7-1.3 7-3" />
+        </svg>
+    );
+}
+
+function MagicIcon() {
+    return (
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M5 19 17.5 6.5" />
+            <path d="m14.5 4 5.5 5.5" />
+            <path d="m13.4 10.6-4-4" />
+            <path d="M6 4v3" />
+            <path d="M4.5 5.5h3" />
+            <path d="M19 14v3" />
+            <path d="M17.5 15.5h3" />
+        </svg>
+    );
+}
+
+function TagIcon() {
+    return (
+        <svg viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M4 12.4 12.4 4H20v7.6L11.6 20 4 12.4Z" />
+            <circle cx="16.8" cy="7.2" r="1.4" />
+            <path d="m13.8 14.4 2 2 4-4.2" />
+        </svg>
+    );
+}
+
+export default function VendureOwnershipFlow() {
+    const { isPlaying, onComplete } = useAnimationSlide();
+    const diagramRef = useRef<HTMLDivElement>(null);
+    const outputValueRef = useRef<HTMLSpanElement>(null);
+    const timeoutRefs = useRef<ReturnType<typeof setTimeout>[]>([]);
+
+    const clearAllTimeouts = useCallback(() => {
+        timeoutRefs.current.forEach(clearTimeout);
+        timeoutRefs.current = [];
+    }, []);
+
+    const resetAnimation = useCallback(() => {
+        clearAllTimeouts();
+
+        const root = diagramRef.current;
+        if (!root) return;
+
+        root.querySelectorAll<HTMLElement>("[data-flow-node]").forEach(
+            (node) => {
+                node.style.opacity = "0";
+                node.style.transform = "translateY(18px)";
+            },
+        );
+
+        root.querySelectorAll<HTMLElement>("[data-engine-node]").forEach(
+            (node) => {
+                node.style.opacity = "0";
+                node.style.transform = "translateY(18px)";
+            },
+        );
+
+        root.querySelectorAll<HTMLElement>("[data-result-node]").forEach(
+            (node) => {
+                node.style.opacity = "0";
+                node.style.transform = "translateY(18px) scale(0.96)";
+            },
+        );
+
+        root.querySelectorAll<HTMLElement>("[data-table-line]").forEach(
+            (node) => {
+                node.style.opacity = "0";
+                node.style.transform = "translateY(10px)";
+            },
+        );
+
+        if (outputValueRef.current) {
+            outputValueRef.current.textContent = "800";
+        }
+    }, [clearAllTimeouts]);
+
+    useEffect(() => {
+        if (!isPlaying) {
+            resetAnimation();
+            return;
+        }
+
+        const root = diagramRef.current;
+        if (!root) return;
+
+        const addTimeout = (fn: () => void, delay: number) => {
+            const id = setTimeout(fn, delay);
+            timeoutRefs.current.push(id);
+            return id;
+        };
+
+        animate(root.querySelector(`.${styles.sourceCard}`), {
+            opacity: 1,
+            translateY: 0,
+            duration: 900,
+            ease: "outExpo",
+        });
+
+        addTimeout(() => {
+            animate(root.querySelectorAll("[data-table-line]"), {
+                opacity: 1,
+                translateY: 0,
+                duration: 760,
+                delay: stagger(170),
+                ease: "outExpo",
+            });
+        }, 420);
+
+        addTimeout(() => {
+            animate(root.querySelector(`.${styles.engineCard}`), {
+                opacity: 1,
+                translateY: 0,
+                duration: 1050,
+                ease: "outExpo",
+            });
+        }, 1280);
+
+        addTimeout(() => {
+            if (outputValueRef.current) {
+                outputValueRef.current.textContent = "1200";
+            }
+
+            animate(root.querySelector(`.${styles.resultCard}`), {
+                opacity: 1,
+                translateY: 0,
+                scale: [0.96, 1],
+                duration: 1100,
+                ease: "outExpo",
+            });
+        }, 2260);
+
+        addTimeout(() => {
+            if (onComplete) onComplete();
+        }, 3700);
+
+        return () => clearAllTimeouts();
+    }, [clearAllTimeouts, isPlaying, onComplete, resetAnimation]);
+
+    return (
+        <div
+            ref={diagramRef}
+            className={styles.figure}
+            aria-label="Vendure catalog value, Superposition condition and override, and storefront result"
+        >
+            <div className={styles.topGrid}>
+                <section
+                    className={`${styles.card} ${styles.sourceCard}`}
+                    data-flow-node
+                >
+                    <span className={`${styles.eyebrow} ${styles.vendureTone}`}>
+                        Vendure (Source of Truth)
+                    </span>
+
+                    <div className={styles.cardTitle}>
+                        <span
+                            className={`${styles.iconBubble} ${styles.databaseBubble}`}
+                        >
+                            <DatabaseIcon />
+                        </span>
+                        <strong>Catalog Database</strong>
+                    </div>
+
+                    <div className={styles.fieldTable}>
+                        <div className={styles.tableHeader} data-table-line>
+                            <span>Field</span>
+                            <span>Value</span>
+                        </div>
+                        <div className={styles.tableRow} data-table-line>
+                            <span>customFields.bulkPrice</span>
+                            <span>800</span>
+                        </div>
+                    </div>
+                </section>
+
+                <section
+                    className={`${styles.card} ${styles.engineCard}`}
+                    data-engine-node
+                >
+                    <div className={styles.engineHeading}>
+                        <span
+                            className={`${styles.iconBubble} ${styles.magicBubble}`}
+                        >
+                            <MagicIcon />
+                        </span>
+                        <span
+                            className={`${styles.eyebrow} ${styles.engineTone}`}
+                        >
+                            Superposition
+                        </span>
+                    </div>
+
+                    <div className={styles.engineRule}>
+                        <div className={styles.ruleRow}>
+                            <span className={styles.ruleLabel}>Condition</span>
+                            <span className={styles.ruleCodeList}>
+                                <code>channel = b2b</code>
+                                <code>currency = INR</code>
+                            </span>
+                        </div>
+
+                        <div className={styles.ruleRow}>
+                            <span className={styles.ruleLabel}>Override</span>
+                            <span className={styles.ruleCodeList}>
+                                <code className={styles.overrideCode}>
+                                    bulkPrice = <strong>1200</strong>
+                                </code>
+                            </span>
+                        </div>
+                    </div>
+                </section>
+            </div>
+
+            <section
+                className={`${styles.resultCard}`}
+                data-result-node
+                aria-label="Storefront result"
+            >
+                <span className={`${styles.eyebrow} ${styles.engineTone}`}>
+                    Storefront result
+                </span>
+
+                <div className={styles.resultBody}>
+                    <span className={styles.resultIcon}>
+                        <TagIcon />
+                    </span>
+                    <strong>
+                        resolvedBulkPrice ={" "}
+                        <span ref={outputValueRef} className={styles.outputValue}>
+                            800
+                        </span>
+                    </strong>
+                </div>
+            </section>
+        </div>
+    );
+}

--- a/docs/src/components/animations/VendureOwnershipFlow/styles.module.css
+++ b/docs/src/components/animations/VendureOwnershipFlow/styles.module.css
@@ -1,0 +1,536 @@
+.figure {
+    position: relative;
+    display: grid;
+    grid-template-rows: minmax(0, 1fr) auto;
+    gap: 0.75rem;
+    height: 100%;
+    min-height: 360px;
+    padding: clamp(0.85rem, 2vw, 1.15rem);
+    overflow: hidden;
+    background:
+        radial-gradient(
+            circle at 12% 10%,
+            oklch(91% 0.055 287 / 0.42),
+            transparent 28%
+        ),
+        radial-gradient(
+            circle at 84% 14%,
+            oklch(91% 0.06 155 / 0.42),
+            transparent 30%
+        ),
+        linear-gradient(145deg, oklch(99% 0.006 250), oklch(97% 0.011 195));
+    color: oklch(23% 0.026 247);
+}
+
+[data-theme="dark"] .figure {
+    background:
+        radial-gradient(
+            circle at 12% 10%,
+            oklch(36% 0.095 287 / 0.34),
+            transparent 30%
+        ),
+        radial-gradient(
+            circle at 84% 14%,
+            oklch(38% 0.095 155 / 0.3),
+            transparent 32%
+        ),
+        linear-gradient(145deg, oklch(18% 0.025 250), oklch(16% 0.023 190));
+    color: oklch(93% 0.017 240);
+}
+
+.topGrid {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    gap: clamp(0.7rem, 1.6vw, 1rem);
+    align-items: stretch;
+    min-height: 0;
+}
+
+.card,
+.contextPanel,
+.resultCard {
+    min-width: 0;
+    border: 1px solid oklch(78% 0.038 250 / 0.62);
+    border-radius: 8px;
+    background: oklch(99% 0.005 245 / 0.94);
+    box-shadow: 0 16px 34px oklch(34% 0.035 245 / 0.1);
+}
+
+[data-theme="dark"] .card,
+[data-theme="dark"] .contextPanel,
+[data-theme="dark"] .resultCard {
+    border-color: oklch(74% 0.035 240 / 0.2);
+    background: oklch(22% 0.025 242 / 0.9);
+    box-shadow: 0 20px 40px oklch(8% 0.018 245 / 0.34);
+}
+
+.card,
+.contextPanel {
+    position: relative;
+    display: grid;
+    align-content: center;
+    gap: 0.72rem;
+    min-height: 172px;
+    padding: clamp(0.78rem, 1.35vw, 1rem);
+}
+
+.sourceCard {
+    border-color: oklch(78% 0.11 292 / 0.58);
+    background:
+        linear-gradient(
+            180deg,
+            oklch(99% 0.006 287 / 0.98),
+            oklch(98% 0.018 287 / 0.88)
+        );
+}
+
+.engineCard {
+    gap: 0.6rem;
+    border-color: oklch(75% 0.1 156 / 0.62);
+    background:
+        linear-gradient(
+            180deg,
+            oklch(99% 0.006 156 / 0.98),
+            oklch(98% 0.018 156 / 0.88)
+        );
+}
+
+.contextPanel {
+    border-color: oklch(78% 0.055 220 / 0.56);
+    background: oklch(99% 0.006 210 / 0.92);
+}
+
+[data-theme="dark"] .sourceCard {
+    border-color: oklch(73% 0.12 292 / 0.38);
+    background:
+        linear-gradient(
+            180deg,
+            oklch(24% 0.035 287 / 0.92),
+            oklch(21% 0.04 287 / 0.82)
+        );
+}
+
+[data-theme="dark"] .engineCard {
+    border-color: oklch(74% 0.1 156 / 0.36);
+    background:
+        linear-gradient(
+            180deg,
+            oklch(23% 0.035 156 / 0.92),
+            oklch(20% 0.035 156 / 0.82)
+        );
+}
+
+[data-theme="dark"] .contextPanel {
+    border-color: oklch(73% 0.055 220 / 0.24);
+    background: oklch(21% 0.024 220 / 0.88);
+}
+
+.eyebrow {
+    font-size: clamp(0.62rem, 0.95vw, 0.72rem);
+    font-weight: 800;
+    letter-spacing: 0.1em;
+    line-height: 1.2;
+    text-transform: uppercase;
+}
+
+.vendureTone {
+    color: oklch(39% 0.145 292);
+}
+
+.contextTitle {
+    color: oklch(43% 0.058 238);
+    text-align: center;
+}
+
+.engineTone {
+    color: oklch(42% 0.12 156);
+}
+
+[data-theme="dark"] .vendureTone {
+    color: oklch(79% 0.12 292);
+}
+
+[data-theme="dark"] .contextTitle {
+    color: oklch(80% 0.06 238);
+}
+
+[data-theme="dark"] .engineTone {
+    color: oklch(78% 0.12 156);
+}
+
+.cardTitle {
+    display: flex;
+    gap: 0.64rem;
+    align-items: center;
+}
+
+.cardTitle strong {
+    min-width: 0;
+    font-size: clamp(1rem, 1.5vw, 1.22rem);
+    line-height: 1.1;
+}
+
+.iconBubble,
+.contextIcon,
+.resultIcon {
+    display: inline-grid;
+    flex: 0 0 auto;
+    place-items: center;
+    border-radius: 999px;
+}
+
+.iconBubble {
+    width: clamp(2.1rem, 3vw, 2.55rem);
+    height: clamp(2.1rem, 3vw, 2.55rem);
+}
+
+.iconBubble svg,
+.contextIcon svg,
+.resultIcon svg {
+    width: 1.32rem;
+    height: 1.32rem;
+    overflow: visible;
+    fill: none;
+    stroke: currentColor;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    stroke-width: 1.9;
+}
+
+.databaseBubble {
+    color: oklch(51% 0.18 292);
+    background: oklch(94% 0.045 292);
+}
+
+.magicBubble,
+.contextIcon {
+    color: oklch(46% 0.14 156);
+    background: oklch(93% 0.043 156);
+}
+
+[data-theme="dark"] .databaseBubble {
+    color: oklch(80% 0.14 292);
+    background: oklch(33% 0.09 292 / 0.5);
+}
+
+[data-theme="dark"] .magicBubble,
+[data-theme="dark"] .contextIcon {
+    color: oklch(80% 0.12 156);
+    background: oklch(31% 0.075 156 / 0.5);
+}
+
+.fieldTable {
+    display: grid;
+    overflow: hidden;
+    border: 1px solid oklch(82% 0.08 292 / 0.62);
+    border-radius: 8px;
+    background: oklch(99% 0.004 287 / 0.88);
+}
+
+[data-theme="dark"] .fieldTable {
+    border-color: oklch(73% 0.09 292 / 0.28);
+    background: oklch(16% 0.025 287 / 0.52);
+}
+
+.tableHeader,
+.tableRow {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) 54px;
+}
+
+.tableHeader span,
+.tableRow span {
+    min-width: 0;
+    overflow: hidden;
+    padding: 0.46rem 0.54rem;
+}
+
+.tableHeader span + span,
+.tableRow span + span {
+    border-left: 1px solid oklch(82% 0.08 292 / 0.5);
+}
+
+[data-theme="dark"] .tableHeader span + span,
+[data-theme="dark"] .tableRow span + span {
+    border-left-color: oklch(73% 0.09 292 / 0.24);
+}
+
+.tableHeader {
+    border-bottom: 1px solid oklch(82% 0.08 292 / 0.5);
+    color: oklch(41% 0.12 292);
+    font-size: 0.75rem;
+    font-weight: 800;
+}
+
+.tableHeader span {
+    white-space: nowrap;
+}
+
+[data-theme="dark"] .tableHeader {
+    border-bottom-color: oklch(73% 0.09 292 / 0.24);
+    color: oklch(81% 0.1 292);
+}
+
+.tableRow {
+    color: oklch(25% 0.026 247);
+}
+
+.tableRow span:first-child {
+    font-family:
+        ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+        "Liberation Mono", monospace;
+    font-size: clamp(0.58rem, 0.74vw, 0.66rem);
+    overflow-wrap: normal;
+    white-space: nowrap;
+}
+
+.tableRow span:last-child {
+    font-size: clamp(0.68rem, 0.95vw, 0.8rem);
+    font-weight: 800;
+    text-align: center;
+}
+
+[data-theme="dark"] .tableRow {
+    color: oklch(91% 0.017 240);
+}
+
+.contextChips {
+    display: grid;
+    gap: 0.5rem;
+    min-width: 0;
+}
+
+.contextChip {
+    display: grid;
+    grid-template-columns: auto max-content max-content;
+    min-width: 0;
+    width: 100%;
+    box-sizing: border-box;
+    align-items: center;
+    justify-content: start;
+    column-gap: 0.4rem;
+    overflow: hidden;
+    border: 1px solid oklch(78% 0.075 156 / 0.52);
+    border-radius: 8px;
+    padding: 0.48rem 0.5rem;
+    background: oklch(97% 0.023 156 / 0.72);
+}
+
+.contextIcon {
+    width: 1.8rem;
+    height: 1.8rem;
+}
+
+.contextChip strong {
+    color: oklch(39% 0.12 156);
+    font-size: clamp(0.68rem, 0.88vw, 0.8rem);
+    line-height: 1.1;
+    white-space: nowrap;
+}
+
+.contextChip code {
+    min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
+    border-radius: 6px;
+    padding: 0.16rem 0.3rem;
+    color: oklch(26% 0.03 238);
+    background: oklch(99% 0.004 210 / 0.8);
+    font-size: clamp(0.68rem, 0.9vw, 0.74rem);
+    font-weight: 800;
+    overflow-wrap: anywhere;
+    white-space: normal;
+}
+
+[data-theme="dark"] .contextChip {
+    border-color: oklch(72% 0.09 155 / 0.32);
+    background: oklch(25% 0.055 155 / 0.4);
+}
+
+[data-theme="dark"] .contextChip strong {
+    color: oklch(80% 0.12 156);
+}
+
+[data-theme="dark"] .contextChip code {
+    color: oklch(92% 0.016 240);
+    background: oklch(16% 0.024 220 / 0.72);
+}
+
+.engineHeading {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.engineHeading .iconBubble {
+    width: 1.95rem;
+    height: 1.95rem;
+}
+
+.engineRule {
+    display: grid;
+    gap: 0.44rem;
+    min-width: 0;
+}
+
+.ruleRow {
+    display: grid;
+    grid-template-columns: 4.7rem minmax(0, 1fr);
+    gap: 0.42rem;
+    align-items: center;
+    min-width: 0;
+    padding: 0.42rem 0.48rem;
+    border: 1px solid oklch(79% 0.1 156 / 0.5);
+    border-radius: 8px;
+    background: oklch(96% 0.031 156 / 0.64);
+}
+
+.ruleLabel {
+    color: oklch(43% 0.11 156);
+    font-size: clamp(0.58rem, 0.78vw, 0.68rem);
+    font-weight: 800;
+    letter-spacing: 0.06em;
+    line-height: 1;
+    text-transform: uppercase;
+    white-space: nowrap;
+}
+
+.ruleCodeList {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.28rem;
+    min-width: 0;
+}
+
+.ruleCodeList code {
+    min-width: 0;
+    max-width: 100%;
+    box-sizing: border-box;
+    border-radius: 6px;
+    padding: 0.16rem 0.3rem;
+    color: oklch(27% 0.036 238);
+    background: oklch(99% 0.005 160 / 0.86);
+    font-family:
+        ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+        "Liberation Mono", monospace;
+    font-size: clamp(0.58rem, 0.82vw, 0.68rem);
+    line-height: 1.1;
+    overflow-wrap: anywhere;
+    white-space: normal;
+}
+
+.overrideCode {
+    color: oklch(41% 0.12 156);
+}
+
+.overrideCode strong {
+    font-weight: 800;
+}
+
+[data-theme="dark"] .ruleRow {
+    border-color: oklch(74% 0.1 156 / 0.28);
+    background: oklch(18% 0.035 156 / 0.5);
+}
+
+[data-theme="dark"] .ruleLabel {
+    color: oklch(81% 0.12 156);
+}
+
+[data-theme="dark"] .ruleCodeList code {
+    color: oklch(92% 0.016 240);
+    background: oklch(16% 0.024 220 / 0.72);
+}
+
+.resultCard {
+    display: grid;
+    justify-self: center;
+    justify-items: center;
+    width: min(100%, 520px);
+    min-height: 78px;
+    padding: 0.72rem 1rem;
+    border-color: oklch(75% 0.1 156 / 0.62);
+    background: linear-gradient(180deg, oklch(99% 0.007 156), oklch(97% 0.022 156));
+    text-align: center;
+}
+
+[data-theme="dark"] .resultCard {
+    border-color: oklch(74% 0.1 156 / 0.34);
+    background: linear-gradient(180deg, oklch(22% 0.035 156), oklch(18% 0.033 156));
+}
+
+.resultBody {
+    display: flex;
+    gap: 0.64rem;
+    align-items: center;
+    justify-content: center;
+    margin-top: 0.28rem;
+}
+
+.resultIcon {
+    width: 2.15rem;
+    height: 2.15rem;
+    color: oklch(47% 0.13 156);
+}
+
+.resultIcon svg {
+    width: 100%;
+    height: 100%;
+    stroke-width: 1.55;
+}
+
+.resultBody strong {
+    min-width: 0;
+    color: oklch(23% 0.026 247);
+    font-size: clamp(1rem, 2vw, 1.32rem);
+    line-height: 1.08;
+}
+
+[data-theme="dark"] .resultBody strong {
+    color: oklch(94% 0.017 240);
+}
+
+.outputValue {
+    color: oklch(45% 0.14 156);
+}
+
+[data-theme="dark"] .outputValue {
+    color: oklch(79% 0.14 156);
+}
+
+@media (max-width: 860px) {
+    .figure {
+        grid-template-rows: auto auto;
+        min-height: 560px;
+        padding: 0.85rem;
+    }
+
+    .topGrid {
+        grid-template-columns: 1fr;
+        gap: 0.7rem;
+    }
+
+    .card,
+    .contextPanel {
+        min-height: auto;
+    }
+}
+
+@media (max-width: 560px) {
+    .figure {
+        min-height: 600px;
+    }
+
+    .cardTitle,
+    .resultBody {
+        align-items: flex-start;
+    }
+
+    .resultBody strong {
+        text-align: left;
+    }
+
+    .resultCard {
+        justify-items: start;
+        text-align: left;
+    }
+}


### PR DESCRIPTION
## Vendure Blog
Added a Vendure custom fields blog post and a supporting animation that shows Vendure as the stored fallback source and Superposition as the condition + override layer used to produce the resolved storefront value.

## Environment variable changes
None.

## Pre-deployment activity
None.

## Post-deployment activity
Verify the published docs page renders correctly.

## API changes
None.

## Possible Issues in the future
The animation is documentation-only, but layout may need minor tuning if the blog theme, typography, or embedded animation container dimensions change later.