### PR TITLE
feat: add GCP Cloud KMS and OpenBao/Vault as pluggable KMS backends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ DB_HOST=localhost:5432
 DB_NAME=config
 APP_ENV=DEV
 AWS_REGION_ENDPOINT=http://localhost:4566
+# KMS backend for the secrets below (non-dev/test). Default: AWS.
+# KMS_PROVIDER=AWS  # or GCP, OPENBAO
+# GCP_KMS_KEY_NAME=projects/<project>/locations/<location>/keyRings/<ring>/cryptoKeys/<key>  # required for GCP; uses ADC
+# OPENBAO_ADDR=https://127.0.0.1:8200  # required for OPENBAO
+# OPENBAO_TOKEN=<openbao-token>        # required for OPENBAO
+# Note: with OPENBAO, secrets below hold a KV v2 location ("mount:path[:key]") instead of ciphertext.
 ALLOW_SAME_KEYS_OVERLAPPING_CTX=true
 ALLOW_DIFF_KEYS_OVERLAPPING_CTX=true
 ALLOW_SAME_KEYS_NON_OVERLAPPING_CTX=true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8547,6 +8547,7 @@ dependencies = [
  "actix-web",
  "aes-gcm",
  "anyhow",
+ "async-trait",
  "aws-config",
  "aws-sdk-kms",
  "base64 0.21.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -1289,7 +1289,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -3100,6 +3100,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.10",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4130,6 +4161,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "google-cloud-auth"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57a13fbacc5e9c41ded3ad8d0373175a6b7a6ad430d99e89d314ac121b7ab06"
+dependencies = [
+ "async-trait",
+ "base64 0.21.2",
+ "google-cloud-metadata",
+ "google-cloud-token",
+ "home",
+ "jsonwebtoken",
+ "reqwest 0.12.8",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.58",
+ "time",
+ "tokio",
+ "tracing",
+ "urlencoding",
+]
+
+[[package]]
+name = "google-cloud-gax"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de13e62d7e0ffc3eb40a0113ddf753cf6ec741be739164442b08893db4f9bfca"
+dependencies = [
+ "google-cloud-token",
+ "http 1.1.0",
+ "thiserror 1.0.58",
+ "tokio",
+ "tokio-retry2",
+ "tonic",
+ "tower 0.4.13",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-googleapis"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "886aa8ec755382a1fdf4651f6e6ec01f2f3bf49f2cb0f068b9a74cafd574a715"
+dependencies = [
+ "prost 0.13.5",
+ "prost-types",
+ "tonic",
+]
+
+[[package]]
+name = "google-cloud-kms"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8842723521d34b9bf43305c84fd469c4d1858c42a630e1cb8c0d9c53781551"
+dependencies = [
+ "google-cloud-auth",
+ "google-cloud-gax",
+ "google-cloud-googleapis",
+ "google-cloud-token",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.58",
+ "tracing",
+]
+
+[[package]]
+name = "google-cloud-metadata"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d901aeb453fd80e51d64df4ee005014f6cf39f2d736dd64f7239c132d9d39a6a"
+dependencies = [
+ "reqwest 0.12.8",
+ "thiserror 1.0.58",
+ "tokio",
+]
+
+[[package]]
+name = "google-cloud-token"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c12ba8b21d128a2ce8585955246977fbce4415f680ebf9199b6f9d6d725f"
+dependencies = [
+ "async-trait",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5081,6 +5198,21 @@ dependencies = [
  "time",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring 0.17.8",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -6573,6 +6705,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6696,18 +6838,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7019,7 +7161,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -7032,10 +7174,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -7503,13 +7654,17 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
+ "hyper-tls 0.6.0",
  "hyper-util",
  "js-sys",
  "log",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pki-types",
  "sync_wrapper 1.0.2",
  "tokio",
+ "tokio-native-tls",
  "tower 0.5.2",
  "tower-http",
  "tower-service",
@@ -7684,6 +7839,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver 1.0.17",
+]
+
+[[package]]
+name = "rustify"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4800ce4c1cc2fec12c559dae2ddbf0e17fcee7569b796e6d75898efef443368b"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "http 1.1.0",
+ "reqwest 0.13.3",
+ "rustify_derive",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 1.0.58",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "rustify_derive"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78ea7fda74240f7410d0198b603a8a2f662acc7d76b6667a49f9b162cd8d9b4f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "regex",
+ "serde_urlencoded",
+ "syn 1.0.109",
+ "synstructure 0.12.6",
 ]
 
 [[package]]
@@ -8367,6 +8556,7 @@ dependencies = [
  "diesel-adapter",
  "fred",
  "futures-util",
+ "google-cloud-kms",
  "humantime",
  "inventory",
  "juspay_diesel",
@@ -8385,6 +8575,7 @@ dependencies = [
  "regex",
  "reqwest 0.11.27",
  "rs-snowflake",
+ "rustls 0.23.28",
  "secrecy",
  "serde",
  "serde_json",
@@ -8399,6 +8590,7 @@ dependencies = [
  "url",
  "urlencoding",
  "uuid",
+ "vaultrs",
 ]
 
 [[package]]
@@ -8489,6 +8681,18 @@ name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -8978,7 +9182,6 @@ dependencies = [
  "actix-http",
  "actix-web",
  "anyhow",
- "aws-sdk-kms",
  "chrono",
  "context_aware_config",
  "dotenv",
@@ -8997,6 +9200,7 @@ dependencies = [
  "regex",
  "reqwest 0.11.27",
  "rs-snowflake",
+ "rustls 0.23.28",
  "secrecy",
  "serde",
  "serde_json",
@@ -9668,6 +9872,18 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f36bdaa60a83aca3921b5259d5400cbf5e90fc51931376a9bd4a0eb79aa7210f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "unicode-xid",
+]
+
+[[package]]
+name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
@@ -9997,6 +10213,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-retry2"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a0a122635e32bd827df297f311ca5e0292636bbd82f67ff84a4bedeab06dbeb"
+dependencies = [
+ "pin-project",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10151,6 +10377,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
+ "flate2",
  "h2 0.4.11",
  "http 1.1.0",
  "http-body 1.0.1",
@@ -10161,13 +10388,16 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost 0.13.5",
+ "rustls-pemfile 2.2.0",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls 0.26.2",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -10826,6 +11056,25 @@ dependencies = [
  "sval_json",
  "sval_ref",
  "sval_serde",
+]
+
+[[package]]
+name = "vaultrs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30ffcc0e81025065dda612ec1e26a3d81bb16ef3062354873d17a35965d68522"
+dependencies = [
+ "async-trait",
+ "derive_builder",
+ "http 1.1.0",
+ "reqwest 0.13.3",
+ "rustify",
+ "rustify_derive",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
 ]
 
 [[package]]
@@ -11782,7 +12031,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -11823,7 +12072,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
- "synstructure",
+ "synstructure 0.13.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8575,7 +8575,6 @@ dependencies = [
  "regex",
  "reqwest 0.11.27",
  "rs-snowflake",
- "rustls 0.23.28",
  "secrecy",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ assets-dir = "crates/frontend/assets"
 actix-http = "3.3.1"
 actix-web = "4.5.0"
 anyhow = "1.0.75"
+async-trait = "0.1.89"
 aws-sdk-kms = { version = "1.38.0" }
 base64 = "0.21.2"
 google-cloud-kms = "0.6.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ actix-web = "4.5.0"
 anyhow = "1.0.75"
 aws-sdk-kms = { version = "1.38.0" }
 base64 = "0.21.2"
+google-cloud-kms = "0.6.0"
+rustls = "0.23"
+vaultrs = { version = "0.8.0", default-features = false, features = ["native-tls"] }
 bigdecimal = { version = "0.3.1", features = ["serde"] }
 blake3 = "1.3.3"
 cfg-if = "1.0.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,6 @@ anyhow = "1.0.75"
 async-trait = "0.1.89"
 aws-sdk-kms = { version = "1.38.0" }
 base64 = "0.21.2"
-google-cloud-kms = "0.6.0"
-rustls = "0.23"
-vaultrs = { version = "0.8.0", default-features = false, features = ["native-tls"] }
 bigdecimal = { version = "0.3.1", features = ["serde"] }
 blake3 = "1.3.3"
 cfg-if = "1.0.0"
@@ -68,6 +65,7 @@ diesel = { version = "2.3.1", package = "juspay_diesel", features = [
 ] }
 fred = { version = "9.2.1" }
 futures-util = "0.3.28"
+google-cloud-kms = "0.6.0"
 humantime = "2.1"
 inventory = "0.3"
 itertools = { version = "0.10.5" }
@@ -85,6 +83,7 @@ prometheus = { version = "0.14", default-features = false }
 regex = "1.9.1"
 reqwest = { version = "0.11.18", features = ["json"] }
 rs-snowflake = "0.6.0"
+rustls = "0.23"
 rustyscript = { version = "0.12.3", default-features = false, features = ["safe_extensions", "web", "worker"] }
 serde = { version = "=1.0.221", features = ["derive"] }
 serde_json = { version = "1.0.140" }
@@ -104,6 +103,7 @@ tracing-actix-web = "0.7.21"
 url = "2.5.0"
 uuid = { version = "1.20.0", features = ["v4", "serde", "js"] }
 uniffi = { version = "0.29.3", features = ["cli"] }
+vaultrs = { version = "0.8.0", default-features = false, features = ["native-tls"] }
 kronos-worker = { git = "https://github.com/juspay/kronos.git", tag = "v0.1.0" }
 kronos-common = { git = "https://github.com/juspay/kronos.git", tag = "v0.1.0" }
 superposition = { path = "crates/superposition", version = "0.117.1" }

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -14,6 +14,8 @@ anyhow = { workspace = true }
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 aws-sdk-kms = { workspace = true }
 base64 = { workspace = true }
+google-cloud-kms = { workspace = true }
+vaultrs = { workspace = true }
 casbin = { version = "2.19.0", features = ["glob"] }
 chrono = { workspace = true }
 derive_more = { workspace = true }
@@ -57,6 +59,9 @@ urlencoding = "~2.1.2"
 uuid = {workspace = true}
 tracing-actix-web = { workspace = true }
 
+
+[dev-dependencies]
+rustls = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -11,6 +11,7 @@ rust-version.workspace = true
 actix-web = { workspace = true }
 aes-gcm = "0.10.3"
 anyhow = { workspace = true }
+async-trait = { workspace = true }
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 aws-sdk-kms = { workspace = true }
 base64 = { workspace = true }

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -60,8 +60,5 @@ uuid = {workspace = true}
 tracing-actix-web = { workspace = true }
 
 
-[dev-dependencies]
-rustls = { workspace = true }
-
 [lints]
 workspace = true

--- a/crates/service_utils/Cargo.toml
+++ b/crates/service_utils/Cargo.toml
@@ -15,8 +15,6 @@ async-trait = { workspace = true }
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 aws-sdk-kms = { workspace = true }
 base64 = { workspace = true }
-google-cloud-kms = { workspace = true }
-vaultrs = { workspace = true }
 casbin = { version = "2.19.0", features = ["glob"] }
 chrono = { workspace = true }
 derive_more = { workspace = true }
@@ -24,6 +22,7 @@ diesel = { workspace = true }
 diesel-adapter = { version = "1.2.0" }
 fred = { workspace = true, features = ["metrics"] }
 futures-util = { workspace = true }
+google-cloud-kms = { workspace = true }
 humantime = { workspace = true }
 inventory = { workspace = true }
 log = { workspace = true }
@@ -58,6 +57,7 @@ thiserror = { workspace = true }
 url = { workspace = true }
 urlencoding = "~2.1.2"
 uuid = {workspace = true}
+vaultrs = { workspace = true }
 tracing-actix-web = { workspace = true }
 
 

--- a/crates/service_utils/src/aws.rs
+++ b/crates/service_utils/src/aws.rs
@@ -1,1 +1,0 @@
-pub mod kms;

--- a/crates/service_utils/src/db/utils.rs
+++ b/crates/service_utils/src/db/utils.rs
@@ -5,11 +5,11 @@ use diesel::{
 use urlencoding::encode;
 
 use crate::helpers::{get_from_env_or_default, get_from_env_unsafe};
-use crate::kms::KmsProvider;
+use crate::kms::SecretProviderClient;
 use crate::service::types::AppEnv;
 
 pub async fn get_superposition_token(
-    kms_client: &Option<KmsProvider>,
+    kms_client: &Option<SecretProviderClient>,
     app_env: &AppEnv,
 ) -> String {
     match app_env {
@@ -27,7 +27,7 @@ pub async fn get_superposition_token(
 }
 
 pub async fn get_kronos_dispatch_token(
-    kms_client: &Option<KmsProvider>,
+    kms_client: &Option<SecretProviderClient>,
     app_env: &AppEnv,
 ) -> String {
     match app_env {
@@ -45,7 +45,7 @@ pub async fn get_kronos_dispatch_token(
 }
 
 pub async fn get_oidc_client_secret(
-    kms_client: &Option<KmsProvider>,
+    kms_client: &Option<SecretProviderClient>,
     app_env: &AppEnv,
 ) -> String {
     match app_env {
@@ -68,7 +68,7 @@ pub async fn get_oidc_client_secret(
 /// environments. Returns `None` when the (optional) API-token flow is not
 /// configured.
 pub async fn get_introspection_auth_header(
-    kms_client: &Option<KmsProvider>,
+    kms_client: &Option<SecretProviderClient>,
     app_env: &AppEnv,
 ) -> Option<String> {
     if std::env::var("OIDC_INTROSPECTION_AUTH_HEADER").is_err() {
@@ -93,7 +93,7 @@ pub async fn get_introspection_auth_header(
 /// secrets in non-dev environments. Returns `None` when unset (static-token
 /// mechanism disabled).
 pub async fn get_static_api_tokens(
-    kms_client: &Option<KmsProvider>,
+    kms_client: &Option<SecretProviderClient>,
     app_env: &AppEnv,
 ) -> Option<String> {
     if std::env::var("OIDC_API_STATIC_TOKENS").is_err() {
@@ -114,7 +114,7 @@ pub async fn get_static_api_tokens(
 }
 
 pub async fn get_kronos_api_key(
-    kms_client: &Option<KmsProvider>,
+    kms_client: &Option<SecretProviderClient>,
     app_env: &AppEnv,
 ) -> String {
     match app_env {
@@ -132,7 +132,7 @@ pub async fn get_kronos_api_key(
 }
 
 pub async fn get_database_url(
-    kms_client: &Option<KmsProvider>,
+    kms_client: &Option<SecretProviderClient>,
     app_env: &AppEnv,
     env_prefix: Option<&str>,
 ) -> String {
@@ -161,7 +161,7 @@ pub async fn get_database_url(
 }
 
 pub async fn init_pool_manager(
-    kms_client: &Option<KmsProvider>,
+    kms_client: &Option<SecretProviderClient>,
     app_env: &AppEnv,
     max_pool_size: u32,
 ) -> Pool<ConnectionManager<PgConnection>> {

--- a/crates/service_utils/src/db/utils.rs
+++ b/crates/service_utils/src/db/utils.rs
@@ -20,7 +20,7 @@ pub async fn get_superposition_token(
             kms_client
                 .as_ref()
                 .unwrap()
-                .decrypt("SUPERPOSITION_TOKEN")
+                .get_secret("SUPERPOSITION_TOKEN")
                 .await
         }
     }
@@ -38,7 +38,7 @@ pub async fn get_kronos_dispatch_token(
             kms_client
                 .as_ref()
                 .unwrap()
-                .decrypt("KRONOS_DISPATCH_TOKEN")
+                .get_secret("KRONOS_DISPATCH_TOKEN")
                 .await
         }
     }
@@ -56,7 +56,7 @@ pub async fn get_oidc_client_secret(
             kms_client
                 .as_ref()
                 .unwrap()
-                .decrypt("OIDC_CLIENT_SECRET")
+                .get_secret("OIDC_CLIENT_SECRET")
                 .await
         }
     }
@@ -82,7 +82,7 @@ pub async fn get_introspection_auth_header(
             kms_client
                 .as_ref()
                 .unwrap()
-                .decrypt("OIDC_INTROSPECTION_AUTH_HEADER")
+                .get_secret("OIDC_INTROSPECTION_AUTH_HEADER")
                 .await,
         ),
     }
@@ -107,7 +107,7 @@ pub async fn get_static_api_tokens(
             kms_client
                 .as_ref()
                 .unwrap()
-                .decrypt("OIDC_API_STATIC_TOKENS")
+                .get_secret("OIDC_API_STATIC_TOKENS")
                 .await,
         ),
     }
@@ -121,7 +121,13 @@ pub async fn get_kronos_api_key(
         AppEnv::DEV | AppEnv::TEST => {
             get_from_env_or_default("KRONOS_API_KEY", "dev-api-key".into())
         }
-        _ => kms_client.as_ref().unwrap().decrypt("KRONOS_API_KEY").await,
+        _ => {
+            kms_client
+                .as_ref()
+                .unwrap()
+                .get_secret("KRONOS_API_KEY")
+                .await
+        }
     }
 }
 
@@ -144,7 +150,7 @@ pub async fn get_database_url(
             let db_password_raw = kms_client
                 .as_ref()
                 .unwrap()
-                .decrypt(&format!("{env_prefix}DB_PASSWORD"))
+                .get_secret(&format!("{env_prefix}DB_PASSWORD"))
                 .await;
             encode(db_password_raw.as_str()).to_string()
         }

--- a/crates/service_utils/src/db/utils.rs
+++ b/crates/service_utils/src/db/utils.rs
@@ -1,16 +1,15 @@
-use aws_sdk_kms::Client;
 use diesel::{
     PgConnection,
     r2d2::{ConnectionManager, Pool},
 };
 use urlencoding::encode;
 
-use crate::aws::kms;
 use crate::helpers::{get_from_env_or_default, get_from_env_unsafe};
+use crate::kms::{self, KmsProvider};
 use crate::service::types::AppEnv;
 
 pub async fn get_superposition_token(
-    kms_client: &Option<Client>,
+    kms_client: &Option<KmsProvider>,
     app_env: &AppEnv,
 ) -> String {
     match app_env {
@@ -22,7 +21,7 @@ pub async fn get_superposition_token(
 }
 
 pub async fn get_kronos_dispatch_token(
-    kms_client: &Option<Client>,
+    kms_client: &Option<KmsProvider>,
     app_env: &AppEnv,
 ) -> String {
     match app_env {
@@ -34,7 +33,7 @@ pub async fn get_kronos_dispatch_token(
 }
 
 pub async fn get_oidc_client_secret(
-    kms_client: &Option<Client>,
+    kms_client: &Option<KmsProvider>,
     app_env: &AppEnv,
 ) -> String {
     match app_env {
@@ -51,7 +50,7 @@ pub async fn get_oidc_client_secret(
 /// environments. Returns `None` when the (optional) API-token flow is not
 /// configured.
 pub async fn get_introspection_auth_header(
-    kms_client: &Option<Client>,
+    kms_client: &Option<KmsProvider>,
     app_env: &AppEnv,
 ) -> Option<String> {
     if std::env::var("OIDC_INTROSPECTION_AUTH_HEADER").is_err() {
@@ -76,7 +75,7 @@ pub async fn get_introspection_auth_header(
 /// secrets in non-dev environments. Returns `None` when unset (static-token
 /// mechanism disabled).
 pub async fn get_static_api_tokens(
-    kms_client: &Option<Client>,
+    kms_client: &Option<KmsProvider>,
     app_env: &AppEnv,
 ) -> Option<String> {
     if std::env::var("OIDC_API_STATIC_TOKENS").is_err() {
@@ -92,7 +91,10 @@ pub async fn get_static_api_tokens(
     }
 }
 
-pub async fn get_kronos_api_key(kms_client: &Option<Client>, app_env: &AppEnv) -> String {
+pub async fn get_kronos_api_key(
+    kms_client: &Option<KmsProvider>,
+    app_env: &AppEnv,
+) -> String {
     match app_env {
         AppEnv::DEV | AppEnv::TEST => {
             get_from_env_or_default("KRONOS_API_KEY", "dev-api-key".into())
@@ -102,7 +104,7 @@ pub async fn get_kronos_api_key(kms_client: &Option<Client>, app_env: &AppEnv) -
 }
 
 pub async fn get_database_url(
-    kms_client: &Option<Client>,
+    kms_client: &Option<KmsProvider>,
     app_env: &AppEnv,
     env_prefix: Option<&str>,
 ) -> String {
@@ -129,7 +131,7 @@ pub async fn get_database_url(
 }
 
 pub async fn init_pool_manager(
-    kms_client: &Option<Client>,
+    kms_client: &Option<KmsProvider>,
     app_env: &AppEnv,
     max_pool_size: u32,
 ) -> Pool<ConnectionManager<PgConnection>> {

--- a/crates/service_utils/src/db/utils.rs
+++ b/crates/service_utils/src/db/utils.rs
@@ -5,7 +5,7 @@ use diesel::{
 use urlencoding::encode;
 
 use crate::helpers::{get_from_env_or_default, get_from_env_unsafe};
-use crate::kms::{self, KmsProvider};
+use crate::kms::KmsProvider;
 use crate::service::types::AppEnv;
 
 pub async fn get_superposition_token(
@@ -16,7 +16,13 @@ pub async fn get_superposition_token(
         AppEnv::DEV | AppEnv::TEST | AppEnv::SANDBOX => {
             get_from_env_or_default("SUPERPOSITION_TOKEN", "123456".into())
         }
-        _ => kms::decrypt(kms_client.clone().unwrap(), "SUPERPOSITION_TOKEN").await,
+        _ => {
+            kms_client
+                .as_ref()
+                .unwrap()
+                .decrypt("SUPERPOSITION_TOKEN")
+                .await
+        }
     }
 }
 
@@ -28,7 +34,13 @@ pub async fn get_kronos_dispatch_token(
         AppEnv::DEV | AppEnv::TEST => {
             get_from_env_or_default("KRONOS_DISPATCH_TOKEN", "dispatch-123456".into())
         }
-        _ => kms::decrypt(kms_client.clone().unwrap(), "KRONOS_DISPATCH_TOKEN").await,
+        _ => {
+            kms_client
+                .as_ref()
+                .unwrap()
+                .decrypt("KRONOS_DISPATCH_TOKEN")
+                .await
+        }
     }
 }
 
@@ -40,7 +52,13 @@ pub async fn get_oidc_client_secret(
         AppEnv::DEV | AppEnv::TEST | AppEnv::SANDBOX => {
             get_from_env_or_default("OIDC_CLIENT_SECRET", "123456".into())
         }
-        _ => kms::decrypt(kms_client.clone().unwrap(), "OIDC_CLIENT_SECRET").await,
+        _ => {
+            kms_client
+                .as_ref()
+                .unwrap()
+                .decrypt("OIDC_CLIENT_SECRET")
+                .await
+        }
     }
 }
 
@@ -61,11 +79,11 @@ pub async fn get_introspection_auth_header(
             std::env::var("OIDC_INTROSPECTION_AUTH_HEADER").ok()
         }
         _ => Some(
-            kms::decrypt(
-                kms_client.clone().unwrap(),
-                "OIDC_INTROSPECTION_AUTH_HEADER",
-            )
-            .await,
+            kms_client
+                .as_ref()
+                .unwrap()
+                .decrypt("OIDC_INTROSPECTION_AUTH_HEADER")
+                .await,
         ),
     }
 }
@@ -86,7 +104,11 @@ pub async fn get_static_api_tokens(
             std::env::var("OIDC_API_STATIC_TOKENS").ok()
         }
         _ => Some(
-            kms::decrypt(kms_client.clone().unwrap(), "OIDC_API_STATIC_TOKENS").await,
+            kms_client
+                .as_ref()
+                .unwrap()
+                .decrypt("OIDC_API_STATIC_TOKENS")
+                .await,
         ),
     }
 }
@@ -99,7 +121,7 @@ pub async fn get_kronos_api_key(
         AppEnv::DEV | AppEnv::TEST => {
             get_from_env_or_default("KRONOS_API_KEY", "dev-api-key".into())
         }
-        _ => kms::decrypt(kms_client.clone().unwrap(), "KRONOS_API_KEY").await,
+        _ => kms_client.as_ref().unwrap().decrypt("KRONOS_API_KEY").await,
     }
 }
 
@@ -119,9 +141,11 @@ pub async fn get_database_url(
             get_from_env_or_default(&format!("{env_prefix}DB_PASSWORD"), "docker".into())
         }
         _ => {
-            let kms_client = kms_client.clone().unwrap();
-            let db_password_raw =
-                kms::decrypt(kms_client, &format!("{env_prefix}DB_PASSWORD")).await;
+            let db_password_raw = kms_client
+                .as_ref()
+                .unwrap()
+                .decrypt(&format!("{env_prefix}DB_PASSWORD"))
+                .await;
             encode(db_password_raw.as_str()).to_string()
         }
     };

--- a/crates/service_utils/src/encryption.rs
+++ b/crates/service_utils/src/encryption.rs
@@ -169,7 +169,7 @@ pub fn decrypt_workspace_key(
 }
 
 pub async fn get_master_encryption_keys(
-    kms_client: &Option<crate::kms::KmsProvider>,
+    kms_client: &Option<crate::kms::SecretProviderClient>,
     app_env: &AppEnv,
 ) -> Result<Option<EncryptionKey>, EncryptionError> {
     match app_env {

--- a/crates/service_utils/src/encryption.rs
+++ b/crates/service_utils/src/encryption.rs
@@ -169,7 +169,7 @@ pub fn decrypt_workspace_key(
 }
 
 pub async fn get_master_encryption_keys(
-    kms_client: &Option<aws_sdk_kms::Client>,
+    kms_client: &Option<crate::kms::KmsProvider>,
     app_env: &AppEnv,
 ) -> Result<Option<EncryptionKey>, EncryptionError> {
     match app_env {
@@ -194,7 +194,7 @@ pub async fn get_master_encryption_keys(
         _ => {
             let kms_client = kms_client.clone().unwrap();
             let decrypted_master_key =
-                crate::aws::kms::decrypt_opt(kms_client.clone(), "MASTER_ENCRYPTION_KEY")
+                crate::kms::decrypt_opt(kms_client.clone(), "MASTER_ENCRYPTION_KEY")
                     .await
                     .map(SecretString::from);
             let Some(current_key) = decrypted_master_key else {
@@ -204,12 +204,10 @@ pub async fn get_master_encryption_keys(
                 return Ok(None);
             };
 
-            let previous_key = crate::aws::kms::decrypt_opt(
-                kms_client,
-                "PREVIOUS_MASTER_ENCRYPTION_KEY",
-            )
-            .await
-            .map(SecretString::from);
+            let previous_key =
+                crate::kms::decrypt_opt(kms_client, "PREVIOUS_MASTER_ENCRYPTION_KEY")
+                    .await
+                    .map(SecretString::from);
 
             Ok(Some(EncryptionKey {
                 current_key,

--- a/crates/service_utils/src/encryption.rs
+++ b/crates/service_utils/src/encryption.rs
@@ -194,7 +194,7 @@ pub async fn get_master_encryption_keys(
         _ => {
             let kms_client = kms_client.as_ref().unwrap();
             let decrypted_master_key = kms_client
-                .decrypt_opt("MASTER_ENCRYPTION_KEY")
+                .get_secret_opt("MASTER_ENCRYPTION_KEY")
                 .await
                 .map(SecretString::from);
             let Some(current_key) = decrypted_master_key else {
@@ -205,7 +205,7 @@ pub async fn get_master_encryption_keys(
             };
 
             let previous_key = kms_client
-                .decrypt_opt("PREVIOUS_MASTER_ENCRYPTION_KEY")
+                .get_secret_opt("PREVIOUS_MASTER_ENCRYPTION_KEY")
                 .await
                 .map(SecretString::from);
 

--- a/crates/service_utils/src/encryption.rs
+++ b/crates/service_utils/src/encryption.rs
@@ -192,11 +192,11 @@ pub async fn get_master_encryption_keys(
             }))
         }
         _ => {
-            let kms_client = kms_client.clone().unwrap();
-            let decrypted_master_key =
-                crate::kms::decrypt_opt(kms_client.clone(), "MASTER_ENCRYPTION_KEY")
-                    .await
-                    .map(SecretString::from);
+            let kms_client = kms_client.as_ref().unwrap();
+            let decrypted_master_key = kms_client
+                .decrypt_opt("MASTER_ENCRYPTION_KEY")
+                .await
+                .map(SecretString::from);
             let Some(current_key) = decrypted_master_key else {
                 log::info!(
                     "MASTER_ENCRYPTION_KEY not set - secrets functionality will be disabled."
@@ -204,10 +204,10 @@ pub async fn get_master_encryption_keys(
                 return Ok(None);
             };
 
-            let previous_key =
-                crate::kms::decrypt_opt(kms_client, "PREVIOUS_MASTER_ENCRYPTION_KEY")
-                    .await
-                    .map(SecretString::from);
+            let previous_key = kms_client
+                .decrypt_opt("PREVIOUS_MASTER_ENCRYPTION_KEY")
+                .await
+                .map(SecretString::from);
 
             Ok(Some(EncryptionKey {
                 current_key,

--- a/crates/service_utils/src/kms.rs
+++ b/crates/service_utils/src/kms.rs
@@ -26,9 +26,9 @@ pub trait SecretProvider: Send + Sync {
     async fn get_secret_opt(&self, key: &str) -> Option<String>;
 }
 
-pub type KmsProvider = Box<dyn SecretProvider>;
+pub type SecretProviderClient = Box<dyn SecretProvider>;
 
-pub async fn new_client() -> KmsProvider {
+pub async fn new_client() -> SecretProviderClient {
     let raw: String = get_from_env_or_default("KMS_PROVIDER", String::new());
     match parse_provider_kind(&raw) {
         ProviderKind::Gcp => Box::new(gcp::new_client().await),

--- a/crates/service_utils/src/kms.rs
+++ b/crates/service_utils/src/kms.rs
@@ -21,12 +21,12 @@ fn parse_provider_kind(raw: &str) -> ProviderKind {
 }
 
 #[async_trait::async_trait]
-pub trait KmsClient: Send + Sync {
-    async fn decrypt(&self, key: &str) -> String;
-    async fn decrypt_opt(&self, key: &str) -> Option<String>;
+pub trait SecretProvider: Send + Sync {
+    async fn get_secret(&self, key: &str) -> String;
+    async fn get_secret_opt(&self, key: &str) -> Option<String>;
 }
 
-pub type KmsProvider = Box<dyn KmsClient>;
+pub type KmsProvider = Box<dyn SecretProvider>;
 
 pub async fn new_client() -> KmsProvider {
     let raw: String = get_from_env_or_default("KMS_PROVIDER", String::new());

--- a/crates/service_utils/src/kms.rs
+++ b/crates/service_utils/src/kms.rs
@@ -20,35 +20,20 @@ fn parse_provider_kind(raw: &str) -> ProviderKind {
     }
 }
 
-#[derive(Clone)]
-pub enum KmsProvider {
-    Aws(aws_sdk_kms::Client),
-    Gcp(gcp::Client),
-    OpenBao(openbao::Client),
+#[async_trait::async_trait]
+pub trait KmsClient: Send + Sync {
+    async fn decrypt(&self, key: &str) -> String;
+    async fn decrypt_opt(&self, key: &str) -> Option<String>;
 }
+
+pub type KmsProvider = Box<dyn KmsClient>;
 
 pub async fn new_client() -> KmsProvider {
     let raw: String = get_from_env_or_default("KMS_PROVIDER", String::new());
     match parse_provider_kind(&raw) {
-        ProviderKind::Gcp => KmsProvider::Gcp(gcp::new_client().await),
-        ProviderKind::OpenBao => KmsProvider::OpenBao(openbao::new_client().await),
-        ProviderKind::Aws => KmsProvider::Aws(aws::new_client().await),
-    }
-}
-
-pub async fn decrypt(provider: KmsProvider, key: &str) -> String {
-    match provider {
-        KmsProvider::Aws(client) => aws::decrypt(client, key).await,
-        KmsProvider::Gcp(client) => gcp::decrypt(client, key).await,
-        KmsProvider::OpenBao(client) => openbao::decrypt(client, key).await,
-    }
-}
-
-pub async fn decrypt_opt(provider: KmsProvider, key: &str) -> Option<String> {
-    match provider {
-        KmsProvider::Aws(client) => aws::decrypt_opt(client, key).await,
-        KmsProvider::Gcp(client) => gcp::decrypt_opt(client, key).await,
-        KmsProvider::OpenBao(client) => openbao::decrypt_opt(client, key).await,
+        ProviderKind::Gcp => Box::new(gcp::new_client().await),
+        ProviderKind::OpenBao => Box::new(openbao::new_client().await),
+        ProviderKind::Aws => Box::new(aws::new_client().await),
     }
 }
 

--- a/crates/service_utils/src/kms.rs
+++ b/crates/service_utils/src/kms.rs
@@ -1,0 +1,87 @@
+mod aws;
+mod gcp;
+mod openbao;
+
+use crate::helpers::get_from_env_or_default;
+
+#[derive(Debug, PartialEq)]
+enum ProviderKind {
+    Aws,
+    Gcp,
+    OpenBao,
+}
+
+fn parse_provider_kind(raw: &str) -> ProviderKind {
+    match raw.to_uppercase().as_str() {
+        "" | "AWS" => ProviderKind::Aws,
+        "GCP" => ProviderKind::Gcp,
+        "OPENBAO" => ProviderKind::OpenBao,
+        other => panic!("Unknown KMS_PROVIDER '{other}', expected AWS, GCP, or OPENBAO"),
+    }
+}
+
+#[derive(Clone)]
+pub enum KmsProvider {
+    Aws(aws_sdk_kms::Client),
+    Gcp(gcp::Client),
+    OpenBao(openbao::Client),
+}
+
+pub async fn new_client() -> KmsProvider {
+    let raw: String = get_from_env_or_default("KMS_PROVIDER", String::new());
+    match parse_provider_kind(&raw) {
+        ProviderKind::Gcp => KmsProvider::Gcp(gcp::new_client().await),
+        ProviderKind::OpenBao => KmsProvider::OpenBao(openbao::new_client().await),
+        ProviderKind::Aws => KmsProvider::Aws(aws::new_client().await),
+    }
+}
+
+pub async fn decrypt(provider: KmsProvider, key: &str) -> String {
+    match provider {
+        KmsProvider::Aws(client) => aws::decrypt(client, key).await,
+        KmsProvider::Gcp(client) => gcp::decrypt(client, key).await,
+        KmsProvider::OpenBao(client) => openbao::decrypt(client, key).await,
+    }
+}
+
+pub async fn decrypt_opt(provider: KmsProvider, key: &str) -> Option<String> {
+    match provider {
+        KmsProvider::Aws(client) => aws::decrypt_opt(client, key).await,
+        KmsProvider::Gcp(client) => gcp::decrypt_opt(client, key).await,
+        KmsProvider::OpenBao(client) => openbao::decrypt_opt(client, key).await,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_aws_when_unset() {
+        assert_eq!(parse_provider_kind(""), ProviderKind::Aws);
+    }
+
+    #[test]
+    fn selects_aws_case_insensitively() {
+        assert_eq!(parse_provider_kind("aws"), ProviderKind::Aws);
+        assert_eq!(parse_provider_kind("AWS"), ProviderKind::Aws);
+    }
+
+    #[test]
+    fn selects_gcp_case_insensitively() {
+        assert_eq!(parse_provider_kind("gcp"), ProviderKind::Gcp);
+        assert_eq!(parse_provider_kind("GCP"), ProviderKind::Gcp);
+    }
+
+    #[test]
+    fn selects_openbao_case_insensitively() {
+        assert_eq!(parse_provider_kind("openbao"), ProviderKind::OpenBao);
+        assert_eq!(parse_provider_kind("OPENBAO"), ProviderKind::OpenBao);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unknown KMS_PROVIDER 'BOGUS'")]
+    fn panics_on_unrecognized_values() {
+        parse_provider_kind("bogus");
+    }
+}

--- a/crates/service_utils/src/kms/aws.rs
+++ b/crates/service_utils/src/kms/aws.rs
@@ -1,9 +1,14 @@
+use async_trait::async_trait;
 use aws_sdk_kms::{Client, primitives::Blob};
 use base64::{Engine, engine::general_purpose};
 
-use crate::helpers::get_from_env_unsafe;
+use crate::{helpers::get_from_env_unsafe, kms::KmsClient};
 
-async fn decrypt_helper(aws_kms_cli: Client, key: &str, key_value_env: String) -> String {
+async fn decrypt_helper(
+    aws_kms_cli: &Client,
+    key: &str,
+    key_value_env: String,
+) -> String {
     let key_value_enc = general_purpose::STANDARD
         .decode(key_value_env)
         .expect("Input string does not contain valid base 64 characters.");
@@ -25,15 +30,18 @@ async fn decrypt_helper(aws_kms_cli: Client, key: &str, key_value_env: String) -
     key_value
 }
 
-pub async fn decrypt(aws_kms_cli: Client, key: &str) -> String {
-    let key_value_env: String =
-        get_from_env_unsafe(key).unwrap_or_else(|_| panic!("{key} not present in env"));
-    decrypt_helper(aws_kms_cli, key, key_value_env).await
-}
+#[async_trait]
+impl KmsClient for Client {
+    async fn decrypt(&self, key: &str) -> String {
+        let key_value_env: String = get_from_env_unsafe(key)
+            .unwrap_or_else(|_| panic!("{key} not present in env"));
+        decrypt_helper(self, key, key_value_env).await
+    }
 
-pub async fn decrypt_opt(aws_kms_cli: Client, key: &str) -> Option<String> {
-    let key_value_env: String = get_from_env_unsafe(key).ok()?;
-    Some(decrypt_helper(aws_kms_cli, key, key_value_env).await)
+    async fn decrypt_opt(&self, key: &str) -> Option<String> {
+        let key_value_env: String = get_from_env_unsafe(key).ok()?;
+        Some(decrypt_helper(self, key, key_value_env).await)
+    }
 }
 
 pub async fn new_client() -> Client {

--- a/crates/service_utils/src/kms/aws.rs
+++ b/crates/service_utils/src/kms/aws.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use aws_sdk_kms::{Client, primitives::Blob};
 use base64::{Engine, engine::general_purpose};
 
-use crate::{helpers::get_from_env_unsafe, kms::KmsClient};
+use crate::{helpers::get_from_env_unsafe, kms::SecretProvider};
 
 async fn decrypt_helper(
     aws_kms_cli: &Client,
@@ -31,14 +31,14 @@ async fn decrypt_helper(
 }
 
 #[async_trait]
-impl KmsClient for Client {
-    async fn decrypt(&self, key: &str) -> String {
+impl SecretProvider for Client {
+    async fn get_secret(&self, key: &str) -> String {
         let key_value_env: String = get_from_env_unsafe(key)
             .unwrap_or_else(|_| panic!("{key} not present in env"));
         decrypt_helper(self, key, key_value_env).await
     }
 
-    async fn decrypt_opt(&self, key: &str) -> Option<String> {
+    async fn get_secret_opt(&self, key: &str) -> Option<String> {
         let key_value_env: String = get_from_env_unsafe(key).ok()?;
         Some(decrypt_helper(self, key, key_value_env).await)
     }

--- a/crates/service_utils/src/kms/aws.rs
+++ b/crates/service_utils/src/kms/aws.rs
@@ -1,6 +1,7 @@
-use crate::helpers::get_from_env_unsafe;
 use aws_sdk_kms::{Client, primitives::Blob};
 use base64::{Engine, engine::general_purpose};
+
+use crate::helpers::get_from_env_unsafe;
 
 async fn decrypt_helper(aws_kms_cli: Client, key: &str, key_value_env: String) -> String {
     let key_value_enc = general_purpose::STANDARD
@@ -14,7 +15,7 @@ async fn decrypt_helper(aws_kms_cli: Client, key: &str, key_value_env: String) -
         .await;
     let key_value: String = String::from_utf8(
         key_value_bytes_result
-            .unwrap_or_else(|_| panic!("Failed to decrypt {key}"))
+            .unwrap_or_else(|e| panic!("Failed to decrypt {key}: {e:?}"))
             .plaintext()
             .unwrap_or_else(|| panic!("Failed to get plaintext value for {key}"))
             .as_ref()

--- a/crates/service_utils/src/kms/gcp.rs
+++ b/crates/service_utils/src/kms/gcp.rs
@@ -1,15 +1,15 @@
 //! Decrypts a ciphertext via Google Cloud KMS, using the official
 //! `google-cloud-kms` client (gRPC, Application Default Credentials).
 
+use async_trait::async_trait;
 use base64::{Engine, engine::general_purpose};
 use google_cloud_kms::{
     client::{Client as GcpKmsClient, ClientConfig},
     grpc::kms::v1::DecryptRequest,
 };
 
-use crate::helpers::get_from_env_unsafe;
+use crate::{helpers::get_from_env_unsafe, kms::KmsClient};
 
-#[derive(Clone)]
 pub struct Client {
     inner: GcpKmsClient,
     key_name: String,
@@ -30,7 +30,7 @@ pub async fn new_client() -> Client {
     Client { inner, key_name }
 }
 
-async fn decrypt_helper(client: Client, key: &str, ciphertext_b64: String) -> String {
+async fn decrypt_helper(client: &Client, key: &str, ciphertext_b64: String) -> String {
     let ciphertext = general_purpose::STANDARD
         .decode(ciphertext_b64)
         .unwrap_or_else(|e| {
@@ -55,13 +55,16 @@ async fn decrypt_helper(client: Client, key: &str, ciphertext_b64: String) -> St
         .unwrap_or_else(|e| panic!("Could not convert decrypted {key} to UTF-8: {e}"))
 }
 
-pub async fn decrypt(client: Client, key: &str) -> String {
-    let ciphertext_b64: String =
-        get_from_env_unsafe(key).unwrap_or_else(|_| panic!("{key} not present in env"));
-    decrypt_helper(client, key, ciphertext_b64).await
-}
+#[async_trait]
+impl KmsClient for Client {
+    async fn decrypt(&self, key: &str) -> String {
+        let ciphertext_b64: String = get_from_env_unsafe(key)
+            .unwrap_or_else(|_| panic!("{key} not present in env"));
+        decrypt_helper(self, key, ciphertext_b64).await
+    }
 
-pub async fn decrypt_opt(client: Client, key: &str) -> Option<String> {
-    let ciphertext_b64: String = get_from_env_unsafe(key).ok()?;
-    Some(decrypt_helper(client, key, ciphertext_b64).await)
+    async fn decrypt_opt(&self, key: &str) -> Option<String> {
+        let ciphertext_b64: String = get_from_env_unsafe(key).ok()?;
+        Some(decrypt_helper(self, key, ciphertext_b64).await)
+    }
 }

--- a/crates/service_utils/src/kms/gcp.rs
+++ b/crates/service_utils/src/kms/gcp.rs
@@ -65,36 +65,3 @@ pub async fn decrypt_opt(client: Client, key: &str) -> Option<String> {
     let ciphertext_b64: String = get_from_env_unsafe(key).ok()?;
     Some(decrypt_helper(client, key, ciphertext_b64).await)
 }
-
-/// Not run by default (no CI job carries real GCP credentials): exercises
-/// `new_client()`/`decrypt()` against a live Cloud KMS key, since none of the
-/// pure logic in this module can be unit-tested (unlike the AWS/OpenBao
-/// backends, everything here is a thin wrapper around the SDK's own gRPC
-/// client). Run manually against any symmetric encrypt/decrypt key you have
-/// access to via Application Default Credentials:
-///
-/// ```sh
-/// KEY="projects/<project>/locations/<location>/keyRings/<ring>/cryptoKeys/<key>"
-/// echo -n "some-plaintext" > /tmp/pt.txt
-/// gcloud kms encrypt --key="$KEY" --plaintext-file=/tmp/pt.txt --ciphertext-file=/tmp/ct.bin
-/// export GCP_KMS_KEY_NAME="$KEY"
-/// export TEST_GCP_SECRET="$(base64 -i /tmp/ct.bin | tr -d '\n')"
-/// cargo test -p service_utils --lib -- --ignored decrypts_real_ciphertext_against_live_gcp_kms --nocapture
-/// ```
-///
-/// Then update the `assert_eq!` below to match whatever plaintext you used.
-#[cfg(test)]
-mod live_tests {
-    use super::*;
-
-    #[tokio::test]
-    #[ignore]
-    async fn decrypts_real_ciphertext_against_live_gcp_kms() {
-        // Mirrors the install_default() call in crates/superposition/src/main.rs,
-        // which this lib-level test doesn't go through.
-        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
-        let client = new_client().await;
-        let plaintext = decrypt(client, "TEST_GCP_SECRET").await;
-        assert_eq!(plaintext, "superposition-gcp-kms-live-test-v2");
-    }
-}

--- a/crates/service_utils/src/kms/gcp.rs
+++ b/crates/service_utils/src/kms/gcp.rs
@@ -8,7 +8,7 @@ use google_cloud_kms::{
     grpc::kms::v1::DecryptRequest,
 };
 
-use crate::{helpers::get_from_env_unsafe, kms::KmsClient};
+use crate::{helpers::get_from_env_unsafe, kms::SecretProvider};
 
 pub struct Client {
     inner: GcpKmsClient,
@@ -56,14 +56,14 @@ async fn decrypt_helper(client: &Client, key: &str, ciphertext_b64: String) -> S
 }
 
 #[async_trait]
-impl KmsClient for Client {
-    async fn decrypt(&self, key: &str) -> String {
+impl SecretProvider for Client {
+    async fn get_secret(&self, key: &str) -> String {
         let ciphertext_b64: String = get_from_env_unsafe(key)
             .unwrap_or_else(|_| panic!("{key} not present in env"));
         decrypt_helper(self, key, ciphertext_b64).await
     }
 
-    async fn decrypt_opt(&self, key: &str) -> Option<String> {
+    async fn get_secret_opt(&self, key: &str) -> Option<String> {
         let ciphertext_b64: String = get_from_env_unsafe(key).ok()?;
         Some(decrypt_helper(self, key, ciphertext_b64).await)
     }

--- a/crates/service_utils/src/kms/gcp.rs
+++ b/crates/service_utils/src/kms/gcp.rs
@@ -1,0 +1,100 @@
+//! Decrypts a ciphertext via Google Cloud KMS, using the official
+//! `google-cloud-kms` client (gRPC, Application Default Credentials).
+
+use base64::{Engine, engine::general_purpose};
+use google_cloud_kms::{
+    client::{Client as GcpKmsClient, ClientConfig},
+    grpc::kms::v1::DecryptRequest,
+};
+
+use crate::helpers::get_from_env_unsafe;
+
+#[derive(Clone)]
+pub struct Client {
+    inner: GcpKmsClient,
+    key_name: String,
+}
+
+pub async fn new_client() -> Client {
+    let key_name: String = get_from_env_unsafe("GCP_KMS_KEY_NAME")
+        .unwrap_or_else(|_| panic!("GCP_KMS_KEY_NAME not present in env"));
+
+    let config = ClientConfig::default().with_auth().await.unwrap_or_else(|e| {
+        panic!("Failed to initialize GCP credentials (Application Default Credentials): {e:?}")
+    });
+
+    let inner = GcpKmsClient::new(config)
+        .await
+        .unwrap_or_else(|e| panic!("Failed to create GCP KMS client: {e:?}"));
+
+    Client { inner, key_name }
+}
+
+async fn decrypt_helper(client: Client, key: &str, ciphertext_b64: String) -> String {
+    let ciphertext = general_purpose::STANDARD
+        .decode(ciphertext_b64)
+        .unwrap_or_else(|e| {
+            panic!("Input string for {key} does not contain valid base64 characters: {e}")
+        });
+
+    let request = DecryptRequest {
+        name: client.key_name.clone(),
+        ciphertext,
+        additional_authenticated_data: Vec::new(),
+        ciphertext_crc32c: None,
+        additional_authenticated_data_crc32c: None,
+    };
+
+    let response = client
+        .inner
+        .decrypt(request, None)
+        .await
+        .unwrap_or_else(|e| panic!("Failed to decrypt {key} via GCP KMS: {e:?}"));
+
+    String::from_utf8(response.plaintext)
+        .unwrap_or_else(|e| panic!("Could not convert decrypted {key} to UTF-8: {e}"))
+}
+
+pub async fn decrypt(client: Client, key: &str) -> String {
+    let ciphertext_b64: String =
+        get_from_env_unsafe(key).unwrap_or_else(|_| panic!("{key} not present in env"));
+    decrypt_helper(client, key, ciphertext_b64).await
+}
+
+pub async fn decrypt_opt(client: Client, key: &str) -> Option<String> {
+    let ciphertext_b64: String = get_from_env_unsafe(key).ok()?;
+    Some(decrypt_helper(client, key, ciphertext_b64).await)
+}
+
+/// Not run by default (no CI job carries real GCP credentials): exercises
+/// `new_client()`/`decrypt()` against a live Cloud KMS key, since none of the
+/// pure logic in this module can be unit-tested (unlike the AWS/OpenBao
+/// backends, everything here is a thin wrapper around the SDK's own gRPC
+/// client). Run manually against any symmetric encrypt/decrypt key you have
+/// access to via Application Default Credentials:
+///
+/// ```sh
+/// KEY="projects/<project>/locations/<location>/keyRings/<ring>/cryptoKeys/<key>"
+/// echo -n "some-plaintext" > /tmp/pt.txt
+/// gcloud kms encrypt --key="$KEY" --plaintext-file=/tmp/pt.txt --ciphertext-file=/tmp/ct.bin
+/// export GCP_KMS_KEY_NAME="$KEY"
+/// export TEST_GCP_SECRET="$(base64 -i /tmp/ct.bin | tr -d '\n')"
+/// cargo test -p service_utils --lib -- --ignored decrypts_real_ciphertext_against_live_gcp_kms --nocapture
+/// ```
+///
+/// Then update the `assert_eq!` below to match whatever plaintext you used.
+#[cfg(test)]
+mod live_tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore]
+    async fn decrypts_real_ciphertext_against_live_gcp_kms() {
+        // Mirrors the install_default() call in crates/superposition/src/main.rs,
+        // which this lib-level test doesn't go through.
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+        let client = new_client().await;
+        let plaintext = decrypt(client, "TEST_GCP_SECRET").await;
+        assert_eq!(plaintext, "superposition-gcp-kms-live-test-v2");
+    }
+}

--- a/crates/service_utils/src/kms/openbao.rs
+++ b/crates/service_utils/src/kms/openbao.rs
@@ -1,0 +1,143 @@
+//! Fetches a plaintext secret from an OpenBao (or HashiCorp Vault, which
+//! implements the same API) server's KV v2 engine. Unlike the AWS/GCP KMS
+//! backends this does not decrypt a ciphertext: the "secret env var" holds an
+//! OpenBao location string (`mount:path[:key]`, `key` defaults to `value`)
+//! and OpenBao returns the plaintext directly, matching how Hyperswitch's
+//! `hashicorp_vault` backend works.
+
+use std::{collections::HashMap, sync::Arc};
+
+use vaultrs::{
+    client::{VaultClient, VaultClientSettingsBuilder},
+    kv2,
+};
+
+use crate::helpers::get_from_env_unsafe;
+
+#[derive(Debug, PartialEq)]
+struct OpenBaoLocation {
+    mount: String,
+    path: String,
+    key: String,
+}
+
+#[derive(Debug)]
+enum OpenBaoError {
+    IncompleteLocation(String),
+}
+
+impl std::fmt::Display for OpenBaoError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            OpenBaoError::IncompleteLocation(location) => {
+                write!(
+                    f,
+                    "incomplete OpenBao location '{location}', expected 'mount:path[:key]'"
+                )
+            }
+        }
+    }
+}
+
+fn parse_location(location: &str) -> Result<OpenBaoLocation, OpenBaoError> {
+    let mut parts = location.split(':');
+    let mount = parts
+        .next()
+        .ok_or_else(|| OpenBaoError::IncompleteLocation(location.to_string()))?;
+    let path = parts
+        .next()
+        .ok_or_else(|| OpenBaoError::IncompleteLocation(location.to_string()))?;
+    let key = parts.next().unwrap_or("value");
+    Ok(OpenBaoLocation {
+        mount: mount.to_string(),
+        path: path.to_string(),
+        key: key.to_string(),
+    })
+}
+
+#[derive(Clone)]
+pub struct Client {
+    inner: Arc<VaultClient>,
+}
+
+pub async fn new_client() -> Client {
+    let address: String = get_from_env_unsafe("OPENBAO_ADDR")
+        .unwrap_or_else(|_| panic!("OPENBAO_ADDR not present in env"));
+    let token: String = get_from_env_unsafe("OPENBAO_TOKEN")
+        .unwrap_or_else(|_| panic!("OPENBAO_TOKEN not present in env"));
+
+    let settings = VaultClientSettingsBuilder::default()
+        .address(address)
+        .token(token)
+        .build()
+        .unwrap_or_else(|e| panic!("Failed to build OpenBao client settings: {e}"));
+
+    let inner = VaultClient::new(settings)
+        .unwrap_or_else(|e| panic!("Failed to create OpenBao client: {e}"));
+
+    Client {
+        inner: Arc::new(inner),
+    }
+}
+
+async fn fetch_helper(client: Client, key: &str, location: String) -> String {
+    let loc = parse_location(&location)
+        .unwrap_or_else(|e| panic!("Failed to resolve OpenBao location for {key}: {e}"));
+
+    let mut secret: HashMap<String, String> =
+        kv2::read(&*client.inner, &loc.mount, &loc.path)
+            .await
+            .unwrap_or_else(|e| panic!("Failed to fetch {key} from OpenBao: {e}"));
+
+    secret.remove(&loc.key).unwrap_or_else(|| {
+        panic!("OpenBao secret at '{location}' has no field '{}'", loc.key)
+    })
+}
+
+pub async fn decrypt(client: Client, key: &str) -> String {
+    let location: String =
+        get_from_env_unsafe(key).unwrap_or_else(|_| panic!("{key} not present in env"));
+    fetch_helper(client, key, location).await
+}
+
+pub async fn decrypt_opt(client: Client, key: &str) -> Option<String> {
+    let location: String = get_from_env_unsafe(key).ok()?;
+    Some(fetch_helper(client, key, location).await)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_mount_path_and_key() {
+        let loc = parse_location("secret:superposition:master_key").unwrap();
+        assert_eq!(loc.mount, "secret");
+        assert_eq!(loc.path, "superposition");
+        assert_eq!(loc.key, "master_key");
+    }
+
+    #[test]
+    fn defaults_key_to_value_when_omitted() {
+        let loc = parse_location("secret:superposition").unwrap();
+        assert_eq!(loc.mount, "secret");
+        assert_eq!(loc.path, "superposition");
+        assert_eq!(loc.key, "value");
+    }
+
+    #[test]
+    fn rejects_a_location_missing_a_path() {
+        assert!(matches!(
+            parse_location("secret"),
+            Err(OpenBaoError::IncompleteLocation(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_an_empty_location() {
+        assert!(matches!(
+            parse_location(""),
+            Err(OpenBaoError::IncompleteLocation(_))
+        ));
+    }
+}

--- a/crates/service_utils/src/kms/openbao.rs
+++ b/crates/service_utils/src/kms/openbao.rs
@@ -2,18 +2,18 @@
 //! secret by location (`mount:path[:key]`), rather than decrypting a
 //! ciphertext like the AWS/GCP backends.
 
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
+use async_trait::async_trait;
 use vaultrs::{
     client::{VaultClient, VaultClientSettingsBuilder},
     kv2,
 };
 
-use crate::helpers::get_from_env_unsafe;
+use crate::{helpers::get_from_env_unsafe, kms::KmsClient};
 
-#[derive(Clone)]
 pub struct Client {
-    inner: Arc<VaultClient>,
+    inner: VaultClient,
 }
 
 pub async fn new_client() -> Client {
@@ -31,12 +31,10 @@ pub async fn new_client() -> Client {
     let inner = VaultClient::new(settings)
         .unwrap_or_else(|e| panic!("Failed to create OpenBao client: {e}"));
 
-    Client {
-        inner: Arc::new(inner),
-    }
+    Client { inner }
 }
 
-async fn fetch_helper(client: Client, key: &str, location: String) -> String {
+async fn fetch_helper(client: &Client, key: &str, location: String) -> String {
     let mut parts = location.split(':');
     let mount = parts.next().unwrap_or_default();
     let path = parts.next().unwrap_or_else(|| {
@@ -44,7 +42,7 @@ async fn fetch_helper(client: Client, key: &str, location: String) -> String {
     });
     let field = parts.next().unwrap_or("value");
 
-    let mut secret: HashMap<String, String> = kv2::read(&*client.inner, mount, path)
+    let mut secret: HashMap<String, String> = kv2::read(&client.inner, mount, path)
         .await
         .unwrap_or_else(|e| panic!("Failed to fetch {key} from OpenBao: {e}"));
 
@@ -53,13 +51,16 @@ async fn fetch_helper(client: Client, key: &str, location: String) -> String {
     })
 }
 
-pub async fn decrypt(client: Client, key: &str) -> String {
-    let location: String =
-        get_from_env_unsafe(key).unwrap_or_else(|_| panic!("{key} not present in env"));
-    fetch_helper(client, key, location).await
-}
+#[async_trait]
+impl KmsClient for Client {
+    async fn decrypt(&self, key: &str) -> String {
+        let location: String = get_from_env_unsafe(key)
+            .unwrap_or_else(|_| panic!("{key} not present in env"));
+        fetch_helper(self, key, location).await
+    }
 
-pub async fn decrypt_opt(client: Client, key: &str) -> Option<String> {
-    let location: String = get_from_env_unsafe(key).ok()?;
-    Some(fetch_helper(client, key, location).await)
+    async fn decrypt_opt(&self, key: &str) -> Option<String> {
+        let location: String = get_from_env_unsafe(key).ok()?;
+        Some(fetch_helper(self, key, location).await)
+    }
 }

--- a/crates/service_utils/src/kms/openbao.rs
+++ b/crates/service_utils/src/kms/openbao.rs
@@ -10,7 +10,7 @@ use vaultrs::{
     kv2,
 };
 
-use crate::{helpers::get_from_env_unsafe, kms::KmsClient};
+use crate::{helpers::get_from_env_unsafe, kms::SecretProvider};
 
 pub struct Client {
     inner: VaultClient,
@@ -52,14 +52,14 @@ async fn fetch_helper(client: &Client, key: &str, location: String) -> String {
 }
 
 #[async_trait]
-impl KmsClient for Client {
-    async fn decrypt(&self, key: &str) -> String {
+impl SecretProvider for Client {
+    async fn get_secret(&self, key: &str) -> String {
         let location: String = get_from_env_unsafe(key)
             .unwrap_or_else(|_| panic!("{key} not present in env"));
         fetch_helper(self, key, location).await
     }
 
-    async fn decrypt_opt(&self, key: &str) -> Option<String> {
+    async fn get_secret_opt(&self, key: &str) -> Option<String> {
         let location: String = get_from_env_unsafe(key).ok()?;
         Some(fetch_helper(self, key, location).await)
     }

--- a/crates/service_utils/src/kms/openbao.rs
+++ b/crates/service_utils/src/kms/openbao.rs
@@ -1,9 +1,6 @@
-//! Fetches a plaintext secret from an OpenBao (or HashiCorp Vault, which
-//! implements the same API) server's KV v2 engine. Unlike the AWS/GCP KMS
-//! backends this does not decrypt a ciphertext: the "secret env var" holds an
-//! OpenBao location string (`mount:path[:key]`, `key` defaults to `value`)
-//! and OpenBao returns the plaintext directly, matching how Hyperswitch's
-//! `hashicorp_vault` backend works.
+//! OpenBao (or HashiCorp Vault) KV v2 backend: fetches a stored plaintext
+//! secret by location (`mount:path[:key]`), rather than decrypting a
+//! ciphertext like the AWS/GCP backends.
 
 use std::{collections::HashMap, sync::Arc};
 
@@ -13,47 +10,6 @@ use vaultrs::{
 };
 
 use crate::helpers::get_from_env_unsafe;
-
-#[derive(Debug, PartialEq)]
-struct OpenBaoLocation {
-    mount: String,
-    path: String,
-    key: String,
-}
-
-#[derive(Debug)]
-enum OpenBaoError {
-    IncompleteLocation(String),
-}
-
-impl std::fmt::Display for OpenBaoError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            OpenBaoError::IncompleteLocation(location) => {
-                write!(
-                    f,
-                    "incomplete OpenBao location '{location}', expected 'mount:path[:key]'"
-                )
-            }
-        }
-    }
-}
-
-fn parse_location(location: &str) -> Result<OpenBaoLocation, OpenBaoError> {
-    let mut parts = location.split(':');
-    let mount = parts
-        .next()
-        .ok_or_else(|| OpenBaoError::IncompleteLocation(location.to_string()))?;
-    let path = parts
-        .next()
-        .ok_or_else(|| OpenBaoError::IncompleteLocation(location.to_string()))?;
-    let key = parts.next().unwrap_or("value");
-    Ok(OpenBaoLocation {
-        mount: mount.to_string(),
-        path: path.to_string(),
-        key: key.to_string(),
-    })
-}
 
 #[derive(Clone)]
 pub struct Client {
@@ -81,16 +37,19 @@ pub async fn new_client() -> Client {
 }
 
 async fn fetch_helper(client: Client, key: &str, location: String) -> String {
-    let loc = parse_location(&location)
-        .unwrap_or_else(|e| panic!("Failed to resolve OpenBao location for {key}: {e}"));
+    let mut parts = location.split(':');
+    let mount = parts.next().unwrap_or_default();
+    let path = parts.next().unwrap_or_else(|| {
+        panic!("Invalid OpenBao location for {key}: '{location}', expected 'mount:path[:key]'")
+    });
+    let field = parts.next().unwrap_or("value");
 
-    let mut secret: HashMap<String, String> =
-        kv2::read(&*client.inner, &loc.mount, &loc.path)
-            .await
-            .unwrap_or_else(|e| panic!("Failed to fetch {key} from OpenBao: {e}"));
+    let mut secret: HashMap<String, String> = kv2::read(&*client.inner, mount, path)
+        .await
+        .unwrap_or_else(|e| panic!("Failed to fetch {key} from OpenBao: {e}"));
 
-    secret.remove(&loc.key).unwrap_or_else(|| {
-        panic!("OpenBao secret at '{location}' has no field '{}'", loc.key)
+    secret.remove(field).unwrap_or_else(|| {
+        panic!("OpenBao secret at '{location}' has no field '{field}'")
     })
 }
 
@@ -103,41 +62,4 @@ pub async fn decrypt(client: Client, key: &str) -> String {
 pub async fn decrypt_opt(client: Client, key: &str) -> Option<String> {
     let location: String = get_from_env_unsafe(key).ok()?;
     Some(fetch_helper(client, key, location).await)
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parses_mount_path_and_key() {
-        let loc = parse_location("secret:superposition:master_key").unwrap();
-        assert_eq!(loc.mount, "secret");
-        assert_eq!(loc.path, "superposition");
-        assert_eq!(loc.key, "master_key");
-    }
-
-    #[test]
-    fn defaults_key_to_value_when_omitted() {
-        let loc = parse_location("secret:superposition").unwrap();
-        assert_eq!(loc.mount, "secret");
-        assert_eq!(loc.path, "superposition");
-        assert_eq!(loc.key, "value");
-    }
-
-    #[test]
-    fn rejects_a_location_missing_a_path() {
-        assert!(matches!(
-            parse_location("secret"),
-            Err(OpenBaoError::IncompleteLocation(_))
-        ));
-    }
-
-    #[test]
-    fn rejects_an_empty_location() {
-        assert!(matches!(
-            parse_location(""),
-            Err(OpenBaoError::IncompleteLocation(_))
-        ));
-    }
 }

--- a/crates/service_utils/src/lib.rs
+++ b/crates/service_utils/src/lib.rs
@@ -3,11 +3,11 @@
 // when compiling tests.
 #[cfg(test)]
 use opentelemetry_otlp as _;
-pub mod aws;
 pub mod db;
 pub mod encryption;
 pub mod extensions;
 pub mod helpers;
+pub mod kms;
 pub mod kronos_dispatch;
 pub mod middlewares;
 pub mod observability;

--- a/crates/service_utils/src/middlewares/auth_n.rs
+++ b/crates/service_utils/src/middlewares/auth_n.rs
@@ -32,7 +32,7 @@ use crate::{
     },
     extensions::HttpRequestExt,
     helpers::get_from_env_unsafe,
-    kms::KmsProvider,
+    kms::SecretProviderClient,
     kronos_dispatch::DISPATCHER_USERNAME,
     service::types::{AppEnv, AppState},
 };
@@ -253,7 +253,7 @@ impl AuthNHandler {
     }
 
     pub async fn init(
-        kms_client: &Option<KmsProvider>,
+        kms_client: &Option<SecretProviderClient>,
         app_env: &AppEnv,
         path_prefix: String,
     ) -> Self {

--- a/crates/service_utils/src/middlewares/auth_n.rs
+++ b/crates/service_utils/src/middlewares/auth_n.rs
@@ -20,7 +20,6 @@ use actix_web::{
     web::{self, Data, Path},
 };
 use authentication::{Authenticator, BasicAuthGrant, Login, SwitchOrgParams};
-use aws_sdk_kms::Client;
 use base64::{Engine, engine::general_purpose};
 use futures_util::future::LocalBoxFuture;
 use no_auth::DisabledAuthenticator;
@@ -33,6 +32,7 @@ use crate::{
     },
     extensions::HttpRequestExt,
     helpers::get_from_env_unsafe,
+    kms::KmsProvider,
     kronos_dispatch::DISPATCHER_USERNAME,
     service::types::{AppEnv, AppState},
 };
@@ -253,7 +253,7 @@ impl AuthNHandler {
     }
 
     pub async fn init(
-        kms_client: &Option<Client>,
+        kms_client: &Option<KmsProvider>,
         app_env: &AppEnv,
         path_prefix: String,
     ) -> Self {

--- a/crates/service_utils/src/middlewares/auth_z.rs
+++ b/crates/service_utils/src/middlewares/auth_z.rs
@@ -13,7 +13,6 @@ use actix_web::{
     dev::{Payload, Service, ServiceRequest, ServiceResponse, Transform, forward_ready},
 };
 use authorization::Authorizer;
-use aws_sdk_kms::Client;
 use casbin::CasbinPolicyEngine;
 use derive_more::Deref;
 use futures_util::future::LocalBoxFuture;
@@ -23,7 +22,7 @@ use superposition_types::{
     DispatchUser, InternalUser, Resource, User, result as superposition,
 };
 
-use crate::{helpers::get_from_env_unsafe, service::types::AppEnv};
+use crate::{helpers::get_from_env_unsafe, kms::KmsProvider, service::types::AppEnv};
 
 pub trait Action: Send + Sync + 'static {
     fn get() -> String;
@@ -181,7 +180,7 @@ pub fn is_auth_z_enabled() -> bool {
 }
 
 impl AuthZHandler {
-    pub async fn init(kms_client: &Option<Client>, app_env: &AppEnv) -> Self {
+    pub async fn init(kms_client: &Option<KmsProvider>, app_env: &AppEnv) -> Self {
         let ap: Arc<dyn Authorizer> = match get_auth_z_provider().as_str() {
             "CASBIN" => Arc::new(
                 CasbinPolicyEngine::new(kms_client, app_env, None)
@@ -271,7 +270,7 @@ pub enum AuthZManager {
 }
 
 impl AuthZManager {
-    pub async fn init(kms_client: &Option<Client>, app_env: &AppEnv) -> Self {
+    pub async fn init(kms_client: &Option<KmsProvider>, app_env: &AppEnv) -> Self {
         match get_auth_z_provider().as_str() {
             "CASBIN" => Self::Casbin(Arc::new(
                 CasbinPolicyEngine::management(kms_client, app_env)

--- a/crates/service_utils/src/middlewares/auth_z.rs
+++ b/crates/service_utils/src/middlewares/auth_z.rs
@@ -22,7 +22,9 @@ use superposition_types::{
     DispatchUser, InternalUser, Resource, User, result as superposition,
 };
 
-use crate::{helpers::get_from_env_unsafe, kms::KmsProvider, service::types::AppEnv};
+use crate::{
+    helpers::get_from_env_unsafe, kms::SecretProviderClient, service::types::AppEnv,
+};
 
 pub trait Action: Send + Sync + 'static {
     fn get() -> String;
@@ -180,7 +182,10 @@ pub fn is_auth_z_enabled() -> bool {
 }
 
 impl AuthZHandler {
-    pub async fn init(kms_client: &Option<KmsProvider>, app_env: &AppEnv) -> Self {
+    pub async fn init(
+        kms_client: &Option<SecretProviderClient>,
+        app_env: &AppEnv,
+    ) -> Self {
         let ap: Arc<dyn Authorizer> = match get_auth_z_provider().as_str() {
             "CASBIN" => Arc::new(
                 CasbinPolicyEngine::new(kms_client, app_env, None)
@@ -270,7 +275,10 @@ pub enum AuthZManager {
 }
 
 impl AuthZManager {
-    pub async fn init(kms_client: &Option<KmsProvider>, app_env: &AppEnv) -> Self {
+    pub async fn init(
+        kms_client: &Option<SecretProviderClient>,
+        app_env: &AppEnv,
+    ) -> Self {
         match get_auth_z_provider().as_str() {
             "CASBIN" => Self::Casbin(Arc::new(
                 CasbinPolicyEngine::management(kms_client, app_env)

--- a/crates/service_utils/src/middlewares/auth_z/casbin.rs
+++ b/crates/service_utils/src/middlewares/auth_z/casbin.rs
@@ -15,7 +15,7 @@ use tokio::sync::RwLock;
 use crate::{
     db::utils::get_database_url,
     helpers::{get_from_env_or_default, get_from_env_unsafe},
-    kms::KmsProvider,
+    kms::SecretProviderClient,
     middlewares::auth_z::AuthZDomain,
     service::types::{AppEnv, SchemaName},
 };
@@ -375,7 +375,7 @@ const MODEL_CONF: &str = include_str!("casbin/model.conf");
 
 impl CasbinPolicyEngine {
     pub async fn new(
-        kms_client: &Option<KmsProvider>,
+        kms_client: &Option<SecretProviderClient>,
         app_env: &AppEnv,
         db_pool_size: Option<u32>,
     ) -> Result<Self, String> {
@@ -443,7 +443,7 @@ impl CasbinPolicyEngine {
     }
 
     pub async fn management(
-        kms_client: &Option<KmsProvider>,
+        kms_client: &Option<SecretProviderClient>,
         app_env: &AppEnv,
     ) -> Result<Self, String> {
         Self::new(kms_client, app_env, Some(1)).await

--- a/crates/service_utils/src/middlewares/auth_z/casbin.rs
+++ b/crates/service_utils/src/middlewares/auth_z/casbin.rs
@@ -2,7 +2,6 @@ mod handlers;
 
 use std::collections::{HashMap, HashSet};
 
-use aws_sdk_kms::Client;
 use casbin::{CoreApi, DefaultModel, Enforcer, MgmtApi};
 use chrono::{DateTime, Utc};
 use diesel_adapter::DieselAdapter;
@@ -16,6 +15,7 @@ use tokio::sync::RwLock;
 use crate::{
     db::utils::get_database_url,
     helpers::{get_from_env_or_default, get_from_env_unsafe},
+    kms::KmsProvider,
     middlewares::auth_z::AuthZDomain,
     service::types::{AppEnv, SchemaName},
 };
@@ -375,7 +375,7 @@ const MODEL_CONF: &str = include_str!("casbin/model.conf");
 
 impl CasbinPolicyEngine {
     pub async fn new(
-        kms_client: &Option<Client>,
+        kms_client: &Option<KmsProvider>,
         app_env: &AppEnv,
         db_pool_size: Option<u32>,
     ) -> Result<Self, String> {
@@ -443,7 +443,7 @@ impl CasbinPolicyEngine {
     }
 
     pub async fn management(
-        kms_client: &Option<Client>,
+        kms_client: &Option<KmsProvider>,
         app_env: &AppEnv,
     ) -> Result<Self, String> {
         Self::new(kms_client, app_env, Some(1)).await

--- a/crates/superposition/Cargo.toml
+++ b/crates/superposition/Cargo.toml
@@ -11,7 +11,6 @@ rust-version.workspace = true
 actix-files = { version = "0.6" }
 actix-web = { workspace = true }
 anyhow = { workspace = true }
-aws-sdk-kms = { workspace = true }
 chrono = { workspace = true }
 context_aware_config = { path = "../context_aware_config" }
 diesel = { workspace = true }
@@ -27,6 +26,7 @@ log = { workspace = true }
 regex = { workspace = true }
 reqwest = { workspace = true }
 rs-snowflake = { workspace = true }
+rustls = { workspace = true }
 secrecy = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/superposition/src/app_state.rs
+++ b/crates/superposition/src/app_state.rs
@@ -20,6 +20,7 @@ use service_utils::{
     },
     encryption::get_master_encryption_keys,
     helpers::{get_from_env_or_default, get_from_env_unsafe},
+    kms::KmsProvider,
     kronos_dispatch::{SuperpositionSchemaProvider, setup_dispatcher},
     service::types::{AppEnv, AppState, ExperimentationFlags},
 };
@@ -28,7 +29,7 @@ use snowflake::SnowflakeIdGenerator;
 pub async fn get(
     app_env: AppEnv,
     port: u16,
-    kms_client: &Option<aws_sdk_kms::Client>,
+    kms_client: &Option<KmsProvider>,
     service_prefix: String,
     base: &str,
 ) -> (AppState, Option<WorkerHandle>, u64) {

--- a/crates/superposition/src/app_state.rs
+++ b/crates/superposition/src/app_state.rs
@@ -20,7 +20,7 @@ use service_utils::{
     },
     encryption::get_master_encryption_keys,
     helpers::{get_from_env_or_default, get_from_env_unsafe},
-    kms::KmsProvider,
+    kms::SecretProviderClient,
     kronos_dispatch::{SuperpositionSchemaProvider, setup_dispatcher},
     service::types::{AppEnv, AppState, ExperimentationFlags},
 };
@@ -29,7 +29,7 @@ use snowflake::SnowflakeIdGenerator;
 pub async fn get(
     app_env: AppEnv,
     port: u16,
-    kms_client: &Option<KmsProvider>,
+    kms_client: &Option<SecretProviderClient>,
     service_prefix: String,
     base: &str,
 ) -> (AppState, Option<WorkerHandle>, u64) {

--- a/crates/superposition/src/main.rs
+++ b/crates/superposition/src/main.rs
@@ -24,8 +24,8 @@ use json_subscriber::fmt;
 use leptos::*;
 use leptos_actix::{LeptosRoutes, generate_route_list};
 use service_utils::{
-    aws::kms,
     helpers::{get_from_env_or_default, get_from_env_unsafe},
+    kms,
     middlewares::{
         auth_n::AuthNHandler,
         auth_z::{AuthZHandler, AuthZManager, is_auth_z_enabled},
@@ -71,6 +71,11 @@ async fn favicon(
 
 #[actix_web::main]
 async fn main() -> Result<()> {
+    // Two rustls crypto backends are linked in (ring via tonic, aws-lc-rs elsewhere); pick one.
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("Failed to install default rustls CryptoProvider");
+
     dotenv::dotenv().ok();
     // Initialize tracing subscriber with custom JSON formatter and reloadable env filter
     let env_filter = EnvFilter::from_default_env();

--- a/crates/superposition/src/main.rs
+++ b/crates/superposition/src/main.rs
@@ -273,7 +273,7 @@ async fn main() -> Result<()> {
                                 },
                                 _ => {
                                     let client = kms::new_client().await;
-                                    let api_key = kms::decrypt(client, "INTERNAL_OPS_API_KEY").await;
+                                    let api_key = client.decrypt("INTERNAL_OPS_API_KEY").await;
                                     urlencoding::encode(api_key.as_str()).to_string()
                                 }
                             };

--- a/crates/superposition/src/main.rs
+++ b/crates/superposition/src/main.rs
@@ -273,7 +273,7 @@ async fn main() -> Result<()> {
                                 },
                                 _ => {
                                     let client = kms::new_client().await;
-                                    let api_key = client.decrypt("INTERNAL_OPS_API_KEY").await;
+                                    let api_key = client.get_secret("INTERNAL_OPS_API_KEY").await;
                                     urlencoding::encode(api_key.as_str()).to_string()
                                 }
                             };

--- a/docs/docs/basic-concepts/safety/secrets.md
+++ b/docs/docs/basic-concepts/safety/secrets.md
@@ -23,7 +23,7 @@ Master Encryption Key (MEK)
 └─────────────────────┘
 ```
 
-- **Master Encryption Key (MEK)**: Stored in environment variable `MASTER_ENCRYPTION_KEY` (or AWS KMS in production). Never stored in the database.
+- **Master Encryption Key (MEK)**: Stored in environment variable `MASTER_ENCRYPTION_KEY` (or AWS KMS / Google Cloud KMS / OpenBao / HashiCorp Vault in production, see `KMS_PROVIDER`). Never stored in the database.
 - **Workspace Encryption Key (WEK)**: Auto-generated per workspace, stored encrypted in the `workspaces` table.
 - **Secrets**: Encrypted with AES-256-GCM and stored in the `secrets` table.
 

--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -101,7 +101,7 @@ Health is good :D
 | Redis | No | Enables shared caching. If `REDIS_URL` is unset, the app reads from PostgreSQL directly. |
 | OIDC provider | Recommended | Required when using `AUTH_PROVIDER=OIDC` or `AUTH_PROVIDER=OIDC_SAAS`. |
 | Casbin policy DB | Optional | Required only when `AUTH_Z_PROVIDER=CASBIN`; it can use the same PostgreSQL instance. |
-| AWS KMS | Required for `APP_ENV=PROD` | In production mode, secret values such as database passwords are read through KMS. |
+| AWS KMS, Google Cloud KMS, or OpenBao/Vault | Required for `APP_ENV=PROD` | In production mode, secret values such as database passwords are resolved through this backend. AWS KMS is used by default; set `KMS_PROVIDER=GCP` for Cloud KMS or `KMS_PROVIDER=OPENBAO` for OpenBao/HashiCorp Vault instead. |
 
 The app is mostly stateless. Multiple replicas can run behind a load balancer as
 long as they share the same PostgreSQL database and, if enabled, the same Redis

--- a/docs/docs/self-hosting/environment-variables.md
+++ b/docs/docs/self-hosting/environment-variables.md
@@ -23,6 +23,10 @@ deployment.
 | `ACTIX_WORKER_COUNT` | `5` | Number of Actix workers. |
 | `ACTIX_KEEP_ALIVE` | `120` | Keep-alive timeout in seconds. |
 | `SUPERPOSITION_TOKEN` | secret value | Internal service token. In `DEV`, `TEST`, and `SANDBOX`, it defaults to `123456` if unset. In `PROD`, provide a KMS ciphertext. |
+| `KMS_PROVIDER` | `AWS`, `GCP`, or `OPENBAO` | Optional, defaults to `AWS`. Selects the backend used to resolve secrets in `PROD`/`SANDBOX`. See Secret Loading Modes below. |
+| `GCP_KMS_KEY_NAME` | `projects/<project>/locations/<location>/keyRings/<ring>/cryptoKeys/<key>` | Required when `KMS_PROVIDER=GCP`. Full resource name of the symmetric key used to decrypt secrets. |
+| `OPENBAO_ADDR` | `https://openbao.example.com:8200` | Required when `KMS_PROVIDER=OPENBAO`. Address of the OpenBao (or HashiCorp Vault) server. |
+| `OPENBAO_TOKEN` | secret value | Required when `KMS_PROVIDER=OPENBAO`. Auth token for the OpenBao server. |
 
 ## Database And Cache Settings
 
@@ -79,16 +83,26 @@ TENANT_MIDDLEWARE_EXCLUSION_LIST="/health,/assets/favicon.ico,/pkg/frontend.js,/
 
 Superposition currently has two practical deployment modes:
 
-- `APP_ENV=PROD`: the app initializes AWS KMS and expects encrypted, base64 KMS
-  ciphertext values for sensitive settings such as `DB_PASSWORD`,
-  `SUPERPOSITION_TOKEN`, `KRONOS_API_KEY`, `KRONOS_DISPATCH_TOKEN`,
-  `OIDC_CLIENT_SECRET`, `OIDC_INTROSPECTION_AUTH_HEADER` and
-  `OIDC_API_STATIC_TOKENS` (when API-token auth is enabled),
-  `CASBIN_DB_PASSWORD`, and `MASTER_ENCRYPTION_KEY`.
+- `APP_ENV=PROD`: the app initializes a secrets backend client for sensitive
+  settings such as `DB_PASSWORD`, `SUPERPOSITION_TOKEN`, `KRONOS_API_KEY`,
+  `KRONOS_DISPATCH_TOKEN`, `OIDC_CLIENT_SECRET`,
+  `OIDC_INTROSPECTION_AUTH_HEADER` and `OIDC_API_STATIC_TOKENS` (when
+  API-token auth is enabled), `CASBIN_DB_PASSWORD`, and
+  `MASTER_ENCRYPTION_KEY`. The backend is AWS KMS by default, expecting
+  base64 KMS ciphertext values for each of those. Set `KMS_PROVIDER=GCP` and
+  `GCP_KMS_KEY_NAME` (full resource name of the symmetric key) to use Google
+  Cloud KMS instead — GCP authentication uses Application Default
+  Credentials, a service-account key file via `GOOGLE_APPLICATION_CREDENTIALS`
+  locally, or Workload Identity on GKE. Set `KMS_PROVIDER=OPENBAO` and
+  `OPENBAO_ADDR`/`OPENBAO_TOKEN` to use OpenBao (or HashiCorp Vault, which
+  implements the same API) instead — unlike AWS/GCP, each of those env vars
+  then holds an OpenBao KV v2 location (`mount:path[:key]`, `key` defaults to
+  `value`) rather than a ciphertext, since OpenBao returns the plaintext
+  secret directly.
 - `APP_ENV=DEV`: the app reads those values directly from environment variables.
-  This is useful for local and non-AWS self-hosted deployments. If you use this
-  mode outside local development, inject secrets from your platform secret
-  manager and enable real authentication.
+  This is useful for local and non-cloud self-hosted deployments. If you use
+  this mode outside local development, inject secrets from your platform
+  secret manager and enable real authentication.
 
 If you want to use Superposition secrets, set `MASTER_ENCRYPTION_KEY` to a
 base64-encoded 32-byte key:

--- a/docs/docs/self-hosting/kronos.md
+++ b/docs/docs/self-hosting/kronos.md
@@ -73,9 +73,11 @@ must be no longer than 25 characters.
 - `KRONOS_DISPATCH_TOKEN` authenticates only that callback. Use a random value
   that is different from `SUPERPOSITION_TOKEN`.
 - In `DEV` and `TEST`, the callback token and service API key are read directly
-  from the environment. In `PROD` and `SANDBOX`, provide their AWS KMS
-  ciphertexts. `KRONOS_ENCRYPTION_KEY` is always read directly from the
-  environment, so inject it with your deployment secret manager.
+  from the environment. In `PROD` and `SANDBOX`, provide their KMS
+  ciphertexts (AWS KMS, Google Cloud KMS, or OpenBao/HashiCorp Vault, see
+  `KMS_PROVIDER`).
+  `KRONOS_ENCRYPTION_KEY` is always read directly from the environment, so
+  inject it with your deployment secret manager.
 
 After startup, check the Superposition logs for either
 `Kronos library mode: embedded worker started` or `Kronos service mode` to

--- a/docs/docs/self-hosting/production.md
+++ b/docs/docs/self-hosting/production.md
@@ -27,8 +27,10 @@ long as replicas share the same PostgreSQL database and Redis cache.
 - Use Casbin if you need workspace and organisation-level authorization rules.
 - Set `MASTER_ENCRYPTION_KEY` before creating workspaces if you plan to use
   encrypted secrets.
-- Store production secret material in AWS KMS for `APP_ENV=PROD`, or in your
-  platform secret manager if you are running a plain-env self-hosted mode.
+- Store production secret material in AWS KMS, Google Cloud KMS (via
+  `KMS_PROVIDER=GCP`), or OpenBao / HashiCorp Vault (via `KMS_PROVIDER=OPENBAO`)
+  for `APP_ENV=PROD`, or in your platform secret manager if you are running a
+  plain-env self-hosted mode.
 
 ## Database And Networking
 

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -41,6 +41,12 @@ configs:
   db_name: config
   app_env: DEV
   aws_region_endpoint: http://localhost:4566
+  # KMS backend for the `secrets` block below (non-dev/test). Default: AWS.
+  # kms_provider: AWS  # or GCP, OPENBAO
+  # gcp_kms_key_name: projects/<project>/locations/<location>/keyRings/<ring>/cryptoKeys/<key>  # required for GCP; uses ADC
+  # openbao_addr: https://openbao.example.com:8200  # required for OPENBAO
+  # openbao_token: <openbao-token>                   # required for OPENBAO
+  # Note: with OPENBAO, secrets below hold a KV v2 location ("mount:path[:key]") instead of ciphertext.
   allow_same_keys_overlapping_ctx: true
   allow_diff_keys_overlapping_ctx: true
   allow_same_keys_non_overlapping_ctx: true


### PR DESCRIPTION
## Problem

Superposition's secret bootstrap (`MASTER_ENCRYPTION_KEY`, `DB_PASSWORD`, `SUPERPOSITION_TOKEN`, `KRONOS_DISPATCH_TOKEN`, etc.) was tightly coupled to AWS KMS, making it difficult to deploy on other cloud providers or use alternative secret-management systems.

## Solution

Added support for multiple secret/KMS providers:

- Added `KMS_PROVIDER` with support for `AWS`, `GCP`, and `OPENBAO`. Defaults to `AWS` to maintain backward compatibility.
- Added separate provider implementations under `crates/service_utils/src/kms/` for AWS, GCP, and OpenBao.
- Added Google Cloud KMS support using `google-cloud-kms` and Application Default Credentials.
- Added OpenBao KV v2 support using `vaultrs`.
- Added provider-specific configuration:
  - `GCP_KMS_KEY_NAME`
  - `OPENBAO_ADDR`
  - `OPENBAO_TOKEN`
- Invalid `KMS_PROVIDER` values now fail at startup instead of silently falling back to AWS.
- Removed unused `aws-sdk-kms` and `gcp_auth` dependencies.
- Updated `.env.example`, Helm values, and deployment documentation.
- Added the required Rustls configuration for compatibility with `google-cloud-kms`.

## Environment variable changes

| Variable | Description |
|---|---|
| `KMS_PROVIDER` | `AWS` / `GCP` / `OPENBAO`, defaults to `AWS` |
| `GCP_KMS_KEY_NAME` | Google Cloud KMS key resource path |
| `OPENBAO_ADDR` | OpenBao server address |
| `OPENBAO_TOKEN` | OpenBao authentication token |

Existing AWS deployments require no changes.

For OpenBao, secret variables contain a `mount:path[:key]` location instead of encrypted ciphertext.

## Pre-deployment activity

- **AWS:** No changes required.
- **GCP:** Configure the KMS key, IAM permissions, and `GCP_KMS_KEY_NAME`.
- **OpenBao:** Configure the KV v2 engine, store the required secrets, and configure `OPENBAO_ADDR` / `OPENBAO_TOKEN`.

## Post-deployment activity

Verify that:

- The application starts successfully.
- Secrets are successfully retrieved/decrypted.
- `GET /superposition/organisations` works successfully against Postgres.

## API changes

No API changes.

| Endpoint | Method | Request body | Response Body |
|---|:---:|---|---|
| `/superposition/organisations` | GET | None | Existing organisations response |

## Possible Issues in the future

- Invalid provider configuration will cause startup failure.
- GCP requires appropriate Cloud KMS permissions and ADC configuration.
- OpenBao availability and token permissions are required during secret bootstrap.
- Changes to Rustls/dependency versions could reintroduce TLS backend conflicts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google Cloud KMS and OpenBao/Vault as alternatives to AWS KMS for production secret management.
  * Added configuration options for selecting the provider and supplying provider-specific settings.
  * OpenBao secrets can now reference KV v2 locations.

* **Documentation**
  * Updated deployment, self-hosting, Helm, and secrets documentation to explain supported providers and configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->