### PR TITLE
fix: resolve the demo image failures

### DIFF
--- a/example.Dockerfile
+++ b/example.Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 
 RUN apt-get update && apt-get install -y libpq5 ca-certificates curl
 RUN apt-get install -y postgresql-common
-RUN /usr/share/postgresql-common/pgdg/apt.postgresql.org.sh -i -v 17
+RUN apt-get install -y postgresql-17 postgresql-server-dev-17
 # Update the package lists:
 RUN apt-get update
 


### PR DESCRIPTION
## Problem
The docker demo image fails to build because of the postgres dropping support for ubuntu 25.10 and lack of kronos tables

## Solution
Directly install the latest version in apt repository for postgresql 17, and add queries for kronos to prevent errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Kronos database initialization with support for payload specifications, configurations, secrets, endpoints, jobs, executions, attempts, and execution logs.
  * Added database constraints, timestamps, generated identifiers, and indexes to support reliable scheduling, tracking, and logging.

* **Chores**
  * Updated the container setup to install PostgreSQL 17 and its development package directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->