### PR TITLE
feat: add retry for lock in frontend

### DIFF
--- a/crates/frontend/src/api.rs
+++ b/crates/frontend/src/api.rs
@@ -23,7 +23,8 @@ use superposition_types::{
 };
 
 use crate::utils::{
-    construct_request_headers, parse_json_response, request, use_host_server,
+    construct_request_headers, parse_json_response, request,
+    request_with_workspace_lock_retry, use_host_server,
 };
 
 pub mod casbin {
@@ -386,7 +387,7 @@ pub mod dimensions {
         let host = use_host_server();
         let url = format!("{host}/dimension");
 
-        let response = request(
+        let response = request_with_workspace_lock_retry(
             url,
             reqwest::Method::POST,
             Some(payload),
@@ -409,7 +410,7 @@ pub mod dimensions {
         let host = use_host_server();
         let url = format!("{host}/dimension/{dimension_name}");
 
-        let response = request(
+        let response = request_with_workspace_lock_retry(
             url,
             reqwest::Method::PATCH,
             Some(payload),
@@ -431,7 +432,7 @@ pub mod dimensions {
         let host = use_host_server();
         let url = format!("{host}/dimension/{name}");
 
-        request(
+        request_with_workspace_lock_retry(
             url,
             reqwest::Method::DELETE,
             None::<()>,
@@ -454,7 +455,7 @@ pub async fn delete_context(
     let host = use_host_server();
     let url = format!("{}/context/{}", host, context_id);
 
-    request(
+    request_with_workspace_lock_retry(
         url,
         reqwest::Method::DELETE,
         None::<()>,
@@ -644,7 +645,7 @@ pub mod default_configs {
         let host = use_host_server();
         let url = format!("{host}/default-config/{key}");
 
-        request(
+        request_with_workspace_lock_retry(
             url,
             reqwest::Method::DELETE,
             None::<()>,
@@ -859,7 +860,7 @@ pub async fn create_webhook(
     let host = use_host_server();
     let url = format!("{host}/webhook");
 
-    let response = request(
+    let response = request_with_workspace_lock_retry(
         url,
         reqwest::Method::POST,
         Some(payload),
@@ -879,7 +880,7 @@ pub async fn update_webhook(
     let host = use_host_server();
     let url = format!("{host}/webhook/{webhook_name}");
 
-    let response = request(
+    let response = request_with_workspace_lock_retry(
         url,
         reqwest::Method::PATCH,
         Some(payload),
@@ -917,7 +918,7 @@ pub async fn delete_webhooks(
     let host = use_host_server();
     let url = format!("{host}/webhook/{name}");
 
-    request(
+    request_with_workspace_lock_retry(
         url,
         reqwest::Method::DELETE,
         None::<()>,
@@ -1195,7 +1196,7 @@ pub mod variables {
         let host = use_host_server();
         let url = format!("{host}/variables");
 
-        let response = request(
+        let response = request_with_workspace_lock_retry(
             url,
             reqwest::Method::POST,
             Some(payload),
@@ -1240,7 +1241,7 @@ pub mod variables {
         let host = use_host_server();
         let url = format!("{host}/variables/{variable_name}");
 
-        let response = request(
+        let response = request_with_workspace_lock_retry(
             url,
             reqwest::Method::PATCH,
             Some(payload),
@@ -1262,7 +1263,7 @@ pub mod variables {
         let host = use_host_server();
         let url = format!("{host}/variables/{variable_name}");
 
-        request(
+        request_with_workspace_lock_retry(
             url,
             reqwest::Method::DELETE,
             None::<()>,
@@ -1332,7 +1333,7 @@ pub mod secrets {
         let host = use_host_server();
         let url = format!("{host}/secrets");
 
-        let response = request(
+        let response = request_with_workspace_lock_retry(
             url,
             reqwest::Method::POST,
             Some(payload),
@@ -1377,7 +1378,7 @@ pub mod secrets {
         let host = use_host_server();
         let url = format!("{host}/secrets/{secret_name}");
 
-        let response = request(
+        let response = request_with_workspace_lock_retry(
             url,
             reqwest::Method::PATCH,
             Some(payload),
@@ -1399,7 +1400,7 @@ pub mod secrets {
         let host = use_host_server();
         let url = format!("{host}/secrets/{secret_name}");
 
-        let response = request(
+        let response = request_with_workspace_lock_retry(
             url,
             reqwest::Method::DELETE,
             None::<()>,

--- a/crates/frontend/src/components/default_config_form/utils.rs
+++ b/crates/frontend/src/components/default_config_form/utils.rs
@@ -8,7 +8,8 @@ use superposition_types::{
 };
 
 use crate::utils::{
-    construct_request_headers, parse_json_response, request, use_host_server,
+    construct_request_headers, parse_json_response, request_with_workspace_lock_retry,
+    use_host_server,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -35,7 +36,7 @@ pub async fn create_default_config(
     let host = use_host_server();
     let url = format!("{host}/default-config");
 
-    let response = request(
+    let response = request_with_workspace_lock_retry(
         url,
         reqwest::Method::POST,
         Some(payload),
@@ -73,7 +74,7 @@ pub async fn update_default_config(
     let host = use_host_server();
     let url = format!("{host}/default-config/{key}");
 
-    let response = request(
+    let response = request_with_workspace_lock_retry(
         url,
         reqwest::Method::PATCH,
         Some(update_payload),

--- a/crates/frontend/src/components/function_form/utils.rs
+++ b/crates/frontend/src/components/function_form/utils.rs
@@ -10,7 +10,8 @@ use superposition_types::{
 };
 
 use crate::utils::{
-    construct_request_headers, parse_json_response, request, use_host_server,
+    construct_request_headers, parse_json_response, request,
+    request_with_workspace_lock_retry, use_host_server,
 };
 
 #[allow(clippy::too_many_arguments)]
@@ -35,7 +36,7 @@ pub async fn create_function(
 
     let host = use_host_server();
     let url = format!("{host}/function");
-    let response = request(
+    let response = request_with_workspace_lock_retry(
         url,
         reqwest::Method::POST,
         Some(payload),
@@ -65,7 +66,7 @@ pub async fn update_function(
     let host = use_host_server();
     let url = format!("{host}/function/{function_name}");
 
-    let response = request(
+    let response = request_with_workspace_lock_retry(
         url,
         reqwest::Method::PATCH,
         Some(payload),

--- a/crates/frontend/src/components/type_template_form/utils.rs
+++ b/crates/frontend/src/components/type_template_form/utils.rs
@@ -7,7 +7,9 @@ use superposition_types::{
     database::models::{ChangeReason, Description, cac::TypeTemplate},
 };
 
-use crate::utils::{construct_request_headers, request, use_host_server};
+use crate::utils::{
+    construct_request_headers, request_with_workspace_lock_retry, use_host_server,
+};
 
 pub async fn create_type(
     type_name: String,
@@ -27,7 +29,7 @@ pub async fn create_type(
     let host = use_host_server();
     let url = format!("{host}/types");
 
-    let response = request(
+    let response = request_with_workspace_lock_retry(
         url,
         reqwest::Method::POST,
         Some(payload),
@@ -57,7 +59,7 @@ pub async fn update_type(
     let host = use_host_server();
     let url = format!("{host}/types/{type_name}");
 
-    let response = request(
+    let response = request_with_workspace_lock_retry(
         url,
         reqwest::Method::PATCH,
         Some(payload),
@@ -77,7 +79,7 @@ pub async fn delete_type(
 
     let payload: Option<()> = None;
 
-    let response = request(
+    let response = request_with_workspace_lock_retry(
         url,
         reqwest::Method::DELETE,
         payload,

--- a/crates/frontend/src/pages/context_override/utils.rs
+++ b/crates/frontend/src/pages/context_override/utils.rs
@@ -7,7 +7,8 @@ use superposition_types::{
 };
 
 use crate::utils::{
-    construct_request_headers, parse_json_response, request, use_host_server,
+    construct_request_headers, parse_json_response, request_with_workspace_lock_retry,
+    use_host_server,
 };
 
 use super::Conditions;
@@ -41,7 +42,7 @@ pub async fn create_context(
     let url = format!("{host}/context");
     let request_payload =
         context_payload(overrides, conditions, description, change_reason);
-    let response = request(
+    let response = request_with_workspace_lock_retry(
         url,
         reqwest::Method::PUT,
         Some(request_payload),
@@ -73,7 +74,7 @@ pub async fn update_context(
 ) -> Result<Context, String> {
     let host = use_host_server();
     let url = format!("{host}/context/overrides");
-    let response = request(
+    let response = request_with_workspace_lock_retry(
         url,
         reqwest::Method::PATCH,
         Some(request_payload),

--- a/crates/frontend/src/pages/function/utils.rs
+++ b/crates/frontend/src/pages/function/utils.rs
@@ -9,7 +9,9 @@ use crate::components::datetime::DatetimeStr;
 use crate::components::table::types::{
     Column, ColumnSortable, Expandable, default_column_formatter,
 };
-use crate::utils::{construct_request_headers, request, use_host_server};
+use crate::utils::{
+    construct_request_headers, request_with_workspace_lock_retry, use_host_server,
+};
 
 pub fn function_table_columns() -> Vec<Column> {
     vec![
@@ -53,7 +55,7 @@ pub async fn publish_function(
     let host = use_host_server();
     let url = format!("{host}/function/{function_name}/publish");
 
-    let response = request(
+    let response = request_with_workspace_lock_retry(
         url,
         reqwest::Method::PATCH,
         Some(payload),

--- a/crates/frontend/src/utils.rs
+++ b/crates/frontend/src/utils.rs
@@ -1,13 +1,14 @@
 #[cfg(feature = "ssr")]
 use std::env;
-use std::str::FromStr;
+use std::{str::FromStr, time::Duration};
 
+use leptos::leptos_dom::is_browser;
 use leptos::*;
 use reqwest::{
     StatusCode,
     header::{HeaderMap, HeaderName, HeaderValue},
 };
-use serde::de::DeserializeOwned;
+use serde::{Deserialize, de::DeserializeOwned};
 use superposition_types::{
     api::functions::{FunctionEnvironment, KeyType},
     database::models::cac::{Function, FunctionType},
@@ -199,6 +200,63 @@ pub fn check_url_and_return_val(s: String) -> String {
 use once_cell::sync::Lazy;
 static HTTP_CLIENT: Lazy<reqwest::Client> = Lazy::new(reqwest::Client::new);
 
+const MAX_WORKSPACE_LOCK_RETRIES: u32 = 3;
+const WORKSPACE_LOCK_RETRY_BASE_DELAY: Duration = Duration::from_millis(250);
+
+#[derive(Clone, Copy)]
+enum RetryPolicy {
+    None,
+    WorkspaceLock,
+}
+
+impl RetryPolicy {
+    fn max_retries(self) -> u32 {
+        match self {
+            Self::WorkspaceLock if is_browser() => MAX_WORKSPACE_LOCK_RETRIES,
+            Self::None | Self::WorkspaceLock => 0,
+        }
+    }
+
+    fn should_retry(
+        self,
+        status: StatusCode,
+        error: &WorkspaceLockedErrorResponse,
+        retry: u32,
+        max_retries: u32,
+    ) -> bool {
+        matches!(self, Self::WorkspaceLock)
+            && status == StatusCode::CONFLICT
+            && error.lock.is_some()
+            && retry < max_retries
+    }
+
+    fn delay(self, retry: u32) -> Duration {
+        match self {
+            Self::WorkspaceLock => WORKSPACE_LOCK_RETRY_BASE_DELAY
+                .saturating_mul(2_u32.saturating_pow(retry)),
+            Self::None => Duration::ZERO,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct WorkspaceLockedErrorResponse {
+    message: String,
+    #[serde(default)]
+    lock: Option<serde_json::Value>,
+}
+
+async fn sleep(duration: Duration) {
+    let (sender, receiver) = futures::channel::oneshot::channel();
+    set_timeout(
+        move || {
+            _ = sender.send(());
+        },
+        duration,
+    );
+    _ = receiver.await;
+}
+
 pub fn construct_request_headers(entries: &[(&str, &str)]) -> Result<HeaderMap, String> {
     entries
         .iter()
@@ -227,6 +285,99 @@ where
     })
 }
 
+async fn request_with_policy<T>(
+    url: String,
+    method: reqwest::Method,
+    body: Option<T>,
+    headers: HeaderMap,
+    skip_error: &[StatusCode],
+    retry_policy: RetryPolicy,
+) -> Result<reqwest::Response, String>
+where
+    T: serde::Serialize,
+{
+    let ssr_headers = use_context::<Option<SsrSharedHttpRequestHeaders>>().flatten();
+    let cookie = ssr_headers.and_then(|h| h.cookie.clone());
+
+    let max_retries = retry_policy.max_retries();
+    let mut retry = 0;
+
+    loop {
+        let mut request_builder = HTTP_CLIENT
+            .request(method.clone(), &url)
+            .headers(headers.clone());
+        request_builder = match (&method, body.as_ref()) {
+            (&reqwest::Method::GET, _) => request_builder,
+            (_, Some(data)) => request_builder.json(data),
+            _ => request_builder,
+        };
+
+        if let Some(cookie_value) = cookie.as_ref() {
+            request_builder =
+                request_builder.header(reqwest::header::COOKIE, cookie_value);
+        }
+
+        let response = request_builder
+            .send()
+            .await
+            .map_err(|err| err.to_string())?;
+
+        let status = response.status();
+
+        if skip_error.contains(&status) {
+            return Ok(response);
+        }
+
+        if status.is_client_error() {
+            let error = response
+                .json::<WorkspaceLockedErrorResponse>()
+                .await
+                .unwrap_or_else(|_| WorkspaceLockedErrorResponse {
+                    message: String::from("Something went wrong"),
+                    lock: None,
+                });
+
+            if retry_policy.should_retry(status, &error, retry, max_retries) {
+                let delay = retry_policy.delay(retry);
+                retry += 1;
+                logging::log!(
+                    "Workspace is locked; retrying request in {:?} ({}/{})",
+                    delay,
+                    retry,
+                    max_retries,
+                );
+                sleep(delay).await;
+                continue;
+            }
+
+            let error_msg = error.message;
+            logging::error!("{}", error_msg);
+            enqueue_alert(error_msg.clone(), AlertType::Error, 5000);
+            return Err(error_msg);
+        }
+
+        if status.is_server_error() {
+            if status == 512 {
+                enqueue_alert(
+                    "Webhook Call Failed, Please Check the Logs.".to_owned(),
+                    AlertType::Error,
+                    5000,
+                );
+            } else {
+                let error_msg = response
+                    .json::<ErrorResponse>()
+                    .await
+                    .map_or(String::from("Something went wrong"), |error| error.message);
+                logging::error!("{}", error_msg);
+                enqueue_alert(error_msg.clone(), AlertType::Error, 5000);
+                return Err(error_msg);
+            }
+        }
+
+        return Ok(response);
+    }
+}
+
 pub async fn request_with_skip_error<T>(
     url: String,
     method: reqwest::Method,
@@ -237,59 +388,7 @@ pub async fn request_with_skip_error<T>(
 where
     T: serde::Serialize,
 {
-    let ssr_headers = use_context::<Option<SsrSharedHttpRequestHeaders>>().flatten();
-    let cookie = ssr_headers.and_then(|h| h.cookie.clone());
-
-    let mut request_builder = HTTP_CLIENT.request(method.clone(), url).headers(headers);
-    request_builder = match (method, body) {
-        (reqwest::Method::GET, _) => request_builder,
-        (_, Some(data)) => request_builder.json(&data),
-        _ => request_builder,
-    };
-
-    if let Some(cookie_value) = cookie {
-        request_builder = request_builder.header(reqwest::header::COOKIE, cookie_value);
-    }
-
-    let response = request_builder
-        .send()
-        .await
-        .map_err(|err| err.to_string())?;
-
-    let status = response.status();
-
-    if skip_error.contains(&status) {
-        return Ok(response);
-    }
-
-    if status.is_client_error() {
-        let error_msg = response
-            .json::<ErrorResponse>()
-            .await
-            .map_or(String::from("Something went wrong"), |error| error.message);
-        logging::error!("{}", error_msg);
-        enqueue_alert(error_msg.clone(), AlertType::Error, 5000);
-        return Err(error_msg);
-    }
-    if status.is_server_error() {
-        if status == 512 {
-            enqueue_alert(
-                "Webhook Call Failed, Please Check the Logs.".to_owned(),
-                AlertType::Error,
-                5000,
-            );
-        } else {
-            let error_msg = response
-                .json::<ErrorResponse>()
-                .await
-                .map_or(String::from("Something went wrong"), |error| error.message);
-            logging::error!("{}", error_msg);
-            enqueue_alert(error_msg.clone(), AlertType::Error, 5000);
-            return Err(error_msg);
-        }
-    }
-
-    Ok(response)
+    request_with_policy(url, method, body, headers, skip_error, RetryPolicy::None).await
 }
 
 pub async fn request<T>(
@@ -301,7 +400,19 @@ pub async fn request<T>(
 where
     T: serde::Serialize,
 {
-    request_with_skip_error(url, method, body, headers, &[]).await
+    request_with_policy(url, method, body, headers, &[], RetryPolicy::None).await
+}
+
+pub async fn request_with_workspace_lock_retry<T>(
+    url: String,
+    method: reqwest::Method,
+    body: Option<T>,
+    headers: HeaderMap,
+) -> Result<reqwest::Response, String>
+where
+    T: serde::Serialize,
+{
+    request_with_policy(url, method, body, headers, &[], RetryPolicy::WorkspaceLock).await
 }
 
 pub fn unwrap_option_or_default_with_error<T>(option: Option<T>, default: T) -> T {


### PR DESCRIPTION
## Problem
Describe the problem you are trying to solve here

## Solution
Provide a brief summary of your solution so that reviewers can understand your code

## Environment variable changes

What ENVs need to be added or changed

## Pre-deployment activity
Things needed to be done before deploying this change (if any)

## Post-deployment activity
Things needed to be done after deploying this change (if any)

## API changes
| Endpoint        | Method           | Request body  | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| API      | GET/POST, etc | request | response |

## Possible Issues in the future
Describe any possible issues that could occur because of this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporarily locked workspaces by automatically retrying affected requests in the browser.
  * Added progressive delays between retry attempts to improve request reliability.
  * Requests now provide a clear error when all retry attempts are exhausted.
  * Preserved existing error alerts and handling for other request failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->