### PR TITLE
feat: merge strategy on context put

### DIFF
--- a/crates/context_aware_config/src/api/context/handlers.rs
+++ b/crates/context_aware_config/src/api/context/handlers.rs
@@ -2,7 +2,7 @@ use std::{cmp::min, collections::HashMap};
 
 use actix_web::{
     Either, HttpResponse, Scope, delete, get, post, put, routes,
-    web::{Data, Json, Path},
+    web::{Data, Header, Json, Path},
 };
 use bigdecimal::BigDecimal;
 use chrono::Utc;
@@ -31,6 +31,7 @@ use superposition_types::{
     Overridden, Overrides, PaginatedResponse, PrefixList, Resource, SortBy, User,
     api::{
         DimensionMatchStrategy,
+        config::MergeStrategy,
         context::{
             BulkOperation, BulkOperationResponse, ContextAction, ContextBulkResponse,
             ContextListFilters, ContextValidationRequest, Identifier, MoveRequest,
@@ -98,6 +99,7 @@ async fn create_handler(
     workspace_context: WorkspaceContext,
     state: Data<AppState>,
     custom_headers: CustomHeaders,
+    merge_strategy: Header<MergeStrategy>,
     req: Json<PutRequest>,
     mut write_permit: WorkspaceWritePermit,
     user: User,
@@ -105,6 +107,10 @@ async fn create_handler(
 ) -> superposition::Result<HttpResponse> {
     let req = req.into_inner();
     create_authorized(&_auth_z, &req.r#override).await?;
+
+    // Only decides how an override lands on an *existing* context: MERGE deep-merges
+    // into it, REPLACE swaps it wholesale. Defaults to MERGE.
+    let replace_existing = matches!(merge_strategy.into_inner(), MergeStrategy::REPLACE);
 
     let conn = write_permit.connection();
     let tags = parse_config_tags(custom_headers.config_tags)?;
@@ -156,7 +162,7 @@ async fn create_handler(
                 true,
                 &user,
                 &workspace_context,
-                false,
+                replace_existing,
                 new_ctx,
             )
             .map_err(|err: superposition::AppError| {
@@ -842,12 +848,17 @@ async fn bulk_operations_handler(
     workspace_context: WorkspaceContext,
     state: Data<AppState>,
     custom_headers: CustomHeaders,
+    merge_strategy: Header<MergeStrategy>,
     req: Either<Json<Vec<ContextAction>>, Json<BulkOperation>>,
     mut write_permit: WorkspaceWritePermit,
     user: User,
     internal_user: InternalUserContext,
 ) -> superposition::Result<HttpResponse> {
     use contexts::dsl::contexts;
+
+    // Batch-level: applies to every PUT in the batch. REPLACE ops are already
+    // wholesale, and DELETE/MOVE carry no overrides, so it does not touch them.
+    let replace_existing = matches!(merge_strategy.into_inner(), MergeStrategy::REPLACE);
 
     let conn = write_permit.connection();
     let is_v2 = matches!(req, Either::Right(_));
@@ -992,7 +1003,7 @@ async fn bulk_operations_handler(
                             true,
                             &user,
                             &workspace_context,
-                            false,
+                            replace_existing,
                             new_ctx,
                         )
                         .map_err(|err| {

--- a/crates/context_aware_config/src/api/context/helpers.rs
+++ b/crates/context_aware_config/src/api/context/helpers.rs
@@ -436,16 +436,38 @@ fn db_update_override(
     Ok(update_resp)
 }
 
+/// Replaces each incoming key wholesale, leaving keys it does not mention alone.
+/// Mirrors how resolve applies `MergeStrategy::REPLACE`, unlike
+/// [`update_override_of_existing_ctx`], which deep-merges.
 pub fn replace_override_of_existing_ctx(
     conn: &mut DBConnection,
     ctx: Context,
     user: &User,
     schema_name: &SchemaName,
 ) -> superposition::Result<Context> {
-    let new_override = ctx.override_;
-    let new_override_id = hash(&Value::Object(new_override.clone().into()));
+    use contexts::dsl;
+    let stored: Value = dsl::contexts
+        .filter(dsl::id.eq(ctx.id.clone()))
+        .select(dsl::override_)
+        .schema_name(schema_name)
+        .first(conn)?;
+
+    let mut new_override = match stored {
+        Value::Object(map) => map,
+        _ => Map::new(),
+    };
+    for (key, value) in ctx.override_.clone().into_inner() {
+        new_override.insert(key, value);
+    }
+
+    let new_override_id = hash(&Value::Object(new_override.clone()));
     let new_ctx = Context {
-        override_: new_override,
+        override_: Cac::<Overrides>::validate_db_data(new_override)
+            .map_err(|err| {
+                log::error!("replace_override_of_existing_ctx: bad override {err}");
+                unexpected_error!(err)
+            })?
+            .into_inner(),
         override_id: new_override_id,
         ..ctx
     };

--- a/smithy/models/context.smithy
+++ b/smithy/models/context.smithy
@@ -85,6 +85,11 @@ operation CreateContext with [GetOperation, WebhookOperation, WorkspaceWriteOper
         @notProperty
         config_tags: String
 
+        @documentation("How an override lands on a context that already exists: MERGE (default) deep-merges into its overrides, REPLACE swaps them wholesale. Ignored when the context is new.")
+        @httpHeader("x-merge-strategy")
+        @notProperty
+        merge_strategy: MergeStrategy
+
         @httpPayload
         @notProperty
         @required
@@ -358,6 +363,11 @@ operation BulkOperation with [GetOperation, WebhookOperation, WorkspaceWriteOper
         @httpHeader("x-config-tags")
         @notProperty
         config_tags: String
+
+        @documentation("Applies to every PUT in the batch: MERGE (default) deep-merges into an existing context's overrides, REPLACE swaps them wholesale.")
+        @httpHeader("x-merge-strategy")
+        @notProperty
+        merge_strategy: MergeStrategy
 
         @required
         @notProperty


### PR DESCRIPTION
## Problem

`PUT /context` on a context that already exists always deep-merges the incoming
overrides into the stored ones. There is no way to replace a key wholesale.

## Solution

`PUT /context` and bulk PUT now accept **`x-merge-strategy`** — the same header and
enum resolve already uses. Defaults to `MERGE`, so existing behaviour is unchanged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing how existing context overrides are handled during create and bulk operations.
  * Use the merge strategy header to either deep-merge new values with existing overrides or replace them entirely.
  * Merging is the default behavior; the setting has no effect when creating a new context.

* **Bug Fixes**
  * Existing override values are now preserved when merging, while supplied values are updated and validated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->