### PR TITLE
fix: workspaces page hydration panic (MetricsForm SSR/CSR id drift)

### DIFF
--- a/crates/frontend/src/components/metrics_form.rs
+++ b/crates/frontend/src/components/metrics_form.rs
@@ -12,6 +12,7 @@ use crate::{
         form::label::Label,
         input::{Input, InputType, StringArrayInput, Toggle},
     },
+    providers::csr_provider::use_client_side_ready,
     schema::{JsonSchemaType, SchemaType},
 };
 
@@ -190,103 +191,121 @@ fn SourceForm(
 }
 
 #[component]
+fn MetricDefinitions(metrics_rws: RwSignal<Metrics>) -> impl IntoView {
+    view! {
+        <div class="form-control gap-2">
+            <div class="form-control">
+                <Label title="Metric Definitions" info="Press enter to add a metric name" />
+                <StringArrayInput
+                    options=metrics_rws
+                        .with(|metrics| {
+                            metrics
+                                .definitions
+                                .as_deref()
+                                .unwrap_or_default()
+                                .iter()
+                                .map(|metric| metric.name.to_string())
+                                .collect()
+                        })
+                    unique=true
+                    show_label=false
+                    on_change=Callback::new(move |list: Vec<String>| {
+                        metrics_rws
+                            .update(|metrics| {
+                                let existing = metrics.definitions.take().unwrap_or_default();
+                                let new_list = list
+                                    .into_iter()
+                                    .map(|name| {
+                                        let direction = existing
+                                            .iter()
+                                            .find(|metric| *metric.name == name)
+                                            .map(|metric| metric.direction)
+                                            .unwrap_or_default();
+                                        MetricDefinition {
+                                            name: name.try_into().unwrap_or_default(),
+                                            direction,
+                                        }
+                                    })
+                                    .collect::<Vec<_>>();
+                                metrics.definitions = (!new_list.is_empty()).then_some(new_list);
+                            });
+                    })
+                />
+            </div>
+            <div class="pl-2.5 flex flex-col">
+                <For
+                    each=move || {
+                        metrics_rws.with(|metrics| metrics.definitions.clone().unwrap_or_default())
+                    }
+                    key=|metric| metric.name.clone()
+                    children=move |metric| {
+                        let metric_name = StoredValue::new(metric.name);
+                        view! {
+                            <div class="flex flex-col first:border-t border-dashed">
+                                <label class="label">
+                                    <span class="label-text-alt">
+                                        {metric_name.get_value().to_string()}
+                                    </span>
+                                </label>
+                                <Dropdown
+                                    dropdown_width="w-44"
+                                    dropdown_direction=DropdownDirection::Down
+                                    dropdown_btn_type=DropdownBtnType::Select
+                                    searchable=false
+                                    dropdown_text=metric.direction.label()
+                                    dropdown_options=MetricDirection::iter().collect()
+                                    on_select=move |direction: MetricDirection| {
+                                        metrics_rws
+                                            .update(|metrics| {
+                                                if let Some(metric) = metrics
+                                                    .definitions
+                                                    .as_mut()
+                                                    .and_then(|list| {
+                                                        list.iter_mut()
+                                                            .find(|metric| { metric.name == metric_name.get_value() })
+                                                    })
+                                                {
+                                                    metric.direction = direction;
+                                                }
+                                            });
+                                    }
+                                />
+                            </div>
+                        }
+                    }
+                />
+            </div>
+        </div>
+    }
+}
+
+#[component]
+fn MetricsBody(metrics_rws: RwSignal<Metrics>, on_change: Callback<Metrics>) -> impl IntoView {
+    view! {
+        <div class="max-w-md w-full pl-2.5 flex flex-col gap-2">
+            <Show when=move || metrics_rws.with(|m| m.enabled)>
+                <SourceForm
+                    source=metrics_rws.with_untracked(|m| m.source.clone())
+                    on_change=move |source| {
+                        metrics_rws.update_untracked(|m| m.source = source);
+                        on_change.call(metrics_rws.get_untracked());
+                    }
+                />
+            </Show>
+            <MetricDefinitions metrics_rws />
+        </div>
+    }
+}
+
+#[component]
 pub fn MetricsForm(
     #[prop(default = Metrics::default())] metrics: Metrics,
     on_change: Callback<Metrics>,
 ) -> impl IntoView {
     let metrics_rws = RwSignal::new(metrics);
+    let client_side_ready = use_client_side_ready();
 
     Effect::new(move |_| on_change.call(metrics_rws.get()));
-
-    let metrics_definition = move || {
-        view! {
-            <div class="form-control gap-2">
-                <div class="form-control">
-                    <Label title="Metric Definitions" info="Press enter to add a metric name" />
-                    <StringArrayInput
-                        options=metrics_rws
-                            .with(|metrics| {
-                                metrics
-                                    .definitions
-                                    .as_deref()
-                                    .unwrap_or_default()
-                                    .iter()
-                                    .map(|metric| metric.name.to_string())
-                                    .collect()
-                            })
-                        unique=true
-                        show_label=false
-                        on_change=Callback::new(move |list: Vec<String>| {
-                            metrics_rws
-                                .update(|metrics| {
-                                    let existing = metrics.definitions.take().unwrap_or_default();
-                                    let new_list = list
-                                        .into_iter()
-                                        .map(|name| {
-                                            let direction = existing
-                                                .iter()
-                                                .find(|metric| *metric.name == name)
-                                                .map(|metric| metric.direction)
-                                                .unwrap_or_default();
-                                            MetricDefinition {
-                                                name: name.try_into().unwrap_or_default(),
-                                                direction,
-                                            }
-                                        })
-                                        .collect::<Vec<_>>();
-                                    metrics.definitions = (!new_list.is_empty())
-                                        .then_some(new_list);
-                                });
-                        })
-                    />
-                </div>
-                <div class="pl-2.5 flex flex-col">
-                    <For
-                        each=move || {
-                            metrics_rws
-                                .with(|metrics| metrics.definitions.clone().unwrap_or_default())
-                        }
-                        key=|metric| metric.name.clone()
-                        children=move |metric| {
-                            let metric_name = StoredValue::new(metric.name);
-                            view! {
-                                <div class="flex flex-col first:border-t border-dashed">
-                                    <label class="label">
-                                        <span class="label-text-alt">
-                                            {metric_name.get_value().to_string()}
-                                        </span>
-                                    </label>
-                                    <Dropdown
-                                        dropdown_width="w-44"
-                                        dropdown_direction=DropdownDirection::Down
-                                        dropdown_btn_type=DropdownBtnType::Select
-                                        searchable=false
-                                        dropdown_text=metric.direction.label()
-                                        dropdown_options=MetricDirection::iter().collect()
-                                        on_select=move |direction: MetricDirection| {
-                                            metrics_rws
-                                                .update(|metrics| {
-                                                    if let Some(metric) = metrics
-                                                        .definitions
-                                                        .as_mut()
-                                                        .and_then(|list| {
-                                                            list.iter_mut()
-                                                                .find(|metric| { metric.name == metric_name.get_value() })
-                                                        })
-                                                    {
-                                                        metric.direction = direction;
-                                                    }
-                                                });
-                                        }
-                                    />
-                                </div>
-                            }
-                        }
-                    />
-                </div>
-            </div>
-        }
-    };
 
     view! {
         <div class="flex flex-col">
@@ -300,18 +319,9 @@ pub fn MetricsForm(
                     extra_info="To view metrics from Grafana, make sure that your setup allows iframe embedding. Also, experiment viewers must have access to the Grafana instance, to view the metrics."
                 />
             </div>
-            <div class="max-w-md w-full pl-2.5 flex flex-col gap-2">
-                <Show when=move || metrics_rws.with(|m| m.enabled)>
-                    <SourceForm
-                        source=metrics_rws.with_untracked(|m| m.source.clone())
-                        on_change=move |source| {
-                            metrics_rws.update_untracked(|m| m.source = source);
-                            on_change.call(metrics_rws.get_untracked());
-                        }
-                    />
-                </Show>
-                {metrics_definition}
-            </div>
+            <Show when=move || *client_side_ready.get()>
+                <MetricsBody metrics_rws on_change />
+            </Show>
         </div>
     }
 }

--- a/crates/frontend/src/components/metrics_form.rs
+++ b/crates/frontend/src/components/metrics_form.rs
@@ -336,6 +336,7 @@ pub fn ExperimentMetricsForm(
 
     let definitions_st = StoredValue::new(definitions);
     let experiment_metrics_rws = RwSignal::new(experiment_metrics);
+    let client_side_ready = use_client_side_ready();
 
     Effect::new(move |_| on_change.call(experiment_metrics_rws.get()));
 
@@ -351,7 +352,7 @@ pub fn ExperimentMetricsForm(
                     extra_info="To view metrics from Grafana, make sure that your setup allows iframe embedding. Also, experiment viewers must have access to the Grafana instance, to view the metrics."
                 />
             </div>
-            <div>
+            <Show when=move || *client_side_ready.get()>
                 <Show when=move || experiment_metrics_rws.with(|m| m.enabled)>
                     <div class="max-w-md w-full pl-2.5 flex flex-col gap-2">
                         <SourceForm
@@ -499,7 +500,7 @@ pub fn ExperimentMetricsForm(
                         </Show>
                     </div>
                 </Show>
-            </div>
+            </Show>
         </div>
     }
 }


### PR DESCRIPTION
## Summary

Fixes a Leptos **hydration panic** that broke the workspaces admin page (`/admin/:org/workspaces`). On load the page threw, killing all client-side interactivity:

```
panicked at leptos_dom-0.6.11/src/html.rs:1546:
assertion `left == right` failed: SSR and CSR elements have the same hydration key
but different node kinds.
  left: "DIV"
  right: "BUTTON"
```

preceded by a cascade of `component/element with id 1-2-0-XXX not found, ignoring it for hydration` warnings.

## Root cause

This is a **hydration id-drift**: the server-rendered HTML and the WASM client assign hydration keys (`data-hk`) in a slightly different order, so the client eventually tries to hydrate a `<button>` onto a `<div>` and panics.

The drift originates in **`MetricsForm`** (`crates/frontend/src/components/metrics_form.rs`), rewritten in #1145. Two things in that subtree cause the leptos `view!` macro to allocate hydration ids in a different order for the SSR string-builder vs. the client builder:

- a static wrapper `<div>` that holds only dynamic children, and
- an empty-rendering `<Show>` (renders `unit` when metrics are disabled).

The counter drifts by one, and every node after it shifts — so the workspace-create drawer's submit `<button>` lands on a `<div>`. The drawer form is server-rendered even while the drawer is closed, so the panic fires on page load.

### How it was localized

- Traced the SSR `data-hk` ids straight into the metrics form (drift begins at `1-2-0-128`, the metrics wrapper `<div>`).
- Bisected with a headless-Chrome hydration harness across 5 structural variants (bare-closure → component, single-closure wrap, child reorder, dynamic `class`, component wrapper) — **all failed at the same node**, confirming it's a macro-level SSR/CSR ordering quirk rather than a fixable child arrangement.

## The fix

Gate the fragile metrics body behind `client_side_ready` so it is **never part of the hydration handshake**. SSR and the client's first render both produce nothing there; the body then renders client-side after mount:

```rust
<Show when=move || *client_side_ready.get()>
    <MetricsBody metrics_rws on_change />
</Show>
```

This is the same pattern already used elsewhere in the codebase (`side_nav`, the `Button` component). Because the drawer is closed on load and opens client-side, there is **no visible flash** in practice; the metrics enable/disable toggle itself is still server-rendered.

The change also extracts the previously-inline metric-definitions closure into a small `MetricDefinitions` component and the body into a `MetricsBody` component for readability.

## Verification

Verified end-to-end with a headless-Chrome harness that captures the WASM console (build **both** the hydrate WASM and the SSR backend, restart, load the page, scan the console):

| | Before / all 5 restructure attempts | After (this fix) |
|---|---|---|
| Console | `component with id … not found` + `different node kinds` panic | **zero** hydration errors, zero panics |

The final formatted (`leptosfmt`) code was rebuilt (WASM + backend) and re-verified clean.

## Also fixed: `ExperimentMetricsForm`

`ExperimentMetricsForm` (same file; experiment/override pages) had the same fragile shape — a static wrapper `<div>` around an empty-rendering `<Show>`. It was confirmed to drift too: a headless before/after on `/admin/localorg/<ws>/experiments` showed `component with id 1-6-0-342/345 not found, ignoring it for hydration` warnings before, and **zero** after. It surfaced as *recoverable* warnings rather than a crash there (no `<button>` immediately follows the drift), but it's the same latent bug, so it gets the same `client_side_ready` gate.

## Commits

1. `fix: fix regression js error on workspaces page` — MetricsForm (the crash).
2. `fix: prevent same hydration drift in ExperimentMetricsForm` — the latent sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
