### PR TITLE
fix: kronos dev mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,7 @@ REDIS_KEY_TTL=604800
 # KRONOS LIBRARY MODE (default)
 KRONOS_ENCRYPTION_KEY="5d5e2e704c866bddeb6dd7ef1ea69f39a6eb3934f60e3f13f67c605b513ced9e"
 KRONOS_DB_POOL_SIZE="1"
+KRONOS_TABLE_PREFIX="kronos_"
 
 # Needed for both service and library mode, but only in DEV/TEST. In production, this is stored in KMS.
 KRONOS_DISPATCH_TOKEN="dispatch-test"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8989,6 +8989,7 @@ dependencies = [
  "inventory",
  "json-subscriber",
  "juspay_diesel",
+ "kronos-common",
  "kronos-worker",
  "leptos",
  "leptos_actix",

--- a/crates/superposition/Cargo.toml
+++ b/crates/superposition/Cargo.toml
@@ -39,6 +39,7 @@ superposition_types = { workspace = true, features = [
     "server",
 ] }
 actix-http = { workspace = true }
+kronos-common = { workspace = true }
 kronos-worker = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/superposition/src/app_state.rs
+++ b/crates/superposition/src/app_state.rs
@@ -9,6 +9,7 @@ use fred::{
     interfaces::ClientLike,
     types::{ConnectionConfig, PerformanceConfig, ReconnectPolicy, RedisConfig},
 };
+use kronos_common::tenant::SchemaProvider;
 use kronos_worker::{
     KronosClient, KronosHttpClient, KronosLibraryClient, WorkerConfig, WorkerHandle,
 };
@@ -139,6 +140,30 @@ pub async fn get(
         .await
         .expect("Failed to create KronosLibraryClient");
         let schema_provider = SuperpositionSchemaProvider::new(client.pool().clone());
+
+        if matches!(app_env, AppEnv::DEV | AppEnv::TEST) {
+            match schema_provider.get_active_schemas().await {
+                Ok(schemas) => {
+                    log::info!(
+                        "Kronos library mode: bootstrapping {} workspace(s)",
+                        schemas.len()
+                    );
+                    for schema in schemas {
+                        setup_dispatcher(
+                            &client,
+                            &schema,
+                            &superposition_host,
+                            &kronos_dispatch_token,
+                        )
+                        .await;
+                    }
+                }
+                Err(e) => log::warn!(
+                    "Kronos bootstrap: could not list workspaces, skipping: {e}"
+                ),
+            }
+        }
+
         let worker_config = WorkerConfig::default();
         let shutdown_timeout_sec = worker_config.shutdown_timeout_sec;
         let handle = client.start_worker(schema_provider, worker_config);


### PR DESCRIPTION
This pull request introduces support for bootstrapping Kronos workspaces in development and test environments, along with some dependency and configuration updates. The main changes are grouped below:

**Kronos workspace bootstrapping (DEV/TEST):**
* In `crates/superposition/src/app_state.rs`, added logic to automatically bootstrap all active Kronos workspaces when running in development or test environments. The code queries for active schemas and calls `setup_dispatcher` for each, logging the results.

**Dependency updates:**
* Added the `kronos-common` crate as a workspace dependency in `crates/superposition/Cargo.toml`.
* Imported `SchemaProvider` from `kronos_common::tenant` in `crates/superposition/src/app_state.rs`.

**Configuration updates:**
* Added the `KRONOS_TABLE_PREFIX` environment variable to `.env.example` for easier configuration of table prefixes.