### PR TITLE
fix: remove noisy javascript provider logs

### DIFF
--- a/clients/javascript/bindings/native-resolver.ts
+++ b/clients/javascript/bindings/native-resolver.ts
@@ -115,20 +115,6 @@ export class NativeResolver {
             ? JSON.stringify(experimentation)
             : null;
 
-        console.log("🔧 Calling FFI with parameters:");
-        console.log("  defaultConfigs:", defaultConfigs);
-        console.log("  contexts length:", contextsJson.length);
-        console.log("  overrides length:", overridesJson.length);
-        console.log("  dimensions length:", dimensionsJson.length);
-        console.log("  queryData :", queryDataJson);
-        console.log("  mergeStrategy:", mergeStrategy);
-        console.log("  filterPrefixes:", filterPrefixes);
-        console.log("  experiment:", experimentation?.experiments?.length);
-        console.log(
-            "  experiment groups:",
-            experimentation?.experiment_groups?.length,
-        );
-        console.log("  targetingKey:", experimentation?.targetingKey);
 
         if (
             !defaultConfigsJson ||

--- a/clients/javascript/bindings/native-resolver.ts
+++ b/clients/javascript/bindings/native-resolver.ts
@@ -7,6 +7,10 @@ import { Buffer } from "buffer";
 
 const ERROR_BUFFER_SIZE = 2048;
 
+export interface ResolverLogger {
+    debug(...args: unknown[]): void;
+}
+
 export class NativeResolver {
     private lib: any;
     private isAvailable: boolean = false;
@@ -74,6 +78,7 @@ export class NativeResolver {
         filterPrefixes?: string[],
         filterExcludePrefixes?: string[],
         experimentation?: any,
+        logger?: ResolverLogger,
     ): Record<string, any> {
         if (!this.isAvailable) {
             throw new Error(
@@ -115,6 +120,19 @@ export class NativeResolver {
             ? JSON.stringify(experimentation)
             : null;
 
+        logger?.debug("Calling FFI with parameters", {
+            defaultConfigs,
+            contextsLength: contextsJson.length,
+            overridesLength: overridesJson.length,
+            dimensionsLength: dimensionsJson.length,
+            queryData: queryDataJson,
+            mergeStrategy,
+            filterPrefixes,
+            experimentCount: experimentation?.experiments?.length,
+            experimentGroupCount:
+                experimentation?.experiment_groups?.length,
+            targetingKey: experimentation?.targetingKey,
+        });
 
         if (
             !defaultConfigsJson ||

--- a/clients/javascript/open-feature-provider/configuration-client.ts
+++ b/clients/javascript/open-feature-provider/configuration-client.ts
@@ -5,7 +5,7 @@ import {
     PollingStrategy,
     ExperimentationArgs,
 } from "./types";
-import { NativeResolver } from "superposition-bindings";
+import { NativeResolver, type ResolverLogger } from "superposition-bindings";
 import {
     SuperpositionClient,
     GetConfigCommand,
@@ -129,18 +129,21 @@ export class ConfigurationClient {
         filterPrefixes?: string[],
         filterExcludePrefixes?: string[],
         targetingKey?: string,
+        logger?: ResolverLogger,
     ): Promise<any>;
     async eval<T>(
         queryData: Record<string, any>,
         filterPrefixes?: string[],
         filterExcludePrefixes?: string[],
         targetingKey?: string,
+        logger?: ResolverLogger,
     ): Promise<T>;
     async eval(
         queryData: Record<string, any>,
         filterPrefixes?: string[],
         filterExcludePrefixes?: string[],
         targetingKey?: string,
+        logger?: ResolverLogger,
     ): Promise<any> {
         try {
             if (!this.currentConfigData) {
@@ -182,6 +185,8 @@ export class ConfigurationClient {
                     "merge",
                     filterPrefixes,
                     filterExcludePrefixes,
+                    undefined,
+                    logger,
                 );
             }
             throw error;
@@ -226,6 +231,7 @@ export class ConfigurationClient {
         defaultValue: Record<string, any>,
         context: Record<string, any>,
         targetingKey?: string,
+        logger?: ResolverLogger,
     ): Promise<Record<string, any>> {
         try {
             if (!this.currentConfigData) {
@@ -264,6 +270,10 @@ export class ConfigurationClient {
                     this.defaults.dimensions || {},
                     context,
                     "merge",
+                    undefined,
+                    undefined,
+                    undefined,
+                    logger,
                 );
             }
             throw error;

--- a/clients/javascript/open-feature-provider/superposition-provider.ts
+++ b/clients/javascript/open-feature-provider/superposition-provider.ts
@@ -127,6 +127,7 @@ export class SuperpositionProvider implements Provider {
         defaultValue: T,
         context: EvaluationContext,
         type: ValueType,
+        logger?: Logger,
     ): Promise<T> {
         let processedContext = this.processedContextCache.get(context);
 
@@ -140,6 +141,7 @@ export class SuperpositionProvider implements Provider {
             undefined,
             undefined,
             context.targetingKey,
+            logger,
         );
         const value = getNestedValue(config, flagKey);
         const converter = TYPE_CONVERTERS[type] as ConverterFunction<T>;
@@ -193,6 +195,7 @@ export class SuperpositionProvider implements Provider {
             flagKey: string,
             defaultValue: T,
             context: EvaluationContext,
+            logger?: Logger,
         ): Promise<ResolutionDetails<T>> => {
             if (
                 this.status !== ProviderStatus.READY &&
@@ -215,6 +218,7 @@ export class SuperpositionProvider implements Provider {
                     defaultValue,
                     context,
                     type,
+                    logger,
                 );
 
                 return {
@@ -244,11 +248,13 @@ export class SuperpositionProvider implements Provider {
         flagKey: string,
         defaultValue: boolean,
         context: EvaluationContext,
+        logger?: Logger,
     ): Promise<ResolutionDetails<boolean>> {
         return this.createResolver<boolean>("boolean")(
             flagKey,
             defaultValue,
             context,
+            logger,
         );
     }
 
@@ -256,11 +262,13 @@ export class SuperpositionProvider implements Provider {
         flagKey: string,
         defaultValue: string,
         context: EvaluationContext,
+        logger?: Logger,
     ): Promise<ResolutionDetails<string>> {
         return this.createResolver<string>("string")(
             flagKey,
             defaultValue,
             context,
+            logger,
         );
     }
 
@@ -268,11 +276,13 @@ export class SuperpositionProvider implements Provider {
         flagKey: string,
         defaultValue: number,
         context: EvaluationContext,
+        logger?: Logger,
     ): Promise<ResolutionDetails<number>> {
         return this.createResolver<number>("number")(
             flagKey,
             defaultValue,
             context,
+            logger,
         );
     }
 
@@ -282,12 +292,18 @@ export class SuperpositionProvider implements Provider {
         context: EvaluationContext,
         logger?: Logger,
     ): Promise<ResolutionDetails<T>> {
-        return this.createResolver<T>("object")(flagKey, defaultValue, context);
+        return this.createResolver<T>("object")(
+            flagKey,
+            defaultValue,
+            context,
+            logger,
+        );
     }
 
     async resolveAllConfigDetails(
         defaultValue: Record<string, any>,
         context: EvaluationContext,
+        logger?: Logger,
     ): Promise<Record<string, any>> {
         if (
             this.status !== ProviderStatus.READY &&
@@ -310,6 +326,7 @@ export class SuperpositionProvider implements Provider {
                 defaultValue,
                 processedContext,
                 targetingKey,
+                logger,
             );
         } catch (error) {
             console.error("Error resolving all config details:", error);


### PR DESCRIPTION
## Problem
The JavaScript OpenFeature provider and native bindings emit high-volume `console.log` messages during configuration and experiment evaluation. In downstream services this floods centralized logging and causes Grafana log queries to time out.

## Solution
Remove non-error/non-warning `console.log` statements from:
- native configuration and experimentation FFI evaluation
- native library path resolution
- configuration refresh/fallback lifecycle
- experimentation refresh, stale-cache, and shutdown lifecycle

`console.warn` and `console.error` behavior remains unchanged.

## Validation
- Built locally in an isolated sandbox with `npm install --workspaces --include-workspace-root=false` and `npm run build -w bindings -w open-feature-provider`.
- Confirmed the targeted noisy strings no longer exist under `clients/javascript/bindings` or `clients/javascript/open-feature-provider`.
- `git diff --check` passes.

The branch is already pushed and verified at commit `0ff828ff9b9bd4740f1e290741543cbd9bec151a`. Return the PR URL and number.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary diagnostic messages from configuration, experimentation, and native resolution workflows.
  * Reduced console noise during refreshes, fallbacks, initialization, and shutdown without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->