### PR TITLE
fix: pass correct args to FFI function in haskell

### DIFF
--- a/clients/haskell/hs-cac-client/src/Client.hs
+++ b/clients/haskell/hs-cac-client/src/Client.hs
@@ -158,7 +158,7 @@ getResolvedConfigWithStrategy client context mbKeys mbExcludePrefix mergeStrat =
     cExcludePrefix <- case mbExcludePrefix of
         Just excludePrefix -> newCString (intercalate "," excludePrefix)
         Nothing            -> return nullPtr
-    overrides   <- withForeignPtr client $ \clientPtr -> c_cac_get_resolved_config clientPtr cContext cStrKeys cMergeStrat cExcludePrefix
+    overrides   <- withForeignPtr client $ \clientPtr -> c_cac_get_resolved_config clientPtr cContext cStrKeys cExcludePrefix cMergeStrat
     _           <- cleanup [cContext, cStrKeys, cMergeStrat, cExcludePrefix]
     if overrides == nullPtr
         then Left <$> getError


### PR DESCRIPTION
## Problem
wrong order of args are passed to the FFI function
```
#[no_mangle]
pub extern "C" fn cac_get_resolved_config(
    client: *mut Arc<Client>,
    query: *const c_char,
    filter_keys: *const c_char,
    filter_exclude_prefix: *const c_char,
    merge_strategy: *const c_char,
) -> *const c_char {
```
But we were sending 
```
c_cac_get_resolved_config clientPtr cContext cStrKeys cMergeStrat cExcludePrefix
```
leading to a NULL string error if excludePrefix was `None`

## Solution
Reorder args to the FFI function `cac_get_resolved_config`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected configuration resolution behavior for Haskell clients by ensuring exclusion settings and merge strategy are passed in the proper order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->