### PR TITLE
fix: fix all links in our documentation

### DIFF
--- a/.agents/skills/superposition/reference/documentation/documentation_index.json
+++ b/.agents/skills/superposition/reference/documentation/documentation_index.json
@@ -1150,7 +1150,7 @@
           },
           {
             "language": "text",
-            "code": "* [Context-Aware-Configuration](https://juspay.io/superposition/docs/basic-concepts/context-aware-config)\n* [Experimentation](https://juspay.io/superposition/docs/basic-concepts/experimentation)"
+            "code": "* [Context-Aware-Configuration](https://superposition.juspay.io/docs/category/context-aware-config/)\n* [Experimentation](https://superposition.juspay.io/docs/category/experimentation/)"
           }
         ],
         "tables": 1,

--- a/.agents/skills/superposition/reference/documentation/overview/intro.md
+++ b/.agents/skills/superposition/reference/documentation/overview/intro.md
@@ -8,7 +8,7 @@ Superposition is a configuration and experimentation management platform that al
 * supporting strong typing of configuration values (via [json-schema](https://json-schema.org/))
 * custom validation functions (written in Javascript) that can validate configuration values using state-less logic or validate them against external data-sources
 * supporting staggering configuration changes via experiments.
-* allows configurations to cascade from least specific to most specific contexts [much like CSS](https://juspay.io/superposition/docs/basic-concepts/context-aware-config#analogy-with-css)
+* allows configurations to cascade from least specific to most specific contexts [much like CSS](https://superposition.juspay.io/docs/basic-concepts/context-aware-config/how-all-this-works/#analogy-with-css)
 
 This comprehensive setup gives applications a robust platform to roll-out changes safely.
 
@@ -25,7 +25,7 @@ Once you run this command, you can access the Superposition admin interface at `
 
 ### Integrating Superposition in your application
 
-Once you have played with the Superposition admin interface, you may want to consume the configuration in your application.  Superposition is [OpenFeature](https://openfeature.dev/docs/reference/concepts/provider) compatible.  OpenFeature allows your application code to remain agnostic of the underlying configuration/feature-flag platform (like [open telemetry](https://opentelemetry.io/) for telemetry).  The [quick start guide](https://juspay.io/superposition/docs/quick_start) has details on how to integrate and consume configurations (setup in Superposition) in your application using the Superposition Open Feature provider.
+Once you have played with the Superposition admin interface, you may want to consume the configuration in your application.  Superposition is [OpenFeature](https://openfeature.dev/docs/reference/concepts/provider) compatible.  OpenFeature allows your application code to remain agnostic of the underlying configuration/feature-flag platform (like [open telemetry](https://opentelemetry.io/) for telemetry).  The [quick start guide](https://superposition.juspay.io/docs/quick_start/) has details on how to integrate and consume configurations (setup in Superposition) in your application using the Superposition Open Feature provider.
 
 ## Superposition Clients
 
@@ -49,9 +49,9 @@ The following matrix contains the languages in which the above client libraries 
 
 For a deeper dive into the under-pinnings of Superposition, development setup, API docs - you can go over the following links.
 1. Conceptual docs on two foundational services of Superposition:
-    * [Context-Aware-Configuration](https://juspay.io/superposition/docs/basic-concepts/context-aware-config)
-    * [Experimentation](https://juspay.io/superposition/docs/basic-concepts/experimentation)
-3. [Development setup](https://juspay.io/superposition/docs/setup)
+    * [Context-Aware-Configuration](https://superposition.juspay.io/docs/category/context-aware-config/)
+    * [Experimentation](https://superposition.juspay.io/docs/category/experimentation/)
+3. [Development setup](https://superposition.juspay.io/docs/setup)
 4. API Ref (TODO:)
 
 ## Applications using Superposition
@@ -69,4 +69,3 @@ Superposition comes as a shot in the arm for any application that needs safe and
 
 ## Email us
 * [superposition@juspay.in](mailto:superposition@juspay.in)
-

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@
 </p>
 
 <p align="center">
-<a href="https://juspay.io/superposition/docs/quick_start"><b>Quick start</b></a>
+<a href="https://superposition.juspay.io/docs/quick_start/"><b>Quick start</b></a>
 ·
-<a href="https://juspay.io/superposition/docs/category/context-aware-config"><b>Concepts</b></a>
+<a href="https://superposition.juspay.io/docs/category/context-aware-config/"><b>Concepts</b></a>
 ·
-<a href="https://juspay.io/superposition/docs/setup"><b>Self-hosting & setup</b></a>
+<a href="https://superposition.juspay.io/docs/setup/"><b>Self-hosting & setup</b></a>
 ·
 <a href="https://deepwiki.com/juspay/superposition"><b>Architecture guide</b></a>
 </p>
@@ -69,7 +69,7 @@ make run
 
 If you are not using Nix, follow the dependency installation steps in the setup guide before running `make setup`.
 
-Need the guided path? Start with the [quick start guide](https://juspay.io/superposition/docs/quick_start) or read the [setup docs](https://juspay.io/superposition/docs/setup).
+Need the guided path? Start with the [quick start guide](https://superposition.juspay.io/docs/quick_start/) or read the [setup docs](https://superposition.juspay.io/docs/setup/).
 
 ## Why should you use Superposition
 
@@ -79,7 +79,7 @@ Need the guided path? Start with the [quick start guide](https://juspay.io/super
 - **Auditability**: see who changed what, when it changed, why it changed, and the description attached to the change.
 - **Integrations**: connect through OpenFeature-compatible providers, SDKs, APIs, webhooks, and client libraries.
 
-Superposition treats configuration like product logic, not scattered environment variables, one-off switch statements, or oversized feature flag trees. Read more about [context-aware configuration](https://juspay.io/superposition/docs/category/context-aware-config) and [experimentation](https://juspay.io/superposition/docs/category/experimentation).
+Superposition treats configuration like product logic, not scattered environment variables, one-off switch statements, or oversized feature flag trees. Read more about [context-aware configuration](https://superposition.juspay.io/docs/category/context-aware-config/) and [experimentation](https://superposition.juspay.io/docs/category/experimentation).
 
 ## What you can build with it
 
@@ -129,7 +129,7 @@ Superposition ships two integration surfaces:
 | Haskell    | [![Haskell SDK](https://img.shields.io/badge/source-SuperpositionSDK-green)](https://github.com/juspay/superposition/tree/main/clients/haskell/sdk) | [![Haskell Provider](https://img.shields.io/badge/source-superposition--open--feature--provider-green)](https://github.com/juspay/superposition/tree/main/clients/haskell/open-feature-provider) |
 | Go         | TBD | TBD |
 
-Ready to integrate? Use the [quick start guide](https://juspay.io/superposition/docs/quick_start) and choose the SDK or provider that matches your application.
+Ready to integrate? Use the [quick start guide](https://superposition.juspay.io/docs/quick_start/) and choose the SDK or provider that matches your application.
 
 ## Key capabilities
 
@@ -144,10 +144,10 @@ Want a broader systems view? Open the [DeepWiki architecture guide](https://deep
 
 ## Learn more
 
-- [Quick start](https://juspay.io/superposition/docs/quick_start)
-- [Development setup](https://juspay.io/superposition/docs/setup)
-- [Context-aware configuration concepts](https://juspay.io/superposition/docs/category/context-aware-config)
-- [Experimentation concepts](https://juspay.io/superposition/docs/category/experimentation)
+- [Quick start](https://superposition.juspay.io/docs/quick_start/)
+- [Development setup](https://superposition.juspay.io/docs/setup/)
+- [Context-aware configuration concepts](https://superposition.juspay.io/docs/category/context-aware-config/)
+- [Experimentation concepts](https://superposition.juspay.io/docs/category/experimentation/)
 - [Context7 LLM-friendly docs](https://context7.com/juspay/superposition)
 - [DeepWiki repository guide](https://deepwiki.com/juspay/superposition)
 
@@ -163,7 +163,7 @@ curl http://localhost:9091/metrics
 
 We welcome contributions across the platform, clients, docs, and examples.
 
-Start with the [development setup docs](https://juspay.io/superposition/docs/setup). If you'd like help getting started, join the [Discord community](https://discord.gg/jNeUJR9Bwr) or email [superposition@juspay.in](mailto:superposition@juspay.in).
+Start with the [development setup docs](https://superposition.juspay.io/docs/setup/). If you'd like help getting started, join the [Discord community](https://discord.gg/jNeUJR9Bwr) or email [superposition@juspay.in](mailto:superposition@juspay.in).
 
 ## License
 

--- a/clients/javascript/sdk/README.md
+++ b/clients/javascript/sdk/README.md
@@ -1,6 +1,6 @@
 # Superposition SDK
 
-Superposition SDK is a JavaScript client for the Superposition platform, designed to facilitate programmatic integration of all Superposition's API capabilities in JavaScript applications. Read the complete documentation at [Superposition SDK Documentation](https://juspay.io/superposition/docs).
+Superposition SDK is a JavaScript client for the Superposition platform, designed to facilitate programmatic integration of all Superposition's API capabilities in JavaScript applications. Read the complete documentation at [Superposition SDK Documentation](https://superposition.juspay.io/docs/).
 
 ## Installation
 

--- a/clients/python/sdk/README.md
+++ b/clients/python/sdk/README.md
@@ -1,6 +1,6 @@
 # Superposition SDK
 
-Superposition SDK is a Python client for the Superposition platform, designed to facilitate programmatic integration of all Superposition's API capabilities in Python applications. Read the complete documentation at [Superposition SDK Documentation](https://juspay.io/superposition/docs).
+Superposition SDK is a Python client for the Superposition platform, designed to facilitate programmatic integration of all Superposition's API capabilities in Python applications. Read the complete documentation at [Superposition SDK Documentation](https://superposition.juspay.io/docs/).
 
 ## Installation
 

--- a/crates/superposition_sdk/README.md
+++ b/crates/superposition_sdk/README.md
@@ -1,6 +1,6 @@
 # Superposition SDK
 
-Superposition SDK is a rust client for the Superposition platform, designed to facilitate the integration of Superposition's capabilities into rust applications. Read the complete documentation at [Superposition SDK Documentation](https://juspay.io/superposition/docs) or [docs.rs](https://docs.rs/superposition_sdk/latest/superposition_sdk/)
+Superposition SDK is a rust client for the Superposition platform, designed to facilitate the integration of Superposition's capabilities into rust applications. Read the complete documentation at [Superposition SDK Documentation](https://superposition.juspay.io/docs/) or [docs.rs](https://docs.rs/superposition_sdk/latest/superposition_sdk/)
 
 ## Installation
 

--- a/docs/blog/2026-06-22-rustyscript.md
+++ b/docs/blog/2026-06-22-rustyscript.md
@@ -289,4 +289,4 @@ runtime
 
 Rustyscript can do a lot more than what we've shared here - I recommend taking a look at the [documentation](https://rscarson.github.io/rustyscript-book/index.html) if you've never used it before. For Superposition, Rustyscript's ability to run isolated JavaScript seamlessly from within Rust has unlocked richer correctness guarantees — we now support both validation and value-compute functions with full syntax checking and captured logs, without spawning a subprocess.
 
-If you like the idea of Superposition, do take a look at our [docs](https://juspay.io/superposition/docs) to learn more. Have questions? Join our [Slack](https://superpositionjp.slack.com) to interact with the team.
+If you like the idea of Superposition, do take a look at our [docs](https://superposition.juspay.io/docs/) to learn more. Have questions? Join our [Slack](https://superpositionjp.slack.com) to interact with the team.

--- a/docs/docs/basic-concepts/context-aware-config/default-config.mdx
+++ b/docs/docs/basic-concepts/context-aware-config/default-config.mdx
@@ -38,4 +38,4 @@ Two functions that can be linked with default configs to ensure correctness:
 - Value Validation
 - Value Compute
 
-To learn more about these, check out [functions](./basic-concepts/safety/functions.mdx)
+To learn more about these, check out [functions](../safety/functions.mdx)

--- a/docs/docs/basic-concepts/context-aware-config/dimensions.mdx
+++ b/docs/docs/basic-concepts/context-aware-config/dimensions.mdx
@@ -84,7 +84,7 @@ Two functions that can be linked with dimensions to ensure correctness:
 - Value Validation
 - Value Compute
 
-To learn more about these, check out [functions](./basic-concepts/safety/functions.mdx)
+To learn more about these, check out [functions](../safety/functions.mdx)
 
 ## Cohort Dimensions
 

--- a/docs/docs/basic-concepts/context-aware-config/how-all-this-works.mdx
+++ b/docs/docs/basic-concepts/context-aware-config/how-all-this-works.mdx
@@ -91,4 +91,4 @@ _context_ = { city = "Bangalore" }
 per_km_rate = 22.0
 ```
 
-Interested in writing better config files? Check out [SuperTOML](./docs/superposition-config-file/intro.md)
+Interested in writing better config files? Check out [SuperTOML](../../superposition-config-file/intro.md)

--- a/docs/docs/basic-concepts/experimentation/experiment-groups.md
+++ b/docs/docs/basic-concepts/experimentation/experiment-groups.md
@@ -6,7 +6,7 @@ description: Group experiments to prevent overlap and ensure isolated traffic al
 
 ## Introduction
 
-When running multiple experiments, they can overlap with each other due to the cascading nature of [Context-Aware Configs](/docs/basic-concepts/how-all-this-works.mdx). This overlap makes it difficult to predict the final configuration a user receives, as multiple experiments may simultaneously modify the same config keys.
+When running multiple experiments, they can overlap with each other due to the cascading nature of [Context-Aware Configs](../context-aware-config/how-all-this-works.mdx). This overlap makes it difficult to predict the final configuration a user receives, as multiple experiments may simultaneously modify the same config keys.
 
 **Experiment Groups** solve this by ensuring experiments within a group never overlap with each other. Each user is assigned to exactly one experiment (or none) within the group, providing predictable and isolated traffic allocation.
 

--- a/docs/docs/intro.mdx
+++ b/docs/docs/intro.mdx
@@ -21,7 +21,7 @@ In this section, lets talk about when you would want to use Superposition over t
 
 ### Cascading
 
-The big differentiator for Superposition is its ability to cascade configurations based on the context matched from the query sent by the application. You can learn more about [overrides](./basic-concepts/context-aware-config/overrides.mdx), which reduces the number of configurations you need to create to achieve a desired state. [Cascading Style Sheets (CSS)](https://juspay.io/superposition/docs/basic-concepts/context-aware-config#analogy-with-css) is a good mental model to understand this behaviour. 
+The big differentiator for Superposition is its ability to cascade configurations based on the context matched from the query sent by the application. You can learn more about [overrides](./basic-concepts/context-aware-config/overrides.mdx), which reduces the number of configurations you need to create to achieve a desired state. [Cascading Style Sheets (CSS)](https://superposition.juspay.io/docs/basic-concepts/context-aware-config/how-all-this-works/#analogy-with-css) is a good mental model to understand this behaviour. 
 
 As far as we know, no other way to configuration complex applications have this feature. This is why we built Superposition.
 


### PR DESCRIPTION
## Problem
- Some internal links are broken
- links that redirect to `juspay.io/superposition/docs` are broken

## Solution
Fix links

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation links throughout the website, README files, SDK guides, and blog content.
  * Replaced outdated URLs with the current Superposition documentation domain.
  * Corrected relative links for functions, SuperTOML, Context-Aware Configs, experimentation, and CSS cascading references.
  * Improved navigation consistency with updated paths and trailing slashes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->