### PR TITLE
fix: free Rust-owned FFI strings to stop native memory leak

### DIFF
--- a/clients/javascript/bindings/native-resolver.ts
+++ b/clients/javascript/bindings/native-resolver.ts
@@ -10,6 +10,7 @@ const ERROR_BUFFER_SIZE = 2048;
 export interface ResolverLogger {
     debug(...args: unknown[]): void;
 }
+let ownedStrTypeRegistered = false;
 
 export class NativeResolver {
     private lib: any;
@@ -19,24 +20,29 @@ export class NativeResolver {
         try {
             this.lib = koffi.load(libPath || this.getDefaultLibPath());
 
-            // Define the core resolution functions with CORRECT 8 parameters each
-            this.lib.core_get_resolved_config = this.lib.func(
-                "char* core_get_resolved_config(const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*)",
-            );
             this.lib.core_free_string = this.lib.func(
                 "void core_free_string(char*)",
             );
+
+            if (!ownedStrTypeRegistered) {
+                koffi.disposable("OwnedStr", "str", this.lib.core_free_string);
+                ownedStrTypeRegistered = true;
+            }
+
+            this.lib.core_get_resolved_config = this.lib.func(
+                "OwnedStr core_get_resolved_config(const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*, const char*)",
+            );
             this.lib.core_get_applicable_variants = this.lib.func(
-                "char* core_get_applicable_variants(const char*, const char*, const char*, const char*, const char*, const char*, const char*, char*)",
+                "OwnedStr core_get_applicable_variants(const char*, const char*, const char*, const char*, const char*, const char*, const char*, char*)",
             );
             this.lib.core_test_connection = this.lib.func(
                 "int core_test_connection()",
             );
             this.lib.core_parse_toml_config = this.lib.func(
-                "char* core_parse_toml_config(const char*, char*)",
+                "OwnedStr core_parse_toml_config(const char*, char*)",
             );
             this.lib.core_parse_json_config = this.lib.func(
-                "char* core_parse_json_config(const char*, char*)",
+                "OwnedStr core_parse_json_config(const char*, char*)",
             );
             this.lib.core_provider_cache_new = this.lib.func(
                 "void* core_provider_cache_new()",
@@ -51,7 +57,7 @@ export class NativeResolver {
                 "void core_provider_cache_init_experiments(void*, const char*, const char*, char*)",
             );
             this.lib.core_provider_cache_eval_config = this.lib.func(
-                "char* core_provider_cache_eval_config(void*, const char*, const char*, const char*, const char*, const char*, char*)",
+                "OwnedStr core_provider_cache_eval_config(void*, const char*, const char*, const char*, const char*, const char*, char*)",
             );
 
             this.isAvailable = true;
@@ -191,14 +197,7 @@ export class NativeResolver {
             this.throwFFIError(err);
         }
 
-        const configStr =
-            typeof result === "string"
-                ? result
-                : this.lib.decode(result, "string");
-
-        if (typeof result !== "string") {
-            this.lib.core_free_string(result);
-        }
+        const configStr = result;
 
         try {
             return JSON.parse(configStr);
@@ -274,14 +273,7 @@ export class NativeResolver {
             this.throwFFIError(err);
         }
 
-        const resultStr =
-            typeof result === "string"
-                ? result
-                : this.lib.decode(result, "string");
-
-        if (typeof result !== "string") {
-            this.lib.core_free_string(result);
-        }
+        const resultStr = result;
 
         try {
             return JSON.parse(resultStr);
@@ -338,16 +330,7 @@ export class NativeResolver {
             throw new Error(`TOML parsing failed: ${errorMsg}`);
         }
 
-        // Decode the result to a JS string if it's not already a string
-        const configStr =
-            typeof resultJson === "string"
-                ? resultJson
-                : this.lib.decode(resultJson, "string");
-
-        // Free the native string if it wasn't already a string
-        if (typeof resultJson !== "string") {
-            this.lib.core_free_string(resultJson);
-        }
+        const configStr = resultJson;
 
         // Parse the JSON result
         try {
@@ -404,16 +387,7 @@ export class NativeResolver {
             throw new Error(`JSON parsing failed: ${errorMsg}`);
         }
 
-        // Decode the result to a JS string if it's not already a string
-        const configStr =
-            typeof resultJson === "string"
-                ? resultJson
-                : this.lib.decode(resultJson, "string");
-
-        // Free the native string if it wasn't already a string
-        if (typeof resultJson !== "string") {
-            this.lib.core_free_string(resultJson);
-        }
+        const configStr = resultJson;
 
         // Parse the JSON result
         try {
@@ -611,12 +585,7 @@ export class NativeResolver {
                 );
                 const err = ebuf.toString("utf8").split("\0")[0];
                 if (err.length !== 0) throw new Error("ffi: " + err);
-                const configStr =
-                    typeof result === "string"
-                        ? result
-                        : lib.decode(result, "string");
-                if (typeof result !== "string") lib.core_free_string(result);
-                return JSON.parse(configStr);
+                return JSON.parse(result);
             },
             free(): void {
                 lib.core_provider_cache_free(handle);


### PR DESCRIPTION
## Problem
The JavaScript client's native resolver leaks native (Rust-owned) memory on **every** FFI call that returns a string. The five string-returning functions were declared with a `char*` return type, so koffi auto-decodes the return into a JS string (a copy) and discards the original pointer. That makes `typeof result === "string"` always true, which means the `core_free_string(result)` calls are **dead code** and the Rust `CString` (`CString::into_raw`) is never freed.

Every evaluation leaks the full returned string (for `core_get_resolved_config`, that's the entire resolved config, ~KBs). In a long-running, high-throughput consumer this grows the process's native heap linearly until it OOMs. Confirmed with jemalloc heap profiling (`jeprof` diff): `alloc::ffi::c_str::CString::_from_vec_unchecked`, reached via `koffi → libsuperposition_core`, accounted for 90%+ of native heap growth. Present in every published version through the latest.

## Solution
Use koffi's **disposable type** — the documented idiom for freeing heap-allocated strings returned from C. Register a named type `OwnedStr` derived from `str` with `core_free_string` as its free callback, then declare the five owned-string functions to return `OwnedStr`:

```js
this.lib.core_free_string = this.lib.func("void core_free_string(char*)");
if (!ownedStrTypeRegistered) {
    koffi.disposable("OwnedStr", "str", this.lib.core_free_string);
    ownedStrTypeRegistered = true;
}
this.lib.core_get_resolved_config = this.lib.func("OwnedStr core_get_resolved_config(...)");
```

koffi converts the returned `char*` to a JS string and then automatically calls `core_free_string` on the **original** Rust pointer, so the native allocation is freed instead of leaked.

Changes in `clients/javascript/bindings/native-resolver.ts`:
- Declare `core_get_resolved_config`, `core_get_applicable_variants`, `core_parse_toml_config`, `core_parse_json_config`, `core_provider_cache_eval_config` to return `OwnedStr` (was `char*`).
- Register the `OwnedStr` disposable type once via a module-level `ownedStrTypeRegistered` guard (koffi type names are process-global, so registering per-instance throws `Duplicate type name`).
- Remove the now-unnecessary manual decode/free branches in the function bodies — the return value is a plain string.
- `core_free_string`'s own `char*` **argument** type is unchanged (it's an input pointer, correct as-is).

No behavior change to return values — callers still receive the same string/parsed object; the pointer is now freed instead of leaked.

## Environment variable changes
None.

## Pre-deployment activity
- Rebuild the JS client workspaces so `dist/` reflects the source change: `npm run build -w bindings -w sdk -w open-feature-provider`.
- Publish a new `superposition-provider` version (this ships in `dist/index.esm.js` / `dist/index.js`).
- Consumers must bump to the new version (or apply it via `pnpm patch` until they can upgrade).

## Post-deployment activity
- On a consumer running the native path, watch RSS/native heap over a few hours — it should stay flat instead of climbing to the memory limit; no OOM/restarts.
- (Optional) Verify with a jemalloc `jeprof` diff that `CString::_from_vec_unchecked` no longer dominates growth.

## API changes
None — no public API, request, or response shape changes. (FFI return types are internal to the binding.)

| Endpoint | Method | Request body | Response Body |
| ------------- |:-------------:| -----:| ----------------:|
| N/A | N/A | N/A | N/A |

## Possible Issues in the future
- **koffi dependency:** the fix relies on koffi's `disposable` type calling the free callback on the original pointer after C→JS conversion. Pin/verify koffi behavior on major upgrades.
- **Ownership contract:** the disposable calls `core_free_string` on every returned pointer, which assumes the Rust side always returns an owned `CString::into_raw` pointer. If a function is ever changed to return a borrowed/static pointer, this would become an invalid free — keep the `OwnedStr` return paired with `into_raw`-style ownership.
- **Debug logging (pre-existing, not addressed here):** these methods still `console.log` per call (including result/param dumps). Not a leak, but noisy/costly at high volume — worth removing in a follow-up.
