### PR TITLE
chore: debug why pypi push fails

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -520,7 +520,7 @@ jobs:
 
             - name: Publish Python packages to PyPI
               run: |
-                  twine upload python-wheels/*.whl
+                  twine upload --verbose python-wheels/*.whl
 
     generate-js-packages:
         needs: [tag-release, generate-rust-binary]


### PR DESCRIPTION
## Problem
Python package pushes fail

## Solution
First figure out why

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enabled verbose output when publishing the Python package, providing more detailed release-upload logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->