### PR TITLE
chore: Reroute docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -17,10 +17,10 @@ const config: Config = {
     },
 
     // Set the production url of your site here
-    url: "https://juspay.io/",
+    url: "https://superposition.juspay.io",
     // Set the /<baseUrl>/ pathname under which your site is served
     // For GitHub pages deployment, it is often '/<projectName>/'
-    baseUrl: "/superposition/",
+    baseUrl: "/",
 
     // GitHub pages deployment config.
     organizationName: "juspay",


### PR DESCRIPTION
## Problem
Docusaurus routing adds `/superposition` prefix to all pages which blocks proxying through our domain

## Solution
Update configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation site URL and base path for deployment at its new standalone address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->