### PR TITLE
feat: add workspace-defined metric selections

### DIFF
--- a/crates/experimentation_platform/src/api/experiments/handlers.rs
+++ b/crates/experimentation_platform/src/api/experiments/handlers.rs
@@ -54,7 +54,8 @@ use superposition_types::{
             ApplicableVariantsQuery, ApplicableVariantsRequest,
             ConcludeExperimentRequest, ExperimentCreateRequest, ExperimentListFilters,
             ExperimentListRequest, ExperimentResponse, ExperimentSortOn,
-            ExperimentStateChangeRequest, OverrideKeysUpdateRequest, RampRequest,
+            ExperimentStateChangeRequest, MetricSelectionUpdate,
+            OverrideKeysUpdateRequest, RampRequest,
         },
         webhook::Action,
     },
@@ -66,8 +67,8 @@ use superposition_types::{
         models::{
             ChangeReason,
             experimentation::{
-                Experiment, ExperimentGroup, ExperimentStatusType, ExperimentType,
-                TrafficPercentage, Variant, VariantType, Variants,
+                Experiment, ExperimentGroup, ExperimentMetrics, ExperimentStatusType,
+                ExperimentType, TrafficPercentage, Variant, VariantType, Variants,
             },
             others::WebhookEvent,
         },
@@ -91,7 +92,7 @@ use crate::api::{
         helpers::{
             get_control_overrides_from_exp_id, put_experiments_in_redis,
             validate_change_reason_with_function, validate_control_overrides,
-            validate_delete_experiment_variants,
+            validate_delete_experiment_variants, validate_metric_selection,
         },
         types::StartedByChangeSet,
     },
@@ -178,6 +179,26 @@ async fn create_handler(
     let mut variants = req.variants;
     let description = req.description.clone();
     let change_reason = req.change_reason.clone();
+
+    let workspace_source = workspace_context.settings.metrics.source();
+    let req_metrics = req.metrics.map(ExperimentMetrics::into_parts);
+    let (req_selection, req_source) = match req_metrics {
+        Some((selection, source)) => {
+            // A per-experiment source override is only allowed when the
+            // workspace itself has a metrics source configured.
+            if source.is_some() && workspace_source.is_none() {
+                return Err(bad_argument!(
+                    "A per-experiment metrics source can only be set when the workspace has a metrics source configured"
+                ));
+            }
+            (selection, source)
+        }
+        None => (None, None),
+    };
+
+    if let Some(selection) = req_selection.as_ref() {
+        validate_metric_selection(selection, &workspace_context.settings.metrics)?;
+    }
 
     validate_change_reason_with_function(
         &workspace_context,
@@ -375,16 +396,17 @@ async fn create_handler(
         status: ExperimentStatusType::CREATED,
         started_by: None,
         started_at: None,
-        context: req.context.clone().into_inner(),
+        context: req.context.into_inner(),
         variants: Variants::new(variants),
         last_modified_by: user.get_email(),
         chosen_variant: None,
         description,
         change_reason,
-        metrics: req
-            .metrics
-            .clone()
-            .unwrap_or(workspace_context.settings.metrics.clone()),
+        metrics: ExperimentMetrics::new(
+            req_selection,
+            req_source.or_else(|| workspace_source.cloned()),
+        )
+        .map_err(|e| bad_argument!(e))?,
         experiment_group_id: req.experiment_group_id,
         idempotency_key: custom_headers.idempotency_key.clone(),
     };
@@ -1596,6 +1618,7 @@ async fn update_handler(
     .await?;
 
     let payload = req.into_inner();
+    let metrics_update = payload.metrics;
     let variants = payload.variants;
 
     let first_variant = variants.first().ok_or(bad_argument!(
@@ -1616,6 +1639,23 @@ async fn update_handler(
         return Err(bad_argument!(
             "Only experiments in CREATED state can be updated"
         ));
+    }
+
+    if let Some(MetricSelectionUpdate::Set { selection, source }) =
+        metrics_update.as_ref()
+    {
+        if let Some(selection) = selection {
+            validate_metric_selection(selection, &workspace_context.settings.metrics)?;
+        }
+        // A per-experiment source override is only allowed when the workspace
+        // itself has a metrics source configured.
+        if matches!(source, Some(Some(_)))
+            && workspace_context.settings.metrics.source().is_none()
+        {
+            return Err(bad_argument!(
+                "A per-experiment metrics source can only be set when the workspace has a metrics source configured"
+            ));
+        }
     }
 
     let id_to_existing_variant: HashMap<String, &Variant> = HashMap::from_iter(
@@ -1847,8 +1887,25 @@ async fn update_handler(
     }
 
     /*************************** Updating experiment in DB **************************/
-    let existing_metrics = &experiment.metrics.clone();
-    let updated_metrics = payload.metrics.as_ref().unwrap_or(existing_metrics);
+    let updated_metrics = match metrics_update {
+        None => experiment.metrics.clone(),
+        Some(MetricSelectionUpdate::Remove) => ExperimentMetrics::default(),
+        Some(MetricSelectionUpdate::Set { selection, source }) => {
+            let updated_source = match source {
+                // `source` key omitted: keep the experiment's existing source.
+                None => experiment.metrics.source().cloned(),
+                // `source: null`: clear the source.
+                Some(None) => None,
+                // `source: {...}`: set the new source.
+                Some(Some(new_source)) => Some(new_source),
+            };
+            // Selection keys omitted: keep the experiment's existing selection.
+            let updated_selection =
+                selection.or_else(|| experiment.metrics.selection().cloned());
+            ExperimentMetrics::new(updated_selection, updated_source)
+                .map_err(|e| bad_argument!(e))?
+        }
+    };
 
     let updated_experiment =
         conn.transaction::<_, superposition::AppError, _>(|transaction_conn| {

--- a/crates/experimentation_platform/src/api/experiments/helpers.rs
+++ b/crates/experimentation_platform/src/api/experiments/helpers.rs
@@ -35,7 +35,7 @@ use superposition_types::{
     custom_query::{DimensionQuery, QueryParam},
     database::{
         models::{
-            ChangeReason,
+            ChangeReason, MetricSelection, Metrics,
             experimentation::{
                 Experiment, ExperimentStatusType, GroupType, Variant, VariantType,
                 Variants,
@@ -91,6 +91,42 @@ pub fn validate_override_keys(override_keys: &Vec<String>) -> superposition::Res
             return Err(bad_argument!(
                 "override_keys are not unique. Remove duplicate entries in override_keys"
             ));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_metric_selection(
+    selection: &MetricSelection,
+    workspace_metrics: &Metrics,
+) -> superposition::Result<()> {
+    if !workspace_metrics.enabled {
+        return Err(bad_argument!("Metrics are not enabled for this workspace"));
+    }
+    // Selections must draw from the workspace's list; when the workspace has
+    // no list configured, per-experiment selection is not accepted.
+    let Some(metric_names) = workspace_metrics.list.as_ref() else {
+        return Err(bad_argument!(
+            "A per-experiment metric selection can only be set when the workspace has a metric list configured"
+        ));
+    };
+
+    let selected = [
+        ("primary", Some(&selection.primary)),
+        ("secondary", selection.secondary.as_ref()),
+        ("guardrail", Some(&selection.guardrail)),
+    ];
+    for (category, metric) in selected {
+        let Some(metric) = metric else {
+            continue;
+        };
+        if !metric_names.iter().any(|defined| defined == metric) {
+            let message = format!(
+                "The {category} metric '{}' and its direction are not defined in the workspace",
+                metric.name
+            );
+            return Err(bad_argument!(message));
         }
     }
 
@@ -925,4 +961,90 @@ pub fn get_control_overrides_from_exp_id(
         })?;
 
     Ok(control_overrides.overrides)
+}
+
+#[cfg(test)]
+mod metric_selection_tests {
+    use super::validate_metric_selection;
+    use superposition_types::database::models::{
+        MetricDefinition, MetricDirection, MetricSelection, MetricSource, Metrics,
+    };
+
+    fn metric(name: &str, direction: MetricDirection) -> MetricDefinition {
+        MetricDefinition {
+            name: name.to_string(),
+            direction,
+        }
+    }
+
+    fn workspace_metrics(enabled: bool) -> Metrics {
+        Metrics {
+            enabled,
+            source: enabled.then(|| MetricSource::Grafana {
+                base_url: "https://grafana.example.com".to_string(),
+                dashboard_uid: "experiment-metrics".to_string(),
+                dashboard_slug: "experiments".to_string(),
+                variant_id_alias: None,
+            }),
+            list: enabled.then(|| {
+                vec![
+                    metric("conversion", MetricDirection::Maximize),
+                    metric("latency", MetricDirection::Minimize),
+                    metric("errors", MetricDirection::Minimize),
+                ]
+            }),
+        }
+    }
+
+    fn selection() -> MetricSelection {
+        MetricSelection {
+            primary: metric("conversion", MetricDirection::Maximize),
+            secondary: None,
+            guardrail: metric("latency", MetricDirection::Minimize),
+        }
+    }
+
+    #[test]
+    fn rejects_selection_when_workspace_metrics_are_disabled() {
+        assert!(
+            validate_metric_selection(&selection(), &workspace_metrics(false)).is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_blank_or_unknown_metric_names() {
+        let mut blank = selection();
+        blank.primary.name = " ".to_string();
+        assert!(validate_metric_selection(&blank, &workspace_metrics(true)).is_err());
+
+        let mut unknown = selection();
+        unknown.guardrail.name = "unknown".to_string();
+        assert!(validate_metric_selection(&unknown, &workspace_metrics(true)).is_err());
+
+        let mut wrong_direction = selection();
+        wrong_direction.guardrail.direction = MetricDirection::Maximize;
+        assert!(
+            validate_metric_selection(&wrong_direction, &workspace_metrics(true))
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn accepts_optional_secondary_and_cross_category_duplicates() {
+        assert!(
+            validate_metric_selection(&selection(), &workspace_metrics(true)).is_ok()
+        );
+
+        let mut duplicate = selection();
+        duplicate.guardrail = duplicate.primary.clone();
+        duplicate.secondary = Some(duplicate.primary.clone());
+        assert!(validate_metric_selection(&duplicate, &workspace_metrics(true)).is_ok());
+    }
+
+    #[test]
+    fn rejects_selection_when_workspace_has_no_list() {
+        let mut ws = workspace_metrics(true);
+        ws.list = None;
+        assert!(validate_metric_selection(&selection(), &ws).is_err());
+    }
 }

--- a/crates/experimentation_platform/tests/experimentation_tests.rs
+++ b/crates/experimentation_platform/tests/experimentation_tests.rs
@@ -5,10 +5,10 @@ use service_utils::service::types::ExperimentationFlags;
 use superposition_types::{
     Condition, Exp, Overrides,
     database::models::{
-        ChangeReason, Description, Metrics,
+        ChangeReason, Description,
         experimentation::{
-            Experiment, ExperimentStatusType, ExperimentType, TrafficPercentage, Variant,
-            Variants,
+            Experiment, ExperimentMetrics, ExperimentStatusType, ExperimentType,
+            TrafficPercentage, Variant, Variants,
         },
     },
     result as superposition,
@@ -62,7 +62,7 @@ fn experiment_gen(
         chosen_variant: None,
         description: Description::try_from(String::from("test")).unwrap(),
         change_reason: ChangeReason::try_from(String::from("test")).unwrap(),
-        metrics: Metrics::default(),
+        metrics: ExperimentMetrics::default(),
         experiment_group_id: None,
         idempotency_key: None,
     }

--- a/crates/frontend/src/components/context_override_form.rs
+++ b/crates/frontend/src/components/context_override_form.rs
@@ -21,6 +21,7 @@ use crate::{
         change_summary::ChangeLogPopup,
         condition_pills::Condition,
         context_form::ContextForm,
+        description::ContentDescription,
         override_form::OverrideForm,
         skeleton::{Skeleton, SkeletonVariant},
         step_indicator::{Step, StepIndicator, StepNavigation, StepType},
@@ -58,7 +59,6 @@ pub fn ContextOverrideForm(
     dimensions: Vec<DimensionResponse>,
     default_config: Vec<DefaultConfig>,
     #[prop(default = String::new())] description: String,
-    #[prop(default = String::new())] change_reason: String,
     #[prop(into)] redirect_url_cancel: String,
     #[prop(into)] redirect_url_success: String,
 ) -> impl IntoView {
@@ -71,7 +71,7 @@ pub fn ContextOverrideForm(
     let (context_rs, context_ws) = create_signal(context);
     let (overrides_rs, overrides_ws) = create_signal(overrides);
     let (description_rs, description_ws) = create_signal(description);
-    let (change_reason_rs, change_reason_ws) = create_signal(change_reason);
+    let (change_reason_rs, change_reason_ws) = create_signal(String::new());
     let (req_inprogress_rs, req_inprogress_ws) = create_signal(false);
     let update_request_rws = RwSignal::new(None);
 
@@ -419,7 +419,7 @@ pub fn OverrideDetailView(
     overrides: Vec<(String, Value)>,
     description: Description,
     override_id: String,
-    change_reason: String,
+    change_reason: ChangeReason,
     created_by: String,
     created_at: chrono::DateTime<chrono::Utc>,
     last_modified_by: String,
@@ -442,24 +442,22 @@ pub fn OverrideDetailView(
 
     view! {
         <div class="flex flex-col gap-4">
-            <div class="block rounded-lg shadow bg-base-100 p-6 flex flex-col gap-4">
-                <div class="flex justify-between items-center">
-                    <div class="flex gap-4 items-center">
-                        <div class="stat-title">"Override ID"</div>
-                        <div class="text-sm font-mono bg-base-200 px-2 py-1 rounded">
-                            {override_id}
-                        </div>
-                    </div>
+            <div class="px-7 py-6 flex flex-row gap-4 bg-base-100 shadow rounded-lg">
+                <div class="stat-title flex items-center justify-center leading-none">
+                    "Override ID"
+                </div>
+                <div class="p-2 flex items-center justify-center font-mono leading-none text-sm bg-base-200 rounded">
+                    {override_id}
                 </div>
             </div>
 
-            <crate::components::description::ContentDescription
-                description=description
-                change_reason=ChangeReason::try_from(change_reason).unwrap_or_default()
-                created_by=created_by
-                created_at=created_at
-                last_modified_by=last_modified_by
-                last_modified_at=last_modified_at
+            <ContentDescription
+                description
+                change_reason
+                created_by
+                created_at
+                last_modified_by
+                last_modified_at
             />
 
             <div class="card bg-base-100 shadow">
@@ -478,9 +476,12 @@ pub fn OverrideDetailView(
             </div>
 
             <div class="card bg-base-100 shadow">
-                <div class="card-body">
-                    <Table rows=override_table_rows key_column="KEY" columns=table_columns />
-                </div>
+                <Table
+                    class="card-body"
+                    rows=override_table_rows
+                    key_column="KEY"
+                    columns=table_columns
+                />
             </div>
         </div>
     }

--- a/crates/frontend/src/components/experiment.rs
+++ b/crates/frontend/src/components/experiment.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use leptos::*;
 use serde_json::{Map, Value};
 use superposition_types::api::experiments::ExperimentResponse;
+use superposition_types::database::models::MetricDirection;
 use superposition_types::database::models::experimentation::{
     ExperimentStatusType, Variant, VariantType,
 };
@@ -22,6 +23,13 @@ fn badge_class(status_type: ExperimentStatusType) -> &'static str {
         ExperimentStatusType::CONCLUDED => "badge-success",
         ExperimentStatusType::DISCARDED => "badge-neutral",
         ExperimentStatusType::PAUSED => "badge-error",
+    }
+}
+
+fn metric_direction_label(direction: MetricDirection) -> &'static str {
+    match direction {
+        MetricDirection::Maximize => "maximize",
+        MetricDirection::Minimize => "minimize",
     }
 }
 
@@ -383,14 +391,50 @@ where
             <Show when=move || {
                 experiment
                     .with_value(|v| {
-                        v.metrics.enabled || v.status == ExperimentStatusType::CREATED
+                        v.metrics.is_enabled() || v.status == ExperimentStatusType::CREATED
                     })
             }>
                 <div class="card bg-base-100 max-w-screen shadow">
                     <div class="card-body collapse collapse-arrow">
                         <input type="checkbox" checked=true />
                         <h2 class="card-title collapse-title h-fit !p-0">Metrics</h2>
-                        <div class="collapse-content !p-0">
+                        <div class="collapse-content !p-0 flex flex-col gap-4">
+                            {experiment
+                                .with_value(|value| value.metrics.selection().cloned())
+                                .map(|metrics| {
+                                    let secondary = metrics
+                                        .secondary
+                                        .map(|metric| {
+                                            format!(
+                                                "{} ({})",
+                                                metric.name,
+                                                metric_direction_label(metric.direction),
+                                            )
+                                        })
+                                        .unwrap_or_else(|| "—".to_string());
+                                    view! {
+                                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                                            <div>
+                                                <div class="stat-title">Primary</div>
+                                                <div class="font-medium">{metrics.primary.name}</div>
+                                                <div class="text-xs opacity-70">
+                                                    {metric_direction_label(metrics.primary.direction)}
+                                                </div>
+                                            </div>
+                                            <div>
+                                                <div class="stat-title">Secondary</div>
+                                                <div class="font-medium">{secondary}</div>
+                                            </div>
+                                            <div>
+                                                <div class="stat-title">Guardrail</div>
+                                                <div class="font-medium">{metrics.guardrail.name}</div>
+                                                <div class="text-xs opacity-70">
+                                                    {metric_direction_label(metrics.guardrail.direction)}
+                                                </div>
+                                            </div>
+                                        </div>
+                                    }
+                                })}
                             {move || {
                                 view! {
                                     {match experiment.with_value(|v| v.metrics_url.clone()) {
@@ -413,7 +457,7 @@ where
                                         _ => {
                                             let message = if experiment
                                                 .with_value(|e| {
-                                                    !e.metrics.enabled
+                                                    !e.metrics.is_enabled()
                                                         && e.status == ExperimentStatusType::CREATED
                                                 })
                                             {

--- a/crates/frontend/src/components/experiment_form.rs
+++ b/crates/frontend/src/components/experiment_form.rs
@@ -9,14 +9,18 @@ use superposition_types::{
     api::{
         dimension::DimensionResponse,
         experiment_groups::ExpGroupFilters,
-        experiments::{ExperimentResponse, OverrideKeysUpdateRequest},
+        experiments::{
+            ExperimentResponse, MetricSelectionUpdate, OverrideKeysUpdateRequest,
+        },
         functions::FunctionEnvironment,
+        workspace::WorkspaceResponse,
     },
     custom_query::{DimensionQuery, PaginationParams},
     database::models::{
-        Metrics,
         cac::DefaultConfig,
-        experimentation::{ExperimentGroup, ExperimentType, VariantType},
+        experimentation::{
+            ExperimentGroup, ExperimentMetrics, ExperimentType, VariantType,
+        },
     },
 };
 use utils::{create_experiment, try_update_payload, update_experiment};
@@ -31,7 +35,7 @@ use crate::components::{
     context_form::ContextForm,
     dropdown::{Dropdown, DropdownBtnType, DropdownDirection},
     form::label::Label,
-    metrics_form::MetricsForm,
+    metrics_form::ExperimentMetricsForm,
     skeleton::{Skeleton, SkeletonVariant},
     variant_form::{DeleteVariantForm, VariantForm},
 };
@@ -88,7 +92,7 @@ pub fn ExperimentForm(
     default_config: Vec<DefaultConfig>,
     dimensions: Vec<DimensionResponse>,
     #[prop(default = String::new())] description: String,
-    metrics: Metrics,
+    #[prop(default = ExperimentMetrics::default())] metrics: ExperimentMetrics,
     #[prop(default = None)] experiment_group_id: Option<String>,
 ) -> impl IntoView {
     let init_variants = get_init_state(&variants);
@@ -97,6 +101,7 @@ pub fn ExperimentForm(
     let dimensions = StoredValue::new(dimensions);
     let experiment_form_type = StoredValue::new(experiment_form_type);
     let workspace = use_context::<Signal<Workspace>>().unwrap();
+    let workspace_settings = use_context::<StoredValue<WorkspaceResponse>>().unwrap();
     let org = use_context::<Signal<OrganisationId>>().unwrap();
 
     let (experiment_name, set_experiment_name) = create_signal(name);
@@ -106,7 +111,9 @@ pub fn ExperimentForm(
 
     let (description_rs, description_ws) = create_signal(description);
     let (change_reason_rs, change_reason_ws) = create_signal(String::new());
-    let metrics_rws = RwSignal::new(metrics);
+    let metrics = StoredValue::new(metrics);
+    let initial_metrics = metrics;
+    let metrics_rws = RwSignal::new(metrics.get_value());
     let update_request_rws = RwSignal::new(None);
     let (experiment_group_id_rs, experiment_group_id_ws) =
         create_signal(experiment_group_id);
@@ -146,6 +153,19 @@ pub fn ExperimentForm(
     });
 
     let on_submit = move || {
+        if metrics_rws.with_untracked(|metrics| {
+            metrics.selection().is_some_and(|selection| {
+                selection.primary.name.trim().is_empty()
+                    || selection.guardrail.name.trim().is_empty()
+            })
+        }) {
+            enqueue_alert(
+                "Primary and Guardrail metrics are required".to_string(),
+                AlertType::Error,
+                5000,
+            );
+            return;
+        }
         req_inprogress_ws.set(true);
 
         let f_experiment_name = experiment_name.get_untracked();
@@ -176,9 +196,28 @@ pub fn ExperimentForm(
                         future.await.map(ResponseType::Response)
                     }
                     (Some(experiment_id), None) => {
+                        let metrics = metrics_rws.get_untracked();
+                        let initial = initial_metrics.get_value();
+                        let metrics_update = (metrics != initial).then(|| {
+                            if metrics.is_enabled() {
+                                let (selection, source) = metrics.into_parts();
+                                let selection_update = (selection
+                                    != initial.selection().cloned())
+                                .then_some(selection)
+                                .flatten();
+                                let source_update = (source.as_ref() != initial.source())
+                                    .then_some(source);
+                                MetricSelectionUpdate::Set {
+                                    selection: selection_update,
+                                    source: source_update,
+                                }
+                            } else {
+                                MetricSelectionUpdate::Remove
+                            }
+                        });
                         let request_payload = try_update_payload(
                             f_variants,
-                            Some(metrics_rws.get_untracked()),
+                            metrics_update,
                             description_rs.get_untracked(),
                             change_reason_rs.get_untracked(),
                             experiment_group_id,
@@ -194,7 +233,7 @@ pub fn ExperimentForm(
                     _ => create_experiment(
                         f_context,
                         f_variants,
-                        Some(metrics_rws.get_untracked()),
+                        metrics_rws.get_untracked(),
                         f_experiment_name,
                         ExperimentType::from(experiment_form_type.get_value()),
                         description_rs.get_untracked(),
@@ -255,11 +294,11 @@ pub fn ExperimentForm(
                 value=description_rs.get_untracked()
                 on_change=move |new_description| description_ws.set(new_description)
             />
-            <MetricsForm
+            <ExperimentMetricsForm
+                workspace_metrics=workspace_settings.with_value(|settings| settings.metrics.clone())
                 metrics=metrics_rws.get_untracked()
                 on_change=Callback::new(move |metrics| metrics_rws.set(metrics))
             />
-
             <Suspense fallback=move || {
                 view! { <Skeleton variant=SkeletonVariant::Block style_class="h-10" /> }
             }>

--- a/crates/frontend/src/components/experiment_form/utils.rs
+++ b/crates/frontend/src/components/experiment_form/utils.rs
@@ -3,14 +3,14 @@ use superposition_types::{
     Condition, Exp,
     api::{
         experiments::{
-            ExperimentCreateRequest, ExperimentResponse, OverrideKeysUpdateRequest,
-            VariantUpdateRequest,
+            ExperimentCreateRequest, ExperimentResponse, MetricSelectionUpdate,
+            OverrideKeysUpdateRequest, VariantUpdateRequest,
         },
         option_i64_from_value,
     },
     database::models::{
-        ChangeReason, Description, Metrics,
-        experimentation::{ExperimentType, Variant},
+        ChangeReason, Description,
+        experimentation::{ExperimentMetrics, ExperimentType, Variant},
     },
 };
 
@@ -31,7 +31,7 @@ pub fn validate_experiment(experiment: &ExperimentCreateRequest) -> Result<(), S
 pub async fn create_experiment(
     conditions: Conditions,
     variants: Vec<VariantFormT>,
-    metrics: Option<Metrics>,
+    metrics: ExperimentMetrics,
     name: String,
     experiment_type: ExperimentType,
     description: String,
@@ -45,7 +45,7 @@ pub async fn create_experiment(
         experiment_type,
         variants: Result::<Vec<Variant>, String>::from_iter(variants)?,
         context: Exp::<Condition>::try_from(Map::from(conditions))?,
-        metrics,
+        metrics: metrics.is_enabled().then_some(metrics),
         description: Description::try_from(description)?,
         change_reason: ChangeReason::try_from(change_reason)?,
         experiment_group_id: option_i64_from_value(experiment_group_id)
@@ -69,7 +69,7 @@ pub async fn create_experiment(
 
 pub fn try_update_payload(
     variants: Vec<VariantFormT>,
-    metrics: Option<Metrics>,
+    metrics: Option<MetricSelectionUpdate>,
     description: String,
     change_reason: String,
     experiment_group_id: Value,

--- a/crates/frontend/src/components/metrics_form.rs
+++ b/crates/frontend/src/components/metrics_form.rs
@@ -1,11 +1,15 @@
 use leptos::*;
 use serde_json::Value;
-use superposition_types::database::models::{MetricSource, Metrics};
+use superposition_types::database::models::{
+    MetricDefinition, MetricDirection, MetricSelection, MetricSource, Metrics,
+    experimentation::ExperimentMetrics,
+};
 
 use crate::{
     components::{
+        dropdown::{Dropdown, DropdownBtnType, DropdownDirection},
         form::label::Label,
-        input::{Input, InputType, Toggle},
+        input::{Input, InputType, StringArrayInput, Toggle},
     },
     schema::{JsonSchemaType, SchemaType},
 };
@@ -180,6 +184,96 @@ pub fn MetricsForm(
                         }
                     />
                 </div>
+                <div class="form-control">
+                    <Label
+                        title="Metric Definitions"
+                        description="Press enter to add a metric name"
+                    />
+                    <StringArrayInput
+                        options=metrics_rws
+                            .with(|metrics| {
+                                metrics
+                                    .list
+                                    .as_deref()
+                                    .unwrap_or_default()
+                                    .iter()
+                                    .map(|metric| metric.name.clone())
+                                    .collect()
+                            })
+                        unique=true
+                        show_label=false
+                        on_change=Callback::new(move |list: Vec<String>| {
+                            metrics_rws
+                                .update(|metrics| {
+                                    let existing = metrics.list.take().unwrap_or_default();
+                                    metrics.list = Some(
+                                        list
+                                            .into_iter()
+                                            .map(|name| {
+                                                existing
+                                                    .iter()
+                                                    .find(|metric| metric.name == name)
+                                                    .cloned()
+                                                    .unwrap_or(MetricDefinition {
+                                                        name,
+                                                        direction: MetricDirection::Maximize,
+                                                    })
+                                            })
+                                            .collect(),
+                                    );
+                                });
+                        })
+                    />
+                    <div class="flex flex-col gap-2 mt-3">
+                        <For
+                            each=move || {
+                                metrics_rws.with(|metrics| metrics.list.clone().unwrap_or_default())
+                            }
+                            key=|metric| metric.name.clone()
+                            children=move |metric| {
+                                let metric_name = StoredValue::new(metric.name);
+                                let direction_label = match metric.direction {
+                                    MetricDirection::Maximize => "Maximize",
+                                    MetricDirection::Minimize => "Minimize",
+                                };
+                                let direction_options: Vec<MetricDirection> = vec![
+                                    MetricDirection::Maximize,
+                                    MetricDirection::Minimize,
+                                ];
+                                view! {
+                                    <div class="flex items-center justify-between gap-4">
+                                        <span class="text-sm truncate">
+                                            {metric_name.get_value()}
+                                        </span>
+                                        <Dropdown
+                                            dropdown_width="w-44"
+                                            dropdown_direction=DropdownDirection::Down
+                                            dropdown_btn_type=DropdownBtnType::Select
+                                            searchable=false
+                                            dropdown_text=direction_label.to_string()
+                                            dropdown_options=direction_options
+                                            on_select=Callback::new(move |direction: MetricDirection| {
+                                                metrics_rws
+                                                    .update(|metrics| {
+                                                        if let Some(metric) = metrics
+                                                            .list
+                                                            .as_mut()
+                                                            .and_then(|list| {
+                                                                list.iter_mut()
+                                                                    .find(|metric| { metric.name == metric_name.get_value() })
+                                                            })
+                                                        {
+                                                            metric.direction = direction;
+                                                        }
+                                                    });
+                                            })
+                                        />
+                                    </div>
+                                }
+                            }
+                        />
+                    </div>
+                </div>
             </div>
         }
     };
@@ -198,6 +292,304 @@ pub fn MetricsForm(
                 metrics_rws
                     .with(|m| m.enabled && matches!(m.source, Some(MetricSource::Grafana { .. })))
             }>{grafana_form_view}</Show>
+        </div>
+    }
+}
+
+#[component]
+pub fn ExperimentMetricsForm(
+    workspace_metrics: Metrics,
+    #[prop(default = ExperimentMetrics::default())] metrics: ExperimentMetrics,
+    on_change: Callback<ExperimentMetrics>,
+) -> impl IntoView {
+    let available_metrics =
+        StoredValue::new(workspace_metrics.list.clone().unwrap_or_default());
+    let workspace_source = StoredValue::new(workspace_metrics.source.clone());
+    let workspace_enabled = workspace_metrics.enabled;
+    // Selection is only offered when the workspace defines a metric list;
+    // matches the server rule at helpers.rs::validate_metric_selection.
+    let has_workspace_list = workspace_metrics
+        .list
+        .as_ref()
+        .is_some_and(|list| !list.is_empty());
+
+    let selection = metrics.selection().cloned();
+    let can_toggle = workspace_enabled || selection.is_some();
+    let enabled = RwSignal::new(selection.is_some());
+    let primary = RwSignal::new(
+        selection
+            .as_ref()
+            .map(|selection| selection.primary.clone())
+            .unwrap_or_default(),
+    );
+    let secondary = RwSignal::new(
+        selection
+            .as_ref()
+            .and_then(|selection| selection.secondary.clone()),
+    );
+    let guardrail = RwSignal::new(
+        selection
+            .as_ref()
+            .map(|selection| selection.guardrail.clone())
+            .unwrap_or_default(),
+    );
+    // Per-experiment source override is offered whenever the workspace has a
+    // source. `Metrics` deserialization guarantees a `Some` source is usable
+    // (blank Grafana fields are normalized to `None`), so a bare `is_some()`
+    // matches the server-side rule at handlers.rs.
+    let has_workspace_source = workspace_source.with_value(|s| s.as_ref().is_some());
+    let initial_source = if has_workspace_source {
+        metrics
+            .source()
+            .cloned()
+            .or_else(|| workspace_source.get_value())
+    } else {
+        None
+    };
+    let custom_source = RwSignal::new(initial_source);
+
+    let emit = move || {
+        let selection = (enabled.get_untracked() && has_workspace_list).then(|| {
+            MetricSelection {
+                primary: primary.get_untracked(),
+                secondary: secondary.get_untracked(),
+                guardrail: guardrail.get_untracked(),
+            }
+        });
+        // Only send source when it differs from the workspace source
+        let source = custom_source.get_untracked().filter(|source| {
+            workspace_source.with_value(|ws| ws.as_ref() != Some(source))
+        });
+        on_change.call(ExperimentMetrics::from_parts(selection, source));
+    };
+
+    let grafana_source_fields = move |source_rws: RwSignal<Option<MetricSource>>| {
+        let get_field = move |f: fn(&MetricSource) -> String| {
+            source_rws.with(|s| s.as_ref().map(f).unwrap_or_default())
+        };
+
+        view! {
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-4 pl-2.5 border-t border-dashed">
+                <div class="form-control">
+                    <label class="label">
+                        <span class="label-text-alt">Grafana Base URL</span>
+                    </label>
+                    <Input
+                        r#type=InputType::Text
+                        placeholder="Base URL".to_string()
+                        class="input-md w-full"
+                        schema_type=SchemaType::Single(JsonSchemaType::String)
+                        value=Value::String(
+                            get_field(|s| match s {
+                                MetricSource::Grafana { base_url, .. } => base_url.clone(),
+                            }),
+                        )
+                        on_change=move |val: Value| {
+                            let v = val.as_str().unwrap_or_default().to_string();
+                            source_rws
+                                .update(|s| {
+                                    if let Some(MetricSource::Grafana { base_url, .. }) = s.as_mut()
+                                    {
+                                        *base_url = v;
+                                    }
+                                });
+                            emit();
+                        }
+                    />
+                </div>
+                <div class="form-control">
+                    <label class="label">
+                        <span class="label-text-alt">Dashboard UID</span>
+                    </label>
+                    <Input
+                        r#type=InputType::Text
+                        placeholder="Dashboard UID".to_string()
+                        class="input-md w-full"
+                        schema_type=SchemaType::Single(JsonSchemaType::String)
+                        value=Value::String(
+                            get_field(|s| match s {
+                                MetricSource::Grafana { dashboard_uid, .. } => dashboard_uid.clone(),
+                            }),
+                        )
+                        on_change=move |val: Value| {
+                            let v = val.as_str().unwrap_or_default().to_string();
+                            source_rws
+                                .update(|s| {
+                                    if let Some(MetricSource::Grafana { dashboard_uid, .. }) = s
+                                        .as_mut()
+                                    {
+                                        *dashboard_uid = v;
+                                    }
+                                });
+                            emit();
+                        }
+                    />
+                </div>
+                <div class="form-control">
+                    <label class="label">
+                        <span class="label-text-alt">Dashboard Slug</span>
+                    </label>
+                    <Input
+                        r#type=InputType::Text
+                        placeholder="Dashboard Slug".to_string()
+                        class="input-md w-full"
+                        schema_type=SchemaType::Single(JsonSchemaType::String)
+                        value=Value::String(
+                            get_field(|s| match s {
+                                MetricSource::Grafana { dashboard_slug, .. } => {
+                                    dashboard_slug.clone()
+                                }
+                            }),
+                        )
+                        on_change=move |val: Value| {
+                            let v = val.as_str().unwrap_or_default().to_string();
+                            source_rws
+                                .update(|s| {
+                                    if let Some(MetricSource::Grafana { dashboard_slug, .. }) = s
+                                        .as_mut()
+                                    {
+                                        *dashboard_slug = v;
+                                    }
+                                });
+                            emit();
+                        }
+                    />
+                </div>
+                <div class="form-control">
+                    <label class="label">
+                        <span class="label-text-alt">Variant ID Alias (Optional)</span>
+                    </label>
+                    <Input
+                        r#type=InputType::Text
+                        placeholder="Variant ID Alias".to_string()
+                        class="input-md w-full"
+                        schema_type=SchemaType::Single(JsonSchemaType::String)
+                        value=Value::String(
+                            get_field(|s| match s {
+                                MetricSource::Grafana { variant_id_alias, .. } => {
+                                    variant_id_alias.clone().unwrap_or_default()
+                                }
+                            }),
+                        )
+                        on_change=move |val: Value| {
+                            let v = val.as_str().unwrap_or_default().to_string();
+                            source_rws
+                                .update(|s| {
+                                    if let Some(MetricSource::Grafana { variant_id_alias, .. }) = s
+                                        .as_mut()
+                                    {
+                                        *variant_id_alias = if v.is_empty() {
+                                            None
+                                        } else {
+                                            Some(v)
+                                        };
+                                    }
+                                });
+                            emit();
+                        }
+                    />
+                </div>
+            </div>
+        }
+    };
+
+    view! {
+        <div class="flex flex-col gap-3">
+            <div class="w-fit flex items-center gap-2">
+                <Toggle
+                    value=enabled.get_untracked()
+                    disabled=!can_toggle
+                    on_change=move |value| {
+                        enabled.set(value);
+                        emit();
+                    }
+                />
+                <Label
+                    title="Experiment Metrics"
+                    info=if workspace_enabled {
+                        String::new()
+                    } else {
+                        "Disabled at workspace level".to_string()
+                    }
+                />
+            </div>
+            <Show when=move || enabled.get()>
+                <Show when=move || has_workspace_list>
+                    <div class="flex flex-col gap-4 max-w-md">
+                        <div class="form-control">
+                            <Label title="Primary Metric" />
+                            <Dropdown
+                                dropdown_width="w-full"
+                                dropdown_direction=DropdownDirection::Down
+                                dropdown_btn_type=DropdownBtnType::Select
+                                dropdown_text={
+                                    let name = primary.get_untracked().name;
+                                    if name.is_empty() {
+                                        "Select primary metric".to_string()
+                                    } else {
+                                        name
+                                    }
+                                }
+                                dropdown_options=available_metrics.get_value()
+                                on_select=Callback::new(move |metric: MetricDefinition| {
+                                    primary.set(metric);
+                                    emit();
+                                })
+                            />
+                        </div>
+                        <div class="form-control">
+                            <Label title="Secondary Metric" info="(Optional)" />
+                            <Dropdown
+                                dropdown_width="w-full"
+                                dropdown_direction=DropdownDirection::Down
+                                dropdown_btn_type=DropdownBtnType::Select
+                                dropdown_text=secondary
+                                    .get_untracked()
+                                    .map(|metric| metric.name)
+                                    .unwrap_or_else(|| "No secondary metric".to_string())
+                                dropdown_options=available_metrics.get_value()
+                                on_select=Callback::new(move |metric: MetricDefinition| {
+                                    secondary.set(Some(metric));
+                                    emit();
+                                })
+                            />
+                        </div>
+                        <div class="form-control">
+                            <Label title="Guardrail Metric" />
+                            <Dropdown
+                                dropdown_width="w-full"
+                                dropdown_direction=DropdownDirection::Down
+                                dropdown_btn_type=DropdownBtnType::Select
+                                dropdown_text={
+                                    let name = guardrail.get_untracked().name;
+                                    if name.is_empty() {
+                                        "Select guardrail metric".to_string()
+                                    } else {
+                                        name
+                                    }
+                                }
+                                dropdown_options=available_metrics.get_value()
+                                on_select=Callback::new(move |metric: MetricDefinition| {
+                                    guardrail.set(metric);
+                                    emit();
+                                })
+                            />
+                        </div>
+                    </div>
+                </Show>
+                {has_workspace_source
+                    .then(|| {
+                        view! {
+                            <div class="form-control max-w-4xl mt-2">
+                                <Label
+                                    title="Metrics Source"
+                                    info="Override the workspace metrics source for this experiment"
+                                />
+                                {grafana_source_fields(custom_source)}
+                            </div>
+                        }
+                    })}
+            </Show>
         </div>
     }
 }

--- a/crates/frontend/src/pages/context_override.rs
+++ b/crates/frontend/src/pages/context_override.rs
@@ -17,7 +17,6 @@ use superposition_types::{
         default_config::DefaultConfigFilters,
         dimension::DimensionResponse,
         functions::FunctionEnvironment,
-        workspace::WorkspaceResponse,
     },
     custom_query::{CustomQuery, DimensionQuery, PaginationParams, Query, QueryMap},
     database::models::{
@@ -320,7 +319,6 @@ fn AutofillExperimentForm(
     default_config: Vec<DefaultConfig>,
     experiment_type: ExperimentType,
 ) -> impl IntoView {
-    let workspace_settings = use_context::<StoredValue<WorkspaceResponse>>().unwrap();
     let default_config = StoredValue::new(default_config);
     let dimensions = StoredValue::new(dimensions);
 
@@ -343,7 +341,6 @@ fn AutofillExperimentForm(
                                         default_config=default_config.get_value()
                                         dimensions=dimensions.get_value()
                                         handle_submit
-                                        metrics=workspace_settings.with_value(|w| w.metrics.clone())
                                     />
                                 }
                             }
@@ -357,7 +354,6 @@ fn AutofillExperimentForm(
                                         default_config=default_config.get_value()
                                         dimensions=dimensions.get_value()
                                         handle_submit
-                                        metrics=workspace_settings.with_value(|w| w.metrics.clone())
                                     />
                                 }
                             }

--- a/crates/frontend/src/pages/experiment_list.rs
+++ b/crates/frontend/src/pages/experiment_list.rs
@@ -12,7 +12,6 @@ use superposition_types::{
         default_config::DefaultConfigFilters,
         dimension::DimensionResponse,
         experiments::{ExperimentListFilters, ExperimentResponse},
-        workspace::WorkspaceResponse,
     },
     custom_query::{CustomQuery, DimensionQuery, PaginationParams, Query, QueryMap},
     database::models::cac::DefaultConfig,
@@ -46,7 +45,6 @@ struct CombinedResource {
 
 #[component]
 pub fn ExperimentList() -> impl IntoView {
-    let workspace_settings = use_context::<StoredValue<WorkspaceResponse>>().unwrap();
     let workspace = use_context::<Signal<Workspace>>().unwrap();
     let org = use_context::<Signal<OrganisationId>>().unwrap();
     let (reset_exp_form, set_exp_form) = create_signal(0);
@@ -215,7 +213,6 @@ pub fn ExperimentList() -> impl IntoView {
                                 dimensions=dim.clone()
                                 default_config=def_conf.clone()
                                 handle_submit=handle_submit_experiment_form
-                                metrics=workspace_settings.with_value(|w| w.metrics.clone())
                             />
                         </EditorProvider>
                     </Drawer>

--- a/crates/frontend/src/pages/override_page.rs
+++ b/crates/frontend/src/pages/override_page.rs
@@ -15,7 +15,8 @@ use crate::{
     api::{default_configs, delete_context, dimensions, get_context},
     components::{
         alert::AlertType,
-        button::Button,
+        button::{Button, ButtonAnchor},
+        context_override_form::{ContextOverrideForm, OverrideDetailView},
         skeleton::{Skeleton, SkeletonVariant},
     },
     logic::Conditions,
@@ -103,7 +104,7 @@ pub fn OverridePage() -> impl IntoView {
                     .into_iter()
                     .collect();
                 let description = context.description.clone();
-                let change_reason = context.change_reason.deref().to_string();
+                let change_reason = context.change_reason.clone();
                 let created_by = context.created_by.clone();
                 let created_at = context.created_at;
                 let last_modified_by = context.last_modified_by.clone();
@@ -115,7 +116,7 @@ pub fn OverridePage() -> impl IntoView {
                         <div class="flex justify-between items-center">
                             <h1 class="text-2xl font-extrabold">"Override"</h1>
                             <div class="w-full max-w-fit flex flex-row join">
-                                <crate::components::button::ButtonAnchor
+                                <ButtonAnchor
                                     force_style="btn join-item px-5 py-2.5 text-white bg-gradient-to-r from-purple-500 via-purple-600 to-purple-700 shadow-lg rounded-lg"
                                     href="edit"
                                     icon_class="ri-edit-line"
@@ -132,16 +133,16 @@ pub fn OverridePage() -> impl IntoView {
                             </div>
                         </div>
 
-                        <crate::components::context_override_form::OverrideDetailView
+                        <OverrideDetailView
                             context=conditions
-                            overrides=overrides
-                            description=description
-                            override_id=override_id
-                            change_reason=change_reason.clone()
-                            created_by=created_by
-                            created_at=created_at
-                            last_modified_by=last_modified_by
-                            last_modified_at=last_modified_at
+                            overrides
+                            description
+                            override_id
+                            change_reason
+                            created_by
+                            created_at
+                            last_modified_by
+                            last_modified_at
                         />
                     </div>
 
@@ -221,7 +222,6 @@ pub fn EditOverride() -> impl IntoView {
                     .into_iter()
                     .collect();
                 let description = context.description.deref().to_string();
-                let change_reason = context.change_reason.deref().to_string();
                 let FormPageResource { dimensions, default_config } = page_resource
                     .get()
                     .unwrap_or_default();
@@ -233,7 +233,7 @@ pub fn EditOverride() -> impl IntoView {
                 );
 
                 view! {
-                    <crate::components::context_override_form::ContextOverrideForm
+                    <ContextOverrideForm
                         edit=true
                         context_id=ctx_id
                         context=conditions
@@ -241,12 +241,10 @@ pub fn EditOverride() -> impl IntoView {
                         dimensions=dimensions
                         default_config=default_config
                         description=description
-                        change_reason=change_reason
                         redirect_url_cancel=redirect_url.clone()
                         redirect_url_success=redirect_url
                     />
                 }
-                    .into_view()
             }}
         </Suspense>
     }
@@ -317,7 +315,7 @@ pub fn CreateOverride() -> impl IntoView {
                 };
 
                 view! {
-                    <crate::components::context_override_form::ContextOverrideForm
+                    <ContextOverrideForm
                         edit=false
                         context=context
                         overrides=overrides
@@ -327,7 +325,6 @@ pub fn CreateOverride() -> impl IntoView {
                         redirect_url_success=redirect_url.get_value()
                     />
                 }
-                    .into_view()
             }}
         </Suspense>
     }

--- a/crates/frontend/src/types.rs
+++ b/crates/frontend/src/types.rs
@@ -10,6 +10,7 @@ use superposition_types::{
     api::dimension::DimensionResponse,
     custom_query::QueryParam,
     database::models::{
+        MetricDefinition, MetricDirection,
         cac::{DefaultConfig, DimensionType, TypeTemplate},
         experimentation::{Variant, VariantType},
         others::{HttpMethod, PayloadVersion, WebhookEvent},
@@ -296,6 +297,33 @@ impl DropdownOption for DimensionTypeOptions {
 
     fn label(&self) -> String {
         self.to_string()
+    }
+}
+
+impl DropdownOption for MetricDirection {
+    fn key(&self) -> String {
+        self.to_string()
+    }
+
+    fn label(&self) -> String {
+        match self {
+            MetricDirection::Maximize => "Maximize".to_string(),
+            MetricDirection::Minimize => "Minimize".to_string(),
+        }
+    }
+}
+
+impl DropdownOption for MetricDefinition {
+    fn key(&self) -> String {
+        self.name.clone()
+    }
+
+    fn label(&self) -> String {
+        let direction = match self.direction {
+            MetricDirection::Maximize => "Maximize",
+            MetricDirection::Minimize => "Minimize",
+        };
+        format!("{} ({direction})", self.name)
     }
 }
 

--- a/crates/superposition_types/src/api/experiments.rs
+++ b/crates/superposition_types/src/api/experiments.rs
@@ -13,16 +13,103 @@ use crate::{
     custom_query::{CommaSeparatedQParams, CommaSeparatedStringQParams, QueryParam},
     database::models::{
         experimentation::{
-            Experiment, ExperimentStatusType, ExperimentType, TrafficPercentage, Variant,
-            Variants,
+            Experiment, ExperimentMetrics, ExperimentStatusType, ExperimentType,
+            TrafficPercentage, Variant, Variants,
         },
-        ChangeReason, Description, MetricSource, Metrics,
+        ChangeReason, Description, MetricSelection, MetricSource,
     },
     experimental::{Experimental, ExperimentalVariants},
     Condition, Exp, IsEmpty, Overrides, SortBy,
 };
 
 use super::I64Update;
+
+/// Update payload for an experiment's metrics.
+///
+/// Serializes to a flat object with optional selection keys (primary,
+/// secondary, guardrail) and an optional `source` key:
+/// - selection keys omitted: keep the experiment's existing selection
+/// - `source` omitted: keep the experiment's existing source
+/// - `source: null`: clear the experiment's source
+/// - `source: {...}`: set a new source
+///
+/// At least one of selection keys or `source` must be present.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MetricSelectionUpdate {
+    Set {
+        selection: Option<MetricSelection>,
+        source: Option<Option<MetricSource>>,
+    },
+    Remove,
+}
+
+impl Serialize for MetricSelectionUpdate {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::Set { selection, source } => {
+                let mut value = match selection {
+                    Some(selection) => serde_json::to_value(selection)
+                        .map_err(serde::ser::Error::custom)?,
+                    None => serde_json::json!({}),
+                };
+                if let Some(source) = source {
+                    value
+                        .as_object_mut()
+                        .expect("selection serializes to object")
+                        .insert(
+                            "source".to_string(),
+                            serde_json::to_value(source)
+                                .map_err(serde::ser::Error::custom)?,
+                        );
+                }
+                value.serialize(serializer)
+            }
+            Self::Remove => serializer.serialize_none(),
+        }
+    }
+}
+
+fn deserialize_metric_selection_update<'de, D>(
+    deserializer: D,
+) -> Result<Option<MetricSelectionUpdate>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let mut value = Value::deserialize(deserializer)?;
+    if value.is_null() {
+        return Ok(Some(MetricSelectionUpdate::Remove));
+    }
+
+    // Extract the `source` key before deserializing the selection, since the
+    // selection itself has no `source` field. `null` means "clear the source",
+    // a missing key means "leave the source unchanged".
+    let source_value = value.as_object_mut().and_then(|map| map.remove("source"));
+    let source = source_value
+        .map(serde_json::from_value::<Option<MetricSource>>)
+        .transpose()
+        .map_err(serde::de::Error::custom)?;
+
+    // Selection keys are optional: a payload with only `source` updates just
+    // the source, leaving the existing selection untouched.
+    let has_selection_keys =
+        value.get("primary").is_some() || value.get("guardrail").is_some();
+    let selection = if has_selection_keys {
+        Some(serde_json::from_value(value).map_err(serde::de::Error::custom)?)
+    } else {
+        None
+    };
+
+    if selection.is_none() && source.is_none() {
+        return Err(serde::de::Error::custom(
+            "metrics update must contain at least one of selection keys or `source`",
+        ));
+    }
+
+    Ok(Some(MetricSelectionUpdate::Set { selection, source }))
+}
 
 /********** Experiment Response Type **************/
 // Same as models::Experiments but `id` field is String
@@ -50,35 +137,44 @@ pub struct ExperimentResponse {
     pub chosen_variant: Option<String>,
     pub description: Description,
     pub change_reason: ChangeReason,
-    pub metrics: Metrics,
+    pub metrics: ExperimentMetrics,
     pub metrics_url: Option<String>,
     pub experiment_group_id: Option<String>,
 }
 
 impl From<Experiment> for ExperimentResponse {
     fn from(experiment: Experiment) -> Self {
-        let metrics_url =
-            experiment.started_at.and_then(|started_at| {
-                experiment.metrics.source().map(|source| {
-                    match source {
-                        MetricSource::Grafana { base_url, dashboard_uid, dashboard_slug, variant_id_alias } => {
-                            let to = if experiment.status.active() {
-                                "now".to_string()
-                            } else {
-                                experiment.last_modified.to_string()
-                            };
-                            let from = started_at.timestamp_millis();
+        let metrics_url = experiment.started_at.and_then(|started_at| {
+            experiment.metrics.source().map(|source| match source {
+                MetricSource::Grafana {
+                    base_url,
+                    dashboard_uid,
+                    dashboard_slug,
+                    variant_id_alias,
+                } => {
+                    let to = if experiment.status.active() {
+                        "now".to_string()
+                    } else {
+                        experiment.last_modified.to_string()
+                    };
+                    let from = started_at.timestamp_millis();
+                    let variant_var = format!(
+                        "var-{}",
+                        variant_id_alias.as_deref().unwrap_or("variantIds")
+                    );
+                    let query = experiment
+                        .variants
+                        .iter()
+                        .map(|variant| format!("{}={}", variant_var, variant.id))
+                        .collect::<Vec<_>>()
+                        .join("&");
 
-                            let variant_var = format!("var-{}", variant_id_alias.unwrap_or_else(|| "variantIds".to_string()));
-                            let query = experiment.variants.iter().map(|v| {
-                                format!("{}={}", variant_var, v.id)
-                            }).collect::<Vec<String>>().join("&");
-
-                            format!("{base_url}/d/{dashboard_uid}/{dashboard_slug}?{query}&from={from}&to={to}&kiosk&theme=light")
-                        }
-                    }
-                })
-            });
+                    format!(
+                        "{base_url}/d/{dashboard_uid}/{dashboard_slug}?{query}&from={from}&to={to}&kiosk&theme=light"
+                    )
+                }
+            })
+        });
 
         Self {
             id: experiment.id.to_string(),
@@ -124,7 +220,8 @@ pub struct ExperimentCreateRequest {
     pub name: String,
     pub context: Exp<Condition>,
     pub variants: Vec<Variant>,
-    pub metrics: Option<Metrics>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metrics: Option<ExperimentMetrics>,
     #[serde(default)]
     pub experiment_type: ExperimentType,
     #[serde(default = "Description::default")]
@@ -280,10 +377,181 @@ pub struct VariantUpdateRequest {
 pub struct OverrideKeysUpdateRequest {
     #[serde(alias = "variant_list")]
     pub variants: Vec<VariantUpdateRequest>,
-    pub metrics: Option<Metrics>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_metric_selection_update"
+    )]
+    pub metrics: Option<MetricSelectionUpdate>,
     pub description: Option<Description>,
     #[serde(default = "ChangeReason::default")]
     pub change_reason: ChangeReason,
     #[serde(default, deserialize_with = "deserialize_option_i64")]
     pub experiment_group_id: Option<I64Update>,
+}
+
+#[cfg(test)]
+mod metric_selection_update_tests {
+    use serde_json::json;
+
+    use super::{MetricSelectionUpdate, OverrideKeysUpdateRequest};
+    use crate::database::models::ChangeReason;
+
+    #[test]
+    fn omitted_metrics_leave_the_selection_unchanged() {
+        let request = serde_json::from_value::<OverrideKeysUpdateRequest>(json!({
+            "variants": []
+        }))
+        .expect("update request without metrics");
+
+        assert!(request.metrics.is_none());
+    }
+
+    #[test]
+    fn null_metrics_clear_the_selection() {
+        let request = serde_json::from_value::<OverrideKeysUpdateRequest>(json!({
+            "variants": [],
+            "metrics": null
+        }))
+        .expect("update request clearing metrics");
+
+        assert!(matches!(
+            request.metrics,
+            Some(MetricSelectionUpdate::Remove)
+        ));
+    }
+
+    #[test]
+    fn metric_object_replaces_the_selection() {
+        let request = serde_json::from_value::<OverrideKeysUpdateRequest>(json!({
+            "variants": [],
+            "metrics": {
+                "primary": {
+                    "name": "conversion",
+                    "direction": "maximize"
+                },
+                "guardrail": {
+                    "name": "latency",
+                    "direction": "minimize"
+                }
+            }
+        }))
+        .expect("update request setting metrics");
+
+        assert!(matches!(
+            request.metrics,
+            Some(MetricSelectionUpdate::Set { source: None, .. })
+        ));
+    }
+
+    #[test]
+    fn metrics_with_source_sets_the_source() {
+        let request = serde_json::from_value::<OverrideKeysUpdateRequest>(json!({
+            "variants": [],
+            "metrics": {
+                "primary": {
+                    "name": "conversion",
+                    "direction": "maximize"
+                },
+                "guardrail": {
+                    "name": "latency",
+                    "direction": "minimize"
+                },
+                "source": {
+                    "grafana": {
+                        "base_url": "https://grafana.example.com",
+                        "dashboard_uid": "uid",
+                        "dashboard_slug": "slug",
+                        "variant_id_alias": null
+                    }
+                }
+            }
+        }))
+        .expect("update request setting metrics with source");
+
+        match request.metrics {
+            Some(MetricSelectionUpdate::Set {
+                source: Some(Some(_)),
+                ..
+            }) => {}
+            other => panic!("expected Set with Some(Some(source)), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn null_source_clears_the_source() {
+        let request = serde_json::from_value::<OverrideKeysUpdateRequest>(json!({
+            "variants": [],
+            "metrics": {
+                "primary": {
+                    "name": "conversion",
+                    "direction": "maximize"
+                },
+                "guardrail": {
+                    "name": "latency",
+                    "direction": "minimize"
+                },
+                "source": null
+            }
+        }))
+        .expect("update request clearing the source");
+
+        match request.metrics {
+            Some(MetricSelectionUpdate::Set {
+                source: Some(None), ..
+            }) => {}
+            other => panic!("expected Set with Some(None), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn remove_serializes_as_explicit_null() {
+        let request = OverrideKeysUpdateRequest {
+            variants: vec![],
+            metrics: Some(MetricSelectionUpdate::Remove),
+            description: None,
+            change_reason: ChangeReason::default(),
+            experiment_group_id: None,
+        };
+
+        assert!(serde_json::to_value(request).unwrap()["metrics"].is_null());
+    }
+
+    #[test]
+    fn set_with_source_round_trips() {
+        use crate::database::models::{
+            MetricDefinition, MetricDirection, MetricSelection, MetricSource,
+        };
+
+        let request = OverrideKeysUpdateRequest {
+            variants: vec![],
+            metrics: Some(MetricSelectionUpdate::Set {
+                selection: Some(MetricSelection {
+                    primary: MetricDefinition {
+                        name: "conversion".to_string(),
+                        direction: MetricDirection::Maximize,
+                    },
+                    secondary: None,
+                    guardrail: MetricDefinition {
+                        name: "latency".to_string(),
+                        direction: MetricDirection::Minimize,
+                    },
+                }),
+                source: Some(Some(MetricSource::Grafana {
+                    base_url: "https://grafana.example.com".to_string(),
+                    dashboard_uid: "uid".to_string(),
+                    dashboard_slug: "slug".to_string(),
+                    variant_id_alias: None,
+                })),
+            }),
+            description: None,
+            change_reason: ChangeReason::default(),
+            experiment_group_id: None,
+        };
+
+        let value = serde_json::to_value(&request).unwrap();
+        let round_tripped =
+            serde_json::from_value::<OverrideKeysUpdateRequest>(value).unwrap();
+        assert_eq!(round_tripped.metrics, request.metrics);
+    }
 }

--- a/crates/superposition_types/src/database/models.rs
+++ b/crates/superposition_types/src/database/models.rs
@@ -3,7 +3,7 @@ pub mod cac;
 pub mod experimentation;
 pub mod others;
 
-use std::str::FromStr;
+use std::{collections::HashSet, str::FromStr};
 
 use chrono::{DateTime, Utc};
 use derive_more::{Deref, DerefMut};
@@ -288,7 +288,7 @@ pub struct Workspace {
     pub workspace_lock_expires_at: Option<DateTime<Utc>>,
 }
 
-#[derive(Clone, Serialize, Deserialize, Debug)]
+#[derive(Clone, PartialEq, Serialize, Deserialize, Debug)]
 #[serde(rename_all = "lowercase")]
 pub enum MetricSource {
     Grafana {
@@ -319,14 +319,52 @@ impl Default for MetricSource {
 pub struct Metrics {
     pub enabled: bool,
     pub source: Option<MetricSource>,
+    pub list: Option<Vec<MetricDefinition>>,
+}
+
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialEq,
+    Eq,
+    Serialize,
+    Deserialize,
+    strum_macros::Display,
+)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum MetricDirection {
+    #[default]
+    Maximize,
+    Minimize,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MetricDefinition {
+    pub name: String,
+    pub direction: MetricDirection,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(
+    feature = "diesel_derives",
+    derive(AsExpression, FromSqlRow, JsonFromSql, JsonToSql)
+)]
+#[cfg_attr(feature = "diesel_derives", diesel(sql_type = Json))]
+pub struct MetricSelection {
+    pub primary: MetricDefinition,
+    pub secondary: Option<MetricDefinition>,
+    pub guardrail: MetricDefinition,
 }
 
 // TODO: Add validation for the source - that the given URL is valid and the
 // dashboard UID and slug are present in the URL - possible once API_KEY is added
 
 impl Metrics {
-    pub fn source(&self) -> Option<MetricSource> {
-        self.enabled.then(|| self.source.clone()).flatten()
+    pub fn source(&self) -> Option<&MetricSource> {
+        self.enabled.then_some(self.source.as_ref()).flatten()
     }
 }
 
@@ -339,16 +377,52 @@ impl<'de> Deserialize<'de> for Metrics {
         struct MetricsHelper {
             enabled: bool,
             source: Option<MetricSource>,
+            list: Option<Vec<MetricDefinition>>,
         }
         let helper = MetricsHelper::deserialize(deserializer)?;
-        if helper.enabled && helper.source.is_none() {
-            return Err(serde::de::Error::custom(
-                "`source` must be provided when enabled is true",
-            ));
+        // Treat a Grafana source with blank required fields as absent.
+        // Keeps the "source is Some ⇔ source is usable" invariant so callers
+        // don't need per-variant emptiness checks, and silently repairs any
+        // legacy rows that were persisted with an empty default source.
+        let source = helper.source.filter(|s| match s {
+            MetricSource::Grafana {
+                base_url,
+                dashboard_uid,
+                ..
+            } => !base_url.trim().is_empty() && !dashboard_uid.trim().is_empty(),
+        });
+        if helper.enabled {
+            let has_source = source.is_some();
+            let has_list = helper.list.as_ref().is_some_and(|list| !list.is_empty());
+            if !has_source && !has_list {
+                return Err(serde::de::Error::custom(
+                    "at least one of `source` or a non-empty `list` must be \
+                     provided when enabled is true",
+                ));
+            }
+            if let Some(list) = helper.list.as_ref().filter(|list| !list.is_empty()) {
+                if list.iter().any(|metric| metric.name.trim().is_empty()) {
+                    return Err(serde::de::Error::custom(
+                        "metric names in `list` must be non-empty",
+                    ));
+                }
+                if list
+                    .iter()
+                    .map(|metric| &metric.name)
+                    .collect::<HashSet<_>>()
+                    .len()
+                    != list.len()
+                {
+                    return Err(serde::de::Error::custom(
+                        "metric names in `list` must be unique",
+                    ));
+                }
+            }
         }
         Ok(Metrics {
             enabled: helper.enabled,
-            source: helper.source.clone(),
+            source,
+            list: helper.list,
         })
     }
 }
@@ -433,5 +507,108 @@ pub mod i64_formatter {
         let s = String::deserialize(deserializer)?;
         s.parse::<i64>()
             .map_err(|e| serde::de::Error::custom(format!("Failed to parse i64: {}", e)))
+    }
+}
+
+#[cfg(test)]
+mod metrics_tests {
+    use serde_json::json;
+
+    use super::{MetricSelection, Metrics};
+
+    fn enabled_metrics(list: serde_json::Value) -> serde_json::Value {
+        json!({
+            "enabled": true,
+            "source": {
+                "grafana": {
+                    "base_url": "https://grafana.example.com",
+                    "dashboard_uid": "experiment-metrics",
+                    "dashboard_slug": "experiments"
+                }
+            },
+            "list": list
+        })
+    }
+
+    #[test]
+    fn enabled_metrics_require_source_or_list() {
+        // Neither source nor list: error
+        assert!(serde_json::from_value::<Metrics>(json!({
+            "enabled": true
+        }))
+        .is_err());
+        // Source only: ok
+        assert!(serde_json::from_value::<Metrics>(json!({
+            "enabled": true,
+            "source": {
+                "grafana": {
+                    "base_url": "https://grafana.example.com",
+                    "dashboard_uid": "experiment-metrics",
+                    "dashboard_slug": "experiments"
+                }
+            }
+        }))
+        .is_ok());
+        // List only: ok
+        assert!(serde_json::from_value::<Metrics>(json!({
+            "enabled": true,
+            "list": [{"name": "conversion", "direction": "maximize"}]
+        }))
+        .is_ok());
+        // Both: ok
+        assert!(serde_json::from_value::<Metrics>(enabled_metrics(json!([
+            {"name": "conversion", "direction": "maximize"}
+        ])))
+        .is_ok());
+    }
+
+    #[test]
+    fn enabled_metrics_reject_blank_or_duplicate_names() {
+        assert!(serde_json::from_value::<Metrics>(enabled_metrics(json!([
+            {"name": "conversion", "direction": "maximize"},
+            {"name": " ", "direction": "minimize"}
+        ])))
+        .is_err());
+        assert!(serde_json::from_value::<Metrics>(enabled_metrics(json!([
+            {"name": "conversion", "direction": "maximize"},
+            {"name": "conversion", "direction": "minimize"}
+        ])))
+        .is_err());
+    }
+
+    #[test]
+    fn blank_grafana_source_is_normalized_to_none() {
+        // Enabled + blank source + no list: error (blank source counts as absent).
+        assert!(serde_json::from_value::<Metrics>(json!({
+            "enabled": true,
+            "source": {"grafana": {"base_url": "", "dashboard_uid": "", "dashboard_slug": ""}}
+        }))
+        .is_err());
+        // Enabled + blank source + list: ok, source is dropped.
+        let metrics = serde_json::from_value::<Metrics>(json!({
+            "enabled": true,
+            "source": {"grafana": {"base_url": "  ", "dashboard_uid": "", "dashboard_slug": ""}},
+            "list": [{"name": "conversion", "direction": "maximize"}]
+        }))
+        .unwrap();
+        assert!(metrics.source.is_none());
+        assert!(metrics.list.is_some());
+    }
+
+    #[test]
+    fn metric_selection_requires_primary_and_guardrail() {
+        assert!(serde_json::from_value::<MetricSelection>(json!({
+            "primary": {"name": "conversion", "direction": "maximize"}
+        }))
+        .is_err());
+        assert!(serde_json::from_value::<MetricSelection>(json!({
+            "guardrail": {"name": "latency", "direction": "minimize"}
+        }))
+        .is_err());
+        assert!(serde_json::from_value::<MetricSelection>(json!({
+            "primary": {"name": "conversion", "direction": "maximize"},
+            "guardrail": {"name": "latency", "direction": "minimize"}
+        }))
+        .is_ok());
     }
 }

--- a/crates/superposition_types/src/database/models/experimentation.rs
+++ b/crates/superposition_types/src/database/models/experimentation.rs
@@ -9,7 +9,7 @@ use diesel::{
     sql_types::{Array, Integer, Json, Nullable},
     Insertable, QueryId, Queryable, QueryableByName, Selectable,
 };
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value;
 #[cfg(feature = "diesel_derives")]
 use superposition_derives::{JsonFromSql, JsonToSql};
@@ -22,7 +22,250 @@ use crate::{
 
 #[cfg(feature = "diesel_derives")]
 use super::super::schema::*;
-use super::{i64_formatter, ChangeReason, Description, Metrics};
+use super::{i64_formatter, ChangeReason, Description, MetricSelection, MetricSource};
+
+#[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(
+    feature = "diesel_derives",
+    derive(AsExpression, FromSqlRow, JsonFromSql, JsonToSql)
+)]
+#[cfg_attr(feature = "diesel_derives", diesel(sql_type = Json))]
+pub struct ExperimentMetrics {
+    selection: Option<MetricSelection>,
+    source: Option<MetricSource>,
+}
+
+impl ExperimentMetrics {
+    /// Create a new ExperimentMetrics with at least one of selection or source.
+    /// Use `ExperimentMetrics::default()` for disabled metrics.
+    pub fn new(
+        selection: Option<MetricSelection>,
+        source: Option<MetricSource>,
+    ) -> Result<Self, String> {
+        if selection.is_none() && source.is_none() {
+            return Err("At least one of selection or source must be provided. \
+                 Use ExperimentMetrics::default() for disabled metrics."
+                .to_string());
+        }
+        Ok(Self { selection, source })
+    }
+
+    /// Check if metrics are enabled (at least one of selection or source is present)
+    pub fn is_enabled(&self) -> bool {
+        self.selection.is_some() || self.source.is_some()
+    }
+
+    /// Returns a reference to the metric source, if present.
+    pub fn source(&self) -> Option<&MetricSource> {
+        self.source.as_ref()
+    }
+
+    /// Build directly from optional parts. `(None, None)` is the disabled
+    /// sentinel (equivalent to `default()`); any other combination represents
+    /// enabled metrics. Prefer `new()` when validation of "at least one
+    /// present" is desired.
+    pub fn from_parts(
+        selection: Option<MetricSelection>,
+        source: Option<MetricSource>,
+    ) -> Self {
+        Self { selection, source }
+    }
+
+    /// Returns a reference to the metric selection, if present.
+    pub fn selection(&self) -> Option<&MetricSelection> {
+        self.selection.as_ref()
+    }
+
+    /// Consumes self and returns both the selection and source.
+    pub fn into_parts(self) -> (Option<MetricSelection>, Option<MetricSource>) {
+        (self.selection, self.source)
+    }
+}
+
+impl Serialize for ExperimentMetrics {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match (&self.selection, &self.source) {
+            // Default: Disabled
+            (None, None) => serde_json::json!({ "enabled": false }).serialize(serializer),
+            // Both present: merge into single object
+            (Some(selection), Some(source)) => {
+                let mut value =
+                    serde_json::to_value(selection).map_err(serde::ser::Error::custom)?;
+                value
+                    .as_object_mut()
+                    .expect("selection serializes to object")
+                    .insert(
+                        "source".to_string(),
+                        serde_json::to_value(source)
+                            .map_err(serde::ser::Error::custom)?,
+                    );
+                value.serialize(serializer)
+            }
+            // Only selection
+            (Some(selection), None) => selection.serialize(serializer),
+            // Only source
+            (None, Some(source)) => {
+                let mut map = serde_json::Map::new();
+                map.insert(
+                    "source".to_string(),
+                    serde_json::to_value(source).map_err(serde::ser::Error::custom)?,
+                );
+                Value::Object(map).serialize(serializer)
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ExperimentMetrics {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+
+        // Handle disabled/null case (default)
+        if value.is_null() || value.get("enabled") == Some(&Value::Bool(false)) {
+            return Ok(Self::default());
+        }
+
+        // Try to extract source
+        let mut value = value;
+        let source = value
+            .as_object_mut()
+            .and_then(|map| map.remove("source"))
+            .map(serde_json::from_value)
+            .transpose()
+            .map_err(serde::de::Error::custom)?;
+
+        // Try to extract selection (only if it has metric fields)
+        let has_metric_fields =
+            value.get("primary").is_some() || value.get("guardrail").is_some();
+
+        let selection = if has_metric_fields {
+            Some(serde_json::from_value(value).map_err(serde::de::Error::custom)?)
+        } else {
+            None
+        };
+
+        Ok(Self { selection, source })
+    }
+}
+
+#[cfg(test)]
+mod experiment_metrics_tests {
+    use serde_json::json;
+
+    use super::ExperimentMetrics;
+
+    #[test]
+    fn disabled_metrics_deserialize_to_default() {
+        let metrics = serde_json::from_value::<ExperimentMetrics>(json!({
+            "enabled": false
+        }))
+        .expect("disabled metrics sentinel");
+
+        assert!(metrics.selection().is_none());
+        assert!(metrics.source().is_none());
+        assert!(!metrics.is_enabled());
+    }
+
+    #[test]
+    fn default_serializes_to_disabled() {
+        assert_eq!(
+            serde_json::to_value(ExperimentMetrics::default()).unwrap(),
+            json!({ "enabled": false })
+        );
+    }
+
+    #[test]
+    fn source_only_round_trips() {
+        let value = json!({
+            "source": {
+                "grafana": {
+                    "base_url": "https://grafana.example.com",
+                    "dashboard_uid": "experiment-metrics",
+                    "dashboard_slug": "experiments",
+                    "variant_id_alias": null
+                }
+            }
+        });
+        let metrics = serde_json::from_value::<ExperimentMetrics>(value.clone())
+            .expect("source only");
+
+        assert!(metrics.selection().is_none());
+        assert!(metrics.source().is_some());
+        assert!(metrics.is_enabled());
+        assert_eq!(serde_json::to_value(metrics).unwrap(), value);
+    }
+
+    #[test]
+    fn selection_only_round_trips() {
+        let value = json!({
+            "primary": {"name": "conversion", "direction": "maximize"},
+            "secondary": null,
+            "guardrail": {"name": "latency", "direction": "minimize"}
+        });
+        let metrics = serde_json::from_value::<ExperimentMetrics>(value.clone())
+            .expect("selection only");
+
+        assert!(metrics.selection().is_some());
+        assert!(metrics.source().is_none());
+        assert!(metrics.is_enabled());
+        assert_eq!(serde_json::to_value(metrics).unwrap(), value);
+    }
+
+    #[test]
+    fn both_selection_and_source_round_trips() {
+        let value = json!({
+            "primary": {"name": "conversion", "direction": "maximize"},
+            "secondary": null,
+            "guardrail": {"name": "latency", "direction": "minimize"},
+            "source": {
+                "grafana": {
+                    "base_url": "https://grafana.example.com",
+                    "dashboard_uid": "experiment-metrics",
+                    "dashboard_slug": "experiments",
+                    "variant_id_alias": null
+                }
+            }
+        });
+        let metrics = serde_json::from_value::<ExperimentMetrics>(value.clone())
+            .expect("both selection and source");
+
+        assert!(metrics.selection().is_some());
+        assert!(metrics.source().is_some());
+        assert!(metrics.is_enabled());
+        assert_eq!(serde_json::to_value(metrics).unwrap(), value);
+    }
+
+    #[test]
+    fn new_requires_at_least_one() {
+        use crate::database::models::{MetricDefinition, MetricDirection, MetricSource};
+
+        let selection = crate::database::models::MetricSelection {
+            primary: MetricDefinition {
+                name: "conversion".to_string(),
+                direction: MetricDirection::Maximize,
+            },
+            secondary: None,
+            guardrail: MetricDefinition {
+                name: "latency".to_string(),
+                direction: MetricDirection::Minimize,
+            },
+        };
+
+        assert!(ExperimentMetrics::new(None, None).is_err());
+        assert!(ExperimentMetrics::new(Some(selection.clone()), None).is_ok());
+        assert!(ExperimentMetrics::new(None, Some(MetricSource::default())).is_ok());
+        assert!(
+            ExperimentMetrics::new(Some(selection), Some(MetricSource::default()))
+                .is_ok()
+        );
+    }
+}
 
 #[derive(
     Debug,
@@ -307,7 +550,7 @@ pub struct Experiment {
     pub chosen_variant: Option<String>,
     pub description: Description,
     pub change_reason: ChangeReason,
-    pub metrics: Metrics,
+    pub metrics: ExperimentMetrics,
     pub experiment_group_id: Option<i64>,
     pub idempotency_key: Option<String>,
 }

--- a/smithy/models/experiments.smithy
+++ b/smithy/models/experiments.smithy
@@ -152,6 +152,7 @@ structure ExperimentResponse for Experiments {
 
     $metrics_url
 
+    @documentation("Optional metrics for this experiment, snapshotted from workspace definitions. May carry a selection (primary and guardrail required, secondary optional) and/or a per-experiment source override; both are optional independently, and omitting both means metrics are disabled.")
     $metrics
 
     $experiment_group_id
@@ -175,6 +176,7 @@ structure CreateExperimentRequest for Experiments with [WorkspaceMixin] {
     @required
     $change_reason
 
+    @documentation("Optional metrics for the experiment. May carry a selection drawn from the workspace's metric list (primary and guardrail required, secondary optional) and/or a per-experiment source override; both are optional independently. A per-experiment source is only accepted when the workspace has a source configured.")
     $metrics
 
     $experiment_group_id
@@ -215,6 +217,7 @@ structure UpdateOverrideRequest for Experiments with [WorkspaceMixin] {
     @required
     $change_reason
 
+    @documentation("Metric selection update using workspace metric definitions containing name and direction. Omit to preserve the current selection, pass null to clear it, or pass a selection object to replace it. Updates are allowed only while the experiment is in CREATED state.")
     $metrics
 
     @documentation("To unset experiment group, pass \"null\" string.")

--- a/smithy/models/workspace.smithy
+++ b/smithy/models/workspace.smithy
@@ -77,6 +77,7 @@ structure CreateWorkspaceRequest for Workspace with [OrganisationMixin] {
 
     $workspace_status
 
+    @documentation("Workspace metric source and catalog. Each metric definition contains a unique name and whether higher or lower values are better.")
     $metrics
 
     $allow_experiment_self_approval
@@ -102,6 +103,7 @@ structure UpdateWorkspaceRequest for Workspace with [OrganisationMixin] {
 
     $workspace_status
 
+    @documentation("Workspace metric source and catalog. Each metric definition contains a unique name and whether higher or lower values are better.")
     $metrics
 
     $allow_experiment_self_approval
@@ -155,6 +157,7 @@ structure WorkspaceResponse for Workspace {
     $mandatory_dimensions
 
     @required
+    @documentation("Workspace metric source and catalog. Each metric definition contains a unique name and whether higher or lower values are better.")
     $metrics
 
     @required


### PR DESCRIPTION
- add primary, secondary, guardrail, and hypothesis fields
- validate experiment selections against workspace metric definitions
- snapshot the Grafana source for experiment metrics
- support setting, clearing, and preserving metrics during updates
- add workspace and experiment metric configuration UI
- display metric selections in experiment details

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable experiment metrics, including primary, secondary, guardrail, and hypothesis fields.
  * Added workspace metric definitions and metric selection controls to experiment forms.
  * Added support for replacing or removing metrics during experiment updates.

* **Bug Fixes**
  * Added validation for unavailable, undefined, blank, and duplicate metric selections.
  * Improved metric display when metrics are disabled or partially configured.

* **Documentation**
  * Documented experiment metric selection, updates, and workspace metric configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->